### PR TITLE
Fix warnings

### DIFF
--- a/beelay/beelay-core/src/effects.rs
+++ b/beelay/beelay-core/src/effects.rs
@@ -48,10 +48,6 @@ impl<R: rand::Rng> State<R> {
         }
     }
 
-    pub(crate) fn log(&mut self) -> &mut subscriptions::Log {
-        &mut self.log
-    }
-
     pub(crate) fn new_notifications(&mut self) -> HashMap<PeerId, Vec<Notification>> {
         self.subscriptions.new_events(&self.log)
     }

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -8,8 +8,8 @@ use std::{
 use effects::IncomingResponse;
 use futures::{future::LocalBoxFuture, FutureExt};
 use io::IoResult;
-use messages::{BlobRef, Message, Notification, Request, Response, TreePart, UploadItem};
 pub use messages::{Envelope, Payload};
+use messages::{Message, Request, Response};
 use rand::Rng;
 
 mod blob;
@@ -683,26 +683,6 @@ impl CommitCategory {
 pub struct DocumentHeads(Vec<crate::CommitHash>);
 
 impl DocumentHeads {
-    pub(crate) fn new(heads: Vec<crate::CommitHash>) -> Self {
-        DocumentHeads(heads)
-    }
-
-    pub(crate) fn parse(
-        input: parse::Input<'_>,
-    ) -> Result<(parse::Input<'_>, Self), parse::ParseError> {
-        input.with_context("DocumentDagHeads", |input| {
-            let (input, heads) = parse::many(input, CommitHash::parse)?;
-            Ok((input, DocumentHeads::new(heads)))
-        })
-    }
-
-    pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
-        crate::leb128::encode_uleb128(buf, self.0.len() as u64);
-        for head in &self.0 {
-            head.encode(buf);
-        }
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/beelay/beelay-core/src/messages/decode.rs
+++ b/beelay/beelay-core/src/messages/decode.rs
@@ -1,6 +1,6 @@
 use crate::{
-    parse, riblt::doc_and_heads::CodedDocAndHeadsSymbol, BlobHash, Commit, CommitCategory,
-    CommitHash, DocumentId, Payload, RequestId, SnapshotId,
+    parse, riblt::doc_and_heads::CodedDocAndHeadsSymbol, BlobHash, CommitCategory, DocumentId,
+    Payload, RequestId, SnapshotId,
 };
 
 use super::{
@@ -151,15 +151,6 @@ fn parse_response(
         ResponseType::Listen => Ok((input, super::Response::Listen)),
     }?;
     Ok((input, Message::Response(request_id, resp)))
-}
-
-fn parse_commit(input: parse::Input) -> Result<(parse::Input<'_>, Commit), parse::ParseError> {
-    input.with_context("Commit", |input| {
-        let (input, parents) = parse::many(input, CommitHash::parse)?;
-        let (input, hash) = CommitHash::parse(input)?;
-        let (input, content) = parse::slice(input)?;
-        Ok((input, Commit::new(parents, content.to_vec(), hash)))
-    })
 }
 
 mod error {

--- a/beelay/beelay-core/src/riblt.rs
+++ b/beelay/beelay-core/src/riblt.rs
@@ -15,16 +15,12 @@ pub(crate) enum Direction {
 #[derive(Clone, Copy)]
 pub(crate) enum Error {
     InvalidDegree = 1,
-    InvalidSize = 2,
-    DecodeFailed = 3,
 }
 
 impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidDegree => f.write_str("InvalidDegree"),
-            Error::InvalidSize => f.write_str("InvalidSize"),
-            Error::DecodeFailed => f.write_str("DecodeFailed"),
         }
     }
 }
@@ -115,13 +111,6 @@ impl<T: Symbol + Copy> Encoder<T> {
             queue: Vec::<SymbolMapping>::new(),
             next_idx: 0,
         };
-    }
-
-    pub(crate) fn reset(&mut self) {
-        self.symbols.clear();
-        self.mappings.clear();
-        self.queue.clear();
-        self.next_idx = 0;
     }
 
     pub(crate) fn add_hashed_symbol_with_mapping(
@@ -231,15 +220,6 @@ impl<T: Symbol + Copy> Decoder<T> {
             decodable: Vec::<i64>::new(),
             num_decoded: 0,
         };
-    }
-
-    pub(crate) fn reset(&mut self) {
-        self.coded.clear();
-        self.local.reset();
-        self.remote.reset();
-        self.window.reset();
-        self.decodable.clear();
-        self.num_decoded = 0;
     }
 
     pub(crate) fn add_symbol(&mut self, sym: &T) {

--- a/beelay/beelay-core/src/sedimentree.rs
+++ b/beelay/beelay-core/src/sedimentree.rs
@@ -246,6 +246,7 @@ impl Stratum {
 }
 
 impl StratumMeta {
+    #[cfg(test)]
     pub(crate) fn new(start: CommitHash, end: CommitHash, blob: BlobMeta) -> Self {
         Self { start, end, blob }
     }
@@ -499,7 +500,7 @@ impl SedimentreeSummary {
     }
 }
 
-enum CommitOrStratum {
+pub(crate) enum CommitOrStratum {
     Commit(LooseCommit),
     Stratum(Stratum),
 }
@@ -538,17 +539,6 @@ impl std::fmt::Debug for Sedimentree {
 pub(crate) struct MinimalTreeHash([u8; 32]);
 
 impl MinimalTreeHash {
-    pub(crate) fn parse(
-        input: parse::Input<'_>,
-    ) -> Result<(parse::Input<'_>, Self), parse::ParseError> {
-        let (input, hash) = parse::arr::<32>(input)?;
-        Ok((input, Self(hash)))
-    }
-
-    pub(crate) fn encode(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0);
-    }
-
     pub(crate) fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
@@ -562,8 +552,6 @@ impl From<[u8; 32]> for MinimalTreeHash {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use num::Num;
 
     use super::{Stratum, StratumMeta};

--- a/beelay/beelay-core/src/subscriptions.rs
+++ b/beelay/beelay-core/src/subscriptions.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     messages::{Notification, UploadItem},
-    parse,
     snapshots::Snapshot,
     CommitCategory, DocumentId, PeerId,
 };
@@ -10,25 +9,6 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct SubscriptionId([u8; 16]);
-
-impl SubscriptionId {
-    pub(crate) fn random<R: rand::Rng>(rng: &mut R) -> Self {
-        let mut id = [0; 16];
-        rng.fill_bytes(&mut id);
-        Self(id)
-    }
-
-    pub(crate) fn parse(
-        input: parse::Input<'_>,
-    ) -> Result<(parse::Input<'_>, Self), parse::ParseError> {
-        let (input, id) = parse::arr::<16>(input)?;
-        Ok((input, Self(id)))
-    }
-
-    pub(crate) fn as_bytes(&self) -> &[u8; 16] {
-        &self.0
-    }
-}
 
 pub(crate) struct DocEvent {
     doc: DocumentId,

--- a/beelay/beelay-core/tests/smoke.rs
+++ b/beelay/beelay-core/tests/smoke.rs
@@ -5,7 +5,6 @@ use beelay_core::{
     BundleSpec, CommitHash, CommitOrBundle, DocEvent, DocumentId, PeerId, SnapshotId,
     SyncDocResult,
 };
-use rand::Rng;
 
 fn init_logging() {
     let _ = tracing_subscriber::fmt::fmt()
@@ -116,7 +115,7 @@ fn request_from_connected() {
         .beelay(&peer1)
         .add_commits(doc1_id, vec![commit1.clone()]);
 
-    let sync_with_2 = network.beelay(&peer3).sync_doc(doc1_id, peer2.clone());
+    let _sync_with_2 = network.beelay(&peer3).sync_doc(doc1_id, peer2.clone());
     let commits_on_3: HashSet<beelay_core::Commit> = network
         .beelay(&peer3)
         .load_doc(doc1_id)


### PR DESCRIPTION
Fixed some unused imports, dead code warnings, and misaligned fn visibility in Beelay.

Two functions that were flagged as dead code are actually used in tests. They were set to `pub(crate)`, so not in the public API. We tag them with `#[allow(dead_code)]`, but I went with `#[cfg(test)]` to indicate where they're actually used.

We could tag the removed code with `#[allow(dead_code)]` if they're useful to have around, but I've opted here to remove them outright since we can always pull them back out of git history. (I find that generally YAGNI but happy to be overruled)