### PR TITLE
Add a static key for the public (anonymous) user

### DIFF
--- a/beehive_core/src/principal.rs
+++ b/beehive_core/src/principal.rs
@@ -7,4 +7,5 @@ pub mod group;
 pub mod identifier;
 pub mod individual;
 pub mod membered;
+pub mod public;
 pub mod verifiable;

--- a/beehive_core/src/principal/individual/state.rs
+++ b/beehive_core/src/principal/individual/state.rs
@@ -1,8 +1,10 @@
-use crate::crypto::{
-    share_key::{ShareKey, ShareSecretKey},
-    signed::{Signed, SigningError},
+use crate::{
+    crypto::{
+        share_key::{ShareKey, ShareSecretKey},
+        signed::{Signed, SigningError},
+    },
+    util::content_addressed_map::CaMap,
 };
-use crate::util::content_addressed_map::CaMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -108,6 +110,18 @@ impl std::hash::Hash for PrekeyState {
 pub enum KeyOp {
     Add(AddKeyOp),
     Update(ShareKeyOp),
+}
+
+impl From<AddKeyOp> for KeyOp {
+    fn from(op: AddKeyOp) -> Self {
+        Self::Add(op)
+    }
+}
+
+impl From<ShareKeyOp> for KeyOp {
+    fn from(op: ShareKeyOp) -> Self {
+        Self::Update(op)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/beehive_core/src/principal/public.rs
+++ b/beehive_core/src/principal/public.rs
@@ -1,0 +1,79 @@
+use super::{
+    active::Active,
+    identifier::Identifier,
+    individual::{
+        state::{AddKeyOp, PrekeyState},
+        Individual,
+    },
+    verifiable::Verifiable,
+};
+use crate::{
+    crypto::{
+        share_key::{ShareKey, ShareSecretKey},
+        signed::Signed,
+    },
+    util::content_addressed_map::CaMap,
+};
+use dupe::Dupe;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// A well-known agent that can be used by anyone. ⚠ USE WITH CAUTION ⚠
+///
+/// This is a constant key that is publicly-known.
+/// Sharing to this key is equivalent to setting a document to "public" by using a
+/// pre-leaked key. We use this so that the visibility of a document can be made
+/// temporarily public and later revoked.
+#[derive(Debug, Clone, Dupe, Copy)]
+pub struct Public;
+
+impl Public {
+    pub fn id(&self) -> Identifier {
+        self.verifying_key().into()
+    }
+
+    pub fn signing_key(&self) -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from([0; 32])
+    }
+
+    pub fn share_secret_key(&self) -> ShareSecretKey {
+        x25519_dalek::StaticSecret::from([0; 32]).into()
+    }
+
+    pub fn share_key(&self) -> ShareKey {
+        self.share_secret_key().share_key()
+    }
+
+    pub fn individual(&self) -> Individual {
+        let op = Signed::try_sign(
+            AddKeyOp {
+                share_key: self.share_key(),
+            }
+            .into(),
+            &self.signing_key(),
+        )
+        .expect("signature with well-known key should work");
+
+        Individual {
+            id: self.verifying_key().into(),
+            prekeys: HashSet::from_iter([self.share_key()]),
+            prekey_state: PrekeyState {
+                ops: CaMap::from_iter([op]),
+                keypairs: HashMap::from_iter([(self.share_key(), self.share_secret_key())]),
+            },
+        }
+    }
+
+    pub fn active(&self) -> Active {
+        Active {
+            signer: self.signing_key(),
+            prekey_pairs: BTreeMap::from_iter([(self.share_key(), self.share_secret_key())]),
+            individual: self.individual(),
+        }
+    }
+}
+
+impl Verifiable for Public {
+    fn verifying_key(&self) -> ed25519_dalek::VerifyingKey {
+        ed25519_dalek::VerifyingKey::from(&self.signing_key())
+    }
+}


### PR DESCRIPTION
I needed a break from #39, and the "public agent" strategy came up in a call. We keep reinventing this pattern, and it's a very small amount of work, so I went ahead and threw it together.

This is captured in the code's docs, but in essence the strategy is to pre-leaks a secret key (`[0; 32]` AKA "oops all zeroes!").

<img src="https://github.com/user-attachments/assets/cf11e3fe-ff9a-465e-ad6a-629627d3a64e" width="200px" />

This lets us open a document at any of the usual access levels, and later remove them. This strategy requires no changes whatsoever to the capability system or BeeKEM. There is one Byzantine case where someone rotates a BeeKEM share key for the public user, which would limit the view to them temporarily. It would be annoying, but anyone could put it back as it was after. I suggest that this gets handled at a higher-level API that is aware of the public user and just doesn't expose those APIs.

There is nothing preventing anyone from pre-leaking a key in their application, so strictly speaking nothing is new here.

[We may follow a similar approach for share links in the future (but with randomly-generated keys), though I can imagine alternatives for that]