### PR TITLE
Replace the use of nested encryption to handle conflict keys

### DIFF
--- a/beehive_core/src/beehive.rs
+++ b/beehive_core/src/beehive.rs
@@ -6,7 +6,7 @@ use crate::{
     content::reference::ContentRef,
     crypto::{
         digest::Digest,
-        encrypted::Encrypted,
+        encrypted::EncryptedContent,
         share_key::ShareKey,
         signed::{Signed, SigningError, VerificationError},
     },
@@ -239,7 +239,7 @@ impl<T: ContentRef, R: rand::CryptoRng + rand::RngCore> Beehive<T, R> {
         content_ref: &T,
         pred_refs: &Vec<T>,
         content: &[u8],
-    ) -> Result<Encrypted<Vec<u8>, T>, EncryptError> {
+    ) -> Result<EncryptedContent<Vec<u8>, T>, EncryptError> {
         let (encrypted, _maybe_update_op) = doc.borrow_mut().try_encrypt_content(
             content_ref,
             content,
@@ -253,7 +253,7 @@ impl<T: ContentRef, R: rand::CryptoRng + rand::RngCore> Beehive<T, R> {
     pub fn try_decrypt_content(
         &mut self,
         doc: Rc<RefCell<Document<T>>>,
-        encrypted: &Encrypted<Vec<u8>, T>,
+        encrypted: &EncryptedContent<Vec<u8>, T>,
     ) -> Result<Vec<u8>, DecryptError> {
         doc.borrow_mut().try_decrypt_content(encrypted)
     }

--- a/beehive_core/src/cgka.rs
+++ b/beehive_core/src/cgka.rs
@@ -18,7 +18,7 @@ use crate::{
     crypto::{
         application_secret::{ApplicationSecret, PcsKey},
         digest::Digest,
-        encrypted::Encrypted,
+        encrypted::EncryptedContent,
         share_key::{ShareKey, ShareSecretKey},
         siv::Siv,
         symmetric_key::SymmetricKey,
@@ -139,7 +139,7 @@ impl Cgka {
     /// hashes. Then we use that [`PcsKey`] to derive an [`ApplicationSecret`].
     pub fn decryption_key_for<T, Cr: ContentRef>(
         &mut self,
-        encrypted: &Encrypted<T, Cr>,
+        encrypted: &EncryptedContent<T, Cr>,
     ) -> Result<SymmetricKey, CgkaError> {
         let pcs_key =
             self.pcs_key_from_hashes(&encrypted.pcs_key_hash, &encrypted.pcs_update_op_hash)?;
@@ -166,7 +166,7 @@ impl Cgka {
         if self.should_replay() {
             self.replay_ops_graph()?;
         }
-        let leaf_index = self.tree.push_leaf(id, pk.into())?;
+        let leaf_index = self.tree.push_leaf(id, pk.into());
         let predecessors = Vec::from_iter(self.ops_graph.cgka_op_heads.iter().cloned());
         let add_predecessors = Vec::from_iter(self.ops_graph.add_heads.iter().cloned());
         let op = CgkaOperation::Add {
@@ -284,13 +284,13 @@ impl Cgka {
         }
         match op {
             CgkaOperation::Add { added_id, pk, .. } => {
-                self.tree.push_leaf(*added_id, (*pk).into())?;
+                self.tree.push_leaf(*added_id, (*pk).into());
             }
             CgkaOperation::Remove { id, .. } => {
                 self.tree.remove_id(*id)?;
             }
             CgkaOperation::Update { new_path, .. } => {
-                self.tree.apply_path(new_path)?;
+                self.tree.apply_path(new_path);
             }
         }
         self.ops_graph.add_op(op, &op.predecessors());
@@ -336,7 +336,7 @@ impl Cgka {
                     .sort_leaves_and_blank_paths_for_concurrent_membership_changes(
                         added_ids,
                         removed_ids,
-                    )?;
+                    );
             }
         }
         Ok(())

--- a/beehive_core/src/cgka/README.md
+++ b/beehive_core/src/cgka/README.md
@@ -9,7 +9,7 @@
 
 *ownership of a tree*: you own a tree if you can use it to encrypt a new root secret. An owner will correspond to one of the members of the tree group (and hence one of its leaves).
 
-*resolution*: either (1) the public key/s of a node or (2) if the node is blank, all of its highest non-blank descendants' public keys. The resolution is ordered by left to right positions on the tree. The resolution is never taken at the root, so the worst case resolution is the n / 2 leaves of one of the root's child sub-trees if all of that sub-tree's inner nodes are blank.
+*resolution*: either (1) the public key/s of a node or (2) if the node is blank or contains conflict keys, all of its highest non-blank, non-conflict descendants' public keys. The resolution is never taken at the root, so the worst case resolution is the n / 2 leaves of one of the root's child sub-trees if all of that sub-tree's inner nodes are blank or contain conflict keys.
 
 ## Invariants
 

--- a/beehive_core/src/cgka/beekem.rs
+++ b/beehive_core/src/cgka/beekem.rs
@@ -4,12 +4,12 @@ use super::{
 use crate::{
     crypto::{
         application_secret::PcsKey,
-        encrypted::NestedEncrypted,
+        encrypted::EncryptedSecret,
         share_key::{ShareKey, ShareSecretKey},
+        siv::Siv,
     },
     principal::{document::id::DocumentId, individual::id::IndividualId},
 };
-use nonempty::{nonempty, NonEmpty};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use treemath::{InnerNodeIndex, LeafNodeIndex, TreeNodeIndex, TreeSize};
@@ -33,9 +33,9 @@ pub struct PathChange {
 /// [Matthew Weidner's Causal TreeKEM][Causal TreeKEM]. The distinctive
 /// feature of BeeKEM is that when merging concurrent updates, we keep all concurrent
 /// public keys at any node where there is a conflict (until they are overwritten by
-/// a future update along that path). The conflict keys are used for nested encryption,
-/// ensuring that a passive adversary needs all of the historical secret keys at
-/// one of the leaves in order to read the latest secret after a merge.
+/// a future update along that path). The conflict keys are used to ensure
+/// that a passive adversary needs all of the historical secret keys at
+/// one of the leaves in order to read the latest root secret after a merge.
 ///
 /// Leaf nodes represent group members. Each member has a fixed identifier as well
 /// as a public key that is rotated over time. Each inner node stores one or more
@@ -49,24 +49,11 @@ pub struct PathChange {
 ///   corresponding secret key. The child uses the public key of its sibling to derive
 ///   a shared Diffie Hellman (DH) secret. It then uses this shared DH secret to
 ///   encrypt the new parent secret.
-/// * In case of a blank sibling, the encrypting child encrypts the secret for each of
-///   the nodes in its sibling's resolution (which is the set of the highest non-blank
-///   descendents of the sibling). This means a separate DH per node in that resolution.
-///   These encryptions of the secret are stored in a map at the parent.
-/// * In the case of a sibling with multiple public keys (because of a merge conflict),
-///   the encrypter must use the nested encryption method for encrypting the new secret
-///   for the parent. It does DH using the child's secret key with each of its sibling's
-///   (sorted) public keys to create a nested encryption.
-/// * * Encryption of a parent of a conflict node will always result in one public key
-///     and one corresponding secret key for that parent. This is because the encrypter
-///     overwrites conflicts on its path as it ascends the tree.
-/// * * A node with multiple public keys will also have multiple corresponding encrypted
-///     secret keys. On decryption, any leaf with a conflict node on its path will need
-///     all those secret keys to do the nested decryption of the conflict node's parent.
-/// * * When starting a decryption, you pass in your map of public keys to decrypted
-///     secret keys. If you hit new public keys on the way up, you add the corresponding
-///     decrypted secret keys to that map. This map allows you to always look up secret
-///     keys for nested decryptions.
+/// * In case of a blank or conflict sibling, the encrypting child encrypts the secret
+///   for each of the nodes in its sibling's resolution (which is the set of the highest
+///   non-blank, non-conflict descendents of the sibling). This means a separate DH per
+///   node in that resolution. These encryptions of the secret are stored in a map at
+///   the parent.
 ///
 /// [Causal TreeKEM]: https://mattweidner.com/assets/pdf/acs-dissertation.pdf
 /// [MLS]: https://messaginglayersecurity.rocks/
@@ -81,7 +68,8 @@ pub(crate) struct BeeKem {
     tree_size: TreeSize,
     id_to_leaf_idx: BTreeMap<IndividualId, LeafNodeIndex>,
     /// The leaf node that was the source of the last path encryption, or [`None`]
-    /// if there is currently no root key.
+    /// if there is currently no root key. This is used to determine when a
+    /// decrypter has intersected with the encrypter's path.
     current_secret_encrypter_leaf_idx: Option<LeafNodeIndex>,
 }
 
@@ -101,7 +89,7 @@ impl BeeKem {
             current_secret_encrypter_leaf_idx: None,
         };
         tree.grow_tree_to_size();
-        tree.push_leaf(initial_member_id, initial_member_pk.into())?;
+        tree.push_leaf(initial_member_id, initial_member_pk.into());
         Ok(tree)
     }
 
@@ -120,53 +108,51 @@ impl BeeKem {
         &mut self,
         mut added_ids: HashSet<IndividualId>,
         removed_ids: HashSet<(IndividualId, u32)>,
-    ) -> Result<(), CgkaError> {
+    ) {
         let mut leaves_to_sort = Vec::new();
         for (id, idx) in removed_ids {
-            let leaf_idx = LeafNodeIndex::new(idx);
             added_ids.remove(&id);
-            if self.leaf(leaf_idx)?.is_none() {
-                self.blank_leaf_and_path(leaf_idx)?;
-            }
+            let leaf_idx = LeafNodeIndex::new(idx);
+            debug_assert!(self.leaf(leaf_idx).is_none());
+            // We should have already removed this id during merge, but concurrent
+            // updates at other leaves with intersecting paths must be overridden by
+            // this remove.
+            self.blank_leaf_and_path(leaf_idx);
         }
         while !added_ids.is_empty() && self.next_leaf_idx.u32() > 0 {
-            if let Some(next_leaf) = self.leaf(self.next_leaf_idx - 1)?.clone() {
+            let leaf_idx = self.next_leaf_idx - 1;
+            if let Some(next_leaf) = self.leaf(leaf_idx).clone() {
                 added_ids.remove(&next_leaf.id);
                 leaves_to_sort.push(next_leaf);
             }
-            self.next_leaf_idx -= 1;
-            self.blank_leaf_and_path(self.next_leaf_idx)?;
+            self.blank_leaf_and_path(leaf_idx);
+            self.next_leaf_idx = leaf_idx;
         }
         leaves_to_sort.sort_by(|a, b| a.id.cmp(&b.id));
         for leaf in leaves_to_sort {
-            self.push_leaf(leaf.id, leaf.pk.clone())?;
+            self.push_leaf(leaf.id, leaf.pk.clone());
         }
-        Ok(())
     }
 
     /// Blank the leaf at the provided [`LeafNodeIndex`] as well as its path
     /// to the root.
-    pub(crate) fn blank_leaf_and_path(&mut self, idx: LeafNodeIndex) -> Result<(), CgkaError> {
-        if idx.usize() >= self.leaves.len() {
-            return Err(CgkaError::TreeIndexOutOfBounds);
-        }
+    pub(crate) fn blank_leaf_and_path(&mut self, idx: LeafNodeIndex) {
         self.leaves[idx.usize()] = None;
-        self.blank_path(treemath::parent(idx.into()))?;
+        self.blank_path(treemath::parent(idx.into()));
         self.current_secret_encrypter_leaf_idx = None;
-        Ok(())
     }
 
     /// Add a new leaf to the first available [`LeafNodeIndex`] on the right and
     /// blank that leaf's path to the root.
-    pub(crate) fn push_leaf(&mut self, id: IndividualId, pk: NodeKey) -> Result<u32, CgkaError> {
+    pub(crate) fn push_leaf(&mut self, id: IndividualId, pk: NodeKey) -> u32 {
         self.maybe_grow_tree(self.next_leaf_idx.u32());
         let l_idx = self.next_leaf_idx;
         self.next_leaf_idx += 1;
-        self.insert_leaf_at(l_idx, id, pk)?;
+        self.insert_leaf_at(l_idx, id, pk);
         self.id_to_leaf_idx.insert(id, l_idx);
-        self.blank_path(treemath::parent(l_idx.into()))?;
+        self.blank_path(treemath::parent(l_idx.into()));
         self.current_secret_encrypter_leaf_idx = None;
-        Ok(l_idx.u32())
+        l_idx.u32()
     }
 
     /// Remove data for the provided [`IndividualId`] and blank its leaf's
@@ -181,16 +167,16 @@ impl BeeKem {
         let l_idx = *self.leaf_index_for_id(id)?;
         let mut removed_keys = Vec::new();
         for idx in treemath::direct_path((l_idx).into(), self.tree_size) {
-            if let Some(store) = self.inner_node(idx)? {
+            if let Some(store) = self.inner_node(idx) {
                 removed_keys.append(&mut store.node_key().keys());
             }
         }
-        self.blank_leaf_and_path(l_idx)?;
+        self.blank_leaf_and_path(l_idx);
         self.id_to_leaf_idx.remove(&id);
         self.current_secret_encrypter_leaf_idx = None;
         // Collect any contiguous "tombstones" at the end of the leaves Vec
-        while self.leaf(self.next_leaf_idx - 1)?.is_none() {
-            self.blank_path(treemath::parent((self.next_leaf_idx - 1).into()))?;
+        while self.leaf(self.next_leaf_idx - 1).is_none() {
+            self.blank_path(treemath::parent((self.next_leaf_idx - 1).into()));
             self.next_leaf_idx -= 1;
         }
         Ok((l_idx.u32(), removed_keys))
@@ -205,11 +191,11 @@ impl BeeKem {
     ///
     /// Starting from the owner's leaf, move up the tree toward the root (i.e., along the
     /// leaf's path). As you look at each parent node along the way, if the node is not
-    /// blank, look up your child idx in the parent's secret store. Derive Diffie Hellman
-    /// shared keys using the public keys stored in the secret store and use those shared
-    /// keys to decrypt the secret key stored there.
+    /// blank, look up the encrypted secret in the parent's secret store using your child
+    /// index. Derive a Diffie Hellman shared key using the encrypter public key stored in
+    /// the secret store and use that shared key to decrypt the secret key you looked up.
     ///
-    /// Hold on to each idx you've seen along the way, since ancestors might have been
+    /// Hold on to each idx you've seen along the way since ancestors might have been
     /// encrypted for any of these descendents (in cases like a blank node or
     /// conflicting keys on a node on the path).
     pub(crate) fn decrypt_tree_secret(
@@ -218,16 +204,13 @@ impl BeeKem {
         owner_sks: &mut ShareKeyMap,
     ) -> Result<ShareSecretKey, CgkaError> {
         let leaf_idx = *self.leaf_index_for_id(owner_id)?;
-        let leaf = self
-            .leaf(leaf_idx)?
-            .as_ref()
-            .ok_or(CgkaError::OwnerIdentifierNotFound)?;
         if !self.has_root_key() {
             return Err(CgkaError::NoRootKey);
         }
-        if self.is_blank(leaf_idx.into())? {
-            return Err(CgkaError::OwnerIdentifierNotFound);
-        }
+        let leaf = self
+            .leaf(leaf_idx)
+            .as_ref()
+            .expect("Leaf should not be blank");
         if Some(leaf_idx) == self.current_secret_encrypter_leaf_idx {
             let NodeKey::ShareKey(pk) = leaf.pk else {
                 return Err(CgkaError::ShareKeyNotFound);
@@ -240,24 +223,27 @@ impl BeeKem {
         let mut child_idx: TreeNodeIndex = leaf_idx.into();
         let mut seen_idxs = vec![child_idx];
         // We will return this at the end once we've decrypted the root secret.
-        let mut last_secret_decrypted = None;
+        let mut maybe_last_secret_decrypted = None;
         let mut child_node_key = leaf.pk.clone();
         let mut parent_idx: TreeNodeIndex = treemath::parent(child_idx).into();
         while !self.is_root(child_idx) {
-            // Find the next non-blank parent
-            while self.is_blank(parent_idx)? {
+            // Find the next non-blank, non-conflict parent
+            while self.should_skip_for_resolution(parent_idx) {
                 child_idx = parent_idx;
                 parent_idx = treemath::parent(child_idx).into();
             }
             debug_assert!(!self.is_root(child_idx));
-            last_secret_decrypted =
-                self.decrypt_parent_key(child_idx, &child_node_key, &seen_idxs, owner_sks)?;
-            if let Some(ref secret) = last_secret_decrypted {
+            maybe_last_secret_decrypted =
+                self.maybe_decrypt_parent_key(child_idx, &child_node_key, &seen_idxs, owner_sks)?;
+            if let Some(ref secret) = maybe_last_secret_decrypted {
                 let lca_with_encrypter = treemath::lowest_common_ancestor(
                     leaf_idx,
                     self.current_secret_encrypter_leaf_idx
-                        .ok_or(CgkaError::CurrentEncrypterNotFound)?,
+                        .expect("A tree with a root key should have a current encrypter"),
                 );
+                // If we have reached the intersection of our path with the encrypter's
+                // path, then we can ratchet this parent secret forward for each of the
+                // remaining nodes in the path and return early.
                 if parent_idx == TreeNodeIndex::Inner(lca_with_encrypter) {
                     return Ok(secret.ratchet_n_forward(
                         treemath::direct_path(parent_idx, self.tree_size).len(),
@@ -265,11 +251,11 @@ impl BeeKem {
                 }
             }
             seen_idxs.push(parent_idx);
-            child_node_key = self.node_key_for_index(parent_idx)?;
             child_idx = parent_idx;
+            child_node_key = self.node_key_for_index(child_idx)?;
             parent_idx = treemath::parent(child_idx).into();
         }
-        last_secret_decrypted.ok_or(CgkaError::NoRootKey)
+        maybe_last_secret_decrypted.ok_or(CgkaError::NoRootKey)
     }
 
     /// Rotate key and encrypt new secrets along the provided [`IndividualId`]'s path.
@@ -277,19 +263,15 @@ impl BeeKem {
     ///
     /// Starting from the owner's leaf, move up the tree toward the root (i.e., along the
     /// leaf's path). As you look at each parent node along the way, you need to populate
-    /// it with a public key and a map from sibling subtree public keys to a newly generated
-    /// secret key encrypted pairwise with each node in the sibling resolution (in the
+    /// it with a public key and a map from sibling subtree public keys to newly generated
+    /// secret keys encrypted pairwise with each node in the sibling resolution (in the
     /// ideal case, this will just be the sibling node itself, but if the sibling is
-    /// blank it can be many nodes).
+    /// blank or contains conflict keys it can be many nodes).
     ///
-    /// If the sibling node's resolution is empty, then you will generate the new key
+    /// If your sibling node's resolution is empty, then you will generate the new key
     /// pair but encrypt the secret by doing Diffie Hellman with a different key pair
     /// generated just for that purpose. The secret store for that parent will then
     /// only have an entry for you.
-    ///
-    /// If one or more members of your sibling's resolution have conflicting public keys,
-    /// then you will do a nested encryption of the secret using all of the conflicting
-    /// public keys ordered lexicographically.
     pub(crate) fn encrypt_path<R: rand::CryptoRng + rand::RngCore>(
         &mut self,
         id: IndividualId,
@@ -297,13 +279,8 @@ impl BeeKem {
         sks: &mut ShareKeyMap,
         csprng: &mut R,
     ) -> Result<Option<(PcsKey, PathChange)>, CgkaError> {
-        if !self.id_to_leaf_idx.contains_key(&id) {
-            return Ok(None);
-        }
         let leaf_idx = *self.leaf_index_for_id(id)?;
-        if self.id_for_leaf(leaf_idx)? != id {
-            return Err(CgkaError::IdentifierNotFound);
-        }
+        debug_assert!(self.id_for_leaf(leaf_idx).unwrap() == id);
         let mut new_path = PathChange {
             leaf_id: id,
             leaf_idx: leaf_idx.u32(),
@@ -311,37 +288,35 @@ impl BeeKem {
             path: Vec::new(),
             removed_keys: self.node_key_for_id(id)?.keys(),
         };
-        self.insert_leaf_at(leaf_idx, id, NodeKey::ShareKey(pk))?;
+        self.insert_leaf_at(leaf_idx, id, NodeKey::ShareKey(pk));
         let mut child_idx: TreeNodeIndex = leaf_idx.into();
         // An encrypter will always have a single public key at each node as it
         // encrypts up its path. At its leaf, it will have written the latest public
-        // key in the past. And as it moves up the path, it will generate a new public
+        // key at the start. And as it moves up the path, it will generate a new public
         // key for each ancestor up to the root.
         let mut child_pk = pk;
         let mut child_sk = *sks.get(&pk).ok_or(CgkaError::SecretKeyNotFound)?;
         let leaf_sk = child_sk;
         let mut parent_idx = treemath::parent(child_idx);
         while !self.is_root(child_idx) {
-            if let Some(store) = self.inner_node(parent_idx)? {
+            if let Some(store) = self.inner_node(parent_idx) {
                 new_path.removed_keys.append(&mut store.node_key().keys());
             }
             let new_parent_sk = child_sk.ratchet_forward();
             let new_parent_pk = new_parent_sk.share_key();
             self.encrypt_key_for_parent(
-                csprng,
                 child_idx,
                 child_pk,
                 &child_sk,
                 new_parent_pk,
                 &new_parent_sk,
+                csprng,
             )?;
-            // Add to our ShareKeyMap so we won't have to decrypt in the future
-            sks.insert(new_parent_pk, new_parent_sk);
             new_path.path.push((
                 parent_idx.u32(),
-                self.inner_node(parent_idx)?
+                self.inner_node(parent_idx)
                     .as_ref()
-                    .ok_or(CgkaError::ShareKeyNotFound)?
+                    .expect("Parent node should not be None after encryption")
                     .clone(),
             ));
             child_idx = parent_idx.into();
@@ -356,37 +331,43 @@ impl BeeKem {
 
     /// Applies a [`PathChange`] representing new public and encrypted secret keys for each
     /// node on a path.
-    pub(crate) fn apply_path(&mut self, new_path: &PathChange) -> Result<(), CgkaError> {
+    pub(crate) fn apply_path(&mut self, new_path: &PathChange) {
+        // If this id has been concurrently removed, it might no longer be present
+        // when we try to apply the concurrent update at that id.
         if !self.id_to_leaf_idx.contains_key(&new_path.leaf_id) {
-            return Ok(());
+            return;
         }
-        let leaf_idx = *self.leaf_index_for_id(new_path.leaf_id)?;
-        if !self.is_valid_change(new_path)? {
-            // A structural change has occurred so we can't apply the whole path.
-            let new_node_key = if let Some(leaf) = self.leaf(leaf_idx)? {
-                leaf.pk.merge(&new_path.leaf_pk, &new_path.removed_keys)
-            } else {
-                new_path.leaf_pk.clone()
+        let leaf_idx = *self
+            .leaf_index_for_id(new_path.leaf_id)
+            .expect("Id should be present");
+        if !self.is_valid_path(new_path) {
+            // Since this path is no longer valid, we can only update the leaf for
+            // this id.
+            let Some(leaf) = self.leaf(leaf_idx) else {
+                panic!("Leaf for present ID should not be None");
             };
-            self.insert_leaf_at(leaf_idx, new_path.leaf_id, new_node_key)?;
-            self.blank_path(treemath::parent(leaf_idx.into()))?;
-            return Ok(());
+            let new_node_key = leaf.pk.merge(&new_path.leaf_pk, &new_path.removed_keys);
+            self.insert_leaf_at(leaf_idx, new_path.leaf_id, new_node_key);
+            self.blank_path(treemath::parent(leaf_idx.into()));
+            return;
         }
 
-        let old_leaf = self.leaf(leaf_idx)?.as_ref().unwrap();
+        let old_leaf = self.leaf(leaf_idx).as_ref().unwrap();
         let new_leaf_pk = new_path.leaf_pk.clone();
         self.insert_leaf_at(
             leaf_idx,
             new_path.leaf_id,
             old_leaf.pk.merge(&new_leaf_pk, &new_path.removed_keys),
-        )?;
+        );
 
+        let removed_keys_set: HashSet<ShareKey> =
+            HashSet::from_iter(new_path.removed_keys.iter().copied());
         for (idx, node) in &new_path.path {
             let current_idx = InnerNodeIndex::new(*idx);
-            if let Some(current_node) = self.inner_node_mut(current_idx)? {
-                current_node.merge(node, &new_path.removed_keys)?;
+            if let Some(current_node) = self.inner_node_mut(current_idx) {
+                current_node.merge(node, &removed_keys_set);
             } else {
-                self.insert_inner_node_at(current_idx, node.clone())?;
+                self.insert_inner_node_at(current_idx, node.clone());
             }
         }
 
@@ -395,20 +376,15 @@ impl BeeKem {
         } else {
             self.current_secret_encrypter_leaf_idx = None;
         }
-        Ok(())
     }
 
     /// Whether the tree currently has a root key.
     pub(crate) fn has_root_key(&self) -> bool {
         let root_idx: TreeNodeIndex = treemath::root(self.tree_size);
         let TreeNodeIndex::Inner(p_idx) = root_idx else {
-            panic!("BeeKEM should always have a root node.")
+            panic!("BeeKEM should always have a root at an inner node.")
         };
-        if let Some(r) = self
-            .inner_node(p_idx)
-            .expect("root node index to be in tree")
-        {
-            // A root with a public key conflict does not have a decryption secret
+        if let Some(r) = self.inner_node(p_idx) {
             !r.has_conflict()
         } else {
             false
@@ -418,9 +394,9 @@ impl BeeKem {
     /// Decrypt parent node's [`ShareSecretKey`].
     ///
     /// Returns the secret if there is a single parent public key.
-    /// In either case, adds any public key/decrypted secret key pair/s
-    /// it encounters to the secret key map.
-    fn decrypt_parent_key(
+    /// In either case, adds any public key/decrypted secret key pairs
+    /// it encounters to the [`ShareKeyMap`].
+    fn maybe_decrypt_parent_key(
         &self,
         child_idx: TreeNodeIndex,
         child_node_key: &NodeKey,
@@ -429,19 +405,12 @@ impl BeeKem {
     ) -> Result<Option<ShareSecretKey>, CgkaError> {
         debug_assert!(!self.is_root(child_idx));
         let parent_idx = treemath::parent(child_idx);
-        debug_assert!(!self.is_blank(parent_idx.into())?);
-        let parent = self
-            .inner_node(parent_idx)?
-            .as_ref()
-            .ok_or(CgkaError::TreeIndexOutOfBounds)?;
+        let Some(parent) = self.inner_node(parent_idx) else {
+            return Ok(None);
+        };
 
         let maybe_secret = match parent.node_key() {
-            NodeKey::ConflictKeys(_) => {
-                // If we haven't decrypted all secrets for a conflict node, we need to do
-                // that before continuing.
-                parent.decrypt_undecrypted_secrets(child_node_key, child_sks, seen_idxs)?;
-                None
-            }
+            NodeKey::ConflictKeys(_) => None,
             NodeKey::ShareKey(parent_pk) => {
                 if child_sks.contains_key(&parent_pk) {
                     return Ok(child_sks.get(&parent_pk).cloned());
@@ -457,24 +426,24 @@ impl BeeKem {
     /// Encrypt new secret for parent node.
     fn encrypt_key_for_parent<R: rand::CryptoRng + rand::RngCore>(
         &mut self,
-        csprng: &mut R,
         child_idx: TreeNodeIndex,
         child_pk: ShareKey,
         child_sk: &ShareSecretKey,
         new_parent_pk: ShareKey,
         new_parent_sk: &ShareSecretKey,
+        csprng: &mut R,
     ) -> Result<(), CgkaError> {
         debug_assert!(!self.is_root(child_idx));
         let parent_idx = treemath::parent(child_idx);
         let secret_store = self.encrypt_new_secret_store_for_parent(
-            csprng,
             child_idx,
             child_pk,
             child_sk,
             new_parent_pk,
             new_parent_sk,
+            csprng,
         )?;
-        self.insert_inner_node_at(parent_idx, secret_store)?;
+        self.insert_inner_node_at(parent_idx, secret_store);
         Ok(())
     }
 
@@ -482,53 +451,41 @@ impl BeeKem {
     ///
     /// Encrypt the new parent [`ShareSecretKey`] for each member of your sibling
     /// node's resolution. These are then stored in the new [`SecretStore`], indexed
-    /// by member of that resolution.
+    /// by the tree index for each member of that resolution.
     #[allow(clippy::type_complexity)]
     fn encrypt_new_secret_store_for_parent<R: rand::CryptoRng + rand::RngCore>(
         &self,
-        csprng: &mut R,
         child_idx: TreeNodeIndex,
         child_pk: ShareKey,
         child_sk: &ShareSecretKey,
         new_parent_pk: ShareKey,
         new_parent_sk: &ShareSecretKey,
+        csprng: &mut R,
     ) -> Result<SecretStore, CgkaError> {
         debug_assert!(!self.is_root(child_idx));
         let sibling_idx = treemath::sibling(child_idx);
         let mut secret_map = BTreeMap::new();
         let mut sibling_resolution = Vec::new();
-        self.append_resolution(sibling_idx, &mut sibling_resolution)?;
+        self.append_resolution(sibling_idx, &mut sibling_resolution);
         if sibling_resolution.is_empty() {
             // Normally you use a DH shared key to encrypt/decrypt the next node up,
             // but if there's a blank sibling subtree, then you generate a key pair
             // just to do DH with when ecrypting the new parent secret.
             let paired_sk = ShareSecretKey::generate(csprng);
             let paired_pk = paired_sk.share_key();
-            let encrypted_sk = NestedEncrypted::<ShareSecretKey>::try_encrypt(
-                self.doc_id,
-                new_parent_sk,
-                child_sk,
-                &nonempty![paired_pk],
-            )
-            .map_err(CgkaError::Encryption)?;
-
+            let encrypted_sk = encrypt_secret(self.doc_id, *new_parent_sk, child_sk, &paired_pk)?;
             secret_map.insert(child_idx, encrypted_sk);
         } else {
             // Encrypt the secret for every node in the sibling resolution, using
-            // a new DH shared secret to do the encryption for each node. If a node in
-            // the resolution has conflicting public keys, you must do a nested encryption
-            // for that node.
+            // a new DH shared secret to do the encryption for each node.
             let mut used_paired_sibling = false;
             for idx in sibling_resolution {
-                let sibling_node_key = self.node_key_for_index(idx)?;
-                let encrypted_sk = NestedEncrypted::<ShareSecretKey>::try_encrypt(
-                    self.doc_id,
-                    new_parent_sk,
-                    child_sk,
-                    &NonEmpty::from_vec(sibling_node_key.keys()).expect("some keys to exist"),
-                )
-                .map_err(CgkaError::Encryption)?;
-
+                let sibling_pk = match self.node_key_for_index(idx)? {
+                    NodeKey::ShareKey(share_key) => share_key,
+                    _ => return Err(CgkaError::ShareKeyNotFound),
+                };
+                let encrypted_sk =
+                    encrypt_secret(self.doc_id, *new_parent_sk, child_sk, &sibling_pk)?;
                 if !used_paired_sibling {
                     secret_map.insert(child_idx, encrypted_sk.clone());
                     used_paired_sibling = true;
@@ -543,23 +500,23 @@ impl BeeKem {
     fn node_key_for_index(&self, idx: TreeNodeIndex) -> Result<NodeKey, CgkaError> {
         Ok(match idx {
             TreeNodeIndex::Leaf(l_idx) => self
-                .leaf(l_idx)?
+                .leaf(l_idx)
                 .as_ref()
                 .ok_or(CgkaError::ShareKeyNotFound)?
                 .pk
                 .clone(),
             TreeNodeIndex::Inner(i_idx) => self
-                .inner_node(i_idx)?
+                .inner_node(i_idx)
                 .as_ref()
                 .ok_or(CgkaError::ShareKeyNotFound)?
                 .node_key(),
         })
     }
 
-    fn leaf(&self, idx: LeafNodeIndex) -> Result<&Option<LeafNode>, CgkaError> {
+    fn leaf(&self, idx: LeafNodeIndex) -> &Option<LeafNode> {
         self.leaves
             .get(idx.usize())
-            .ok_or(CgkaError::TreeIndexOutOfBounds)
+            .expect("Leaf index should be in bounds")
     }
 
     pub(crate) fn leaf_index_for_id(&self, id: IndividualId) -> Result<&LeafNodeIndex, CgkaError> {
@@ -570,85 +527,71 @@ impl BeeKem {
 
     fn id_for_leaf(&self, idx: LeafNodeIndex) -> Result<IndividualId, CgkaError> {
         Ok(self
-            .leaf(idx)?
+            .leaf(idx)
             .as_ref()
             .ok_or(CgkaError::IdentifierNotFound)?
             .id)
     }
 
-    fn inner_node(&self, idx: InnerNodeIndex) -> Result<&Option<InnerNode>, CgkaError> {
+    fn inner_node(&self, idx: InnerNodeIndex) -> &Option<InnerNode> {
         self.inner_nodes
             .get(idx.usize())
-            .ok_or(CgkaError::TreeIndexOutOfBounds)
+            .expect("Inner node index should be in bounds")
     }
 
-    fn inner_node_mut(&mut self, idx: InnerNodeIndex) -> Result<&mut Option<InnerNode>, CgkaError> {
+    fn inner_node_mut(&mut self, idx: InnerNodeIndex) -> &mut Option<InnerNode> {
         self.inner_nodes
             .get_mut(idx.usize())
-            .ok_or(CgkaError::TreeIndexOutOfBounds)
+            .expect("Node should not be blank")
     }
 
-    fn insert_leaf_at(
-        &mut self,
-        idx: LeafNodeIndex,
-        id: IndividualId,
-        pk: NodeKey,
-    ) -> Result<(), CgkaError> {
-        if idx.usize() >= self.leaves.len() {
-            return Err(CgkaError::TreeIndexOutOfBounds);
-        }
+    fn insert_leaf_at(&mut self, idx: LeafNodeIndex, id: IndividualId, pk: NodeKey) {
         let leaf = LeafNode { id, pk };
         self.leaves[idx.usize()] = Some(leaf);
-        Ok(())
     }
 
-    fn insert_inner_node_at(
-        &mut self,
-        idx: InnerNodeIndex,
-        secret_store: SecretStore,
-    ) -> Result<(), CgkaError> {
-        if idx.usize() >= self.inner_nodes.len() {
-            return Err(CgkaError::TreeIndexOutOfBounds);
-        }
+    fn insert_inner_node_at(&mut self, idx: InnerNodeIndex, secret_store: SecretStore) {
         self.inner_nodes[idx.usize()] = Some(secret_store);
-        Ok(())
     }
 
-    fn is_blank(&self, idx: TreeNodeIndex) -> Result<bool, CgkaError> {
-        Ok(match idx {
-            TreeNodeIndex::Leaf(l_idx) => self.leaf(l_idx)?.is_none(),
-            TreeNodeIndex::Inner(p_idx) => self.inner_node(p_idx)?.is_none(),
-        })
-    }
-
-    fn blank_path(&mut self, idx: InnerNodeIndex) -> Result<(), CgkaError> {
-        self.blank_inner_node(idx)?;
-        if self.is_root(idx.into()) {
-            return Ok(());
+    fn is_blank(&self, idx: TreeNodeIndex) -> bool {
+        match idx {
+            TreeNodeIndex::Leaf(l_idx) => self.leaf(l_idx).is_none(),
+            TreeNodeIndex::Inner(p_idx) => self.inner_node(p_idx).is_none(),
         }
-        self.blank_path(treemath::parent(idx.into()))
     }
 
-    fn blank_inner_node(&mut self, idx: InnerNodeIndex) -> Result<(), CgkaError> {
-        if idx.usize() >= self.inner_nodes.len() {
-            return Err(CgkaError::TreeIndexOutOfBounds);
+    fn should_skip_for_resolution(&self, idx: TreeNodeIndex) -> bool {
+        match idx {
+            TreeNodeIndex::Leaf(_) => self.is_blank(idx),
+            TreeNodeIndex::Inner(i_idx) => self
+                .inner_node(i_idx)
+                .as_ref()
+                .map_or(true, |n| n.has_conflict()),
         }
+    }
+
+    fn blank_path(&mut self, mut idx: InnerNodeIndex) {
+        while !self.is_root(idx.into()) {
+            self.blank_inner_node(idx);
+            idx = treemath::parent(idx.into());
+        }
+        self.blank_inner_node(idx);
+    }
+
+    fn blank_inner_node(&mut self, idx: InnerNodeIndex) {
         self.inner_nodes[idx.usize()] = None;
-        Ok(())
     }
 
     /// Whether the [`PathChange`] still makes sense given the state of the tree
     /// we are attempting to merge it into.
-    fn is_valid_change(&self, new_path: &PathChange) -> Result<bool, CgkaError> {
-        let leaf_idx = self.leaf_index_for_id(new_path.leaf_id)?;
-        // TODO: We can probably apply a path change in some cases where the tree
-        // size has changed, for example if the path and copath of the subtree it
-        // was part of are still preserved. For now, we are blanking the path if
-        // we find the tree size has changed.
-        Ok(
-            new_path.path.len() == self.path_length_for(LeafNodeIndex::new(new_path.leaf_idx))
-                && leaf_idx.u32() == new_path.leaf_idx,
-        )
+    fn is_valid_path(&self, new_path: &PathChange) -> bool {
+        debug_assert!(self.id_to_leaf_idx.contains_key(&new_path.leaf_id));
+        let leaf_idx = self
+            .leaf_index_for_id(new_path.leaf_id)
+            .expect("Id should be present");
+        new_path.path.len() == self.path_length_for(LeafNodeIndex::new(new_path.leaf_idx))
+            && leaf_idx.u32() == new_path.leaf_idx
     }
 
     /// Growing the tree will add a new root and a new subtree, all blank.
@@ -675,30 +618,18 @@ impl BeeKem {
         treemath::direct_path(idx.into(), self.tree_size).len()
     }
 
-    /// Highest non-blank descendants of a node
-    fn append_resolution(
-        &self,
-        idx: TreeNodeIndex,
-        acc: &mut Vec<TreeNodeIndex>,
-    ) -> Result<(), CgkaError> {
-        match idx {
-            TreeNodeIndex::Leaf(l_idx) => {
-                if self.leaf(l_idx)?.is_some() {
-                    acc.push(l_idx.into());
-                }
+    /// Highest non-blank, non-conflict descendants of a node
+    fn append_resolution(&self, idx: TreeNodeIndex, acc: &mut Vec<TreeNodeIndex>) {
+        if self.should_skip_for_resolution(idx) {
+            if let TreeNodeIndex::Inner(i_idx) = idx {
+                let left_idx = treemath::left(i_idx);
+                self.append_resolution(left_idx, acc);
+                let right_idx = treemath::right(i_idx);
+                self.append_resolution(right_idx, acc);
             }
-            TreeNodeIndex::Inner(p_idx) => {
-                if self.inner_node(p_idx)?.is_some() {
-                    acc.push(p_idx.into());
-                } else {
-                    let left_idx = treemath::left(p_idx);
-                    self.append_resolution(left_idx, acc)?;
-                    let right_idx = treemath::right(p_idx);
-                    self.append_resolution(right_idx, acc)?;
-                }
-            }
+        } else {
+            acc.push(idx);
         }
-        Ok(())
     }
 }
 
@@ -706,4 +637,19 @@ impl BeeKem {
 pub struct LeafNode {
     pub id: IndividualId,
     pub pk: NodeKey,
+}
+
+fn encrypt_secret(
+    doc_id: DocumentId,
+    secret: ShareSecretKey,
+    sk: &ShareSecretKey,
+    paired_pk: &ShareKey,
+) -> Result<EncryptedSecret<ShareSecretKey>, CgkaError> {
+    let key = sk.derive_symmetric_key(paired_pk);
+    let mut ciphertext: Vec<u8> = (&secret).into();
+    let nonce = Siv::new(&key, &ciphertext, doc_id)
+        .map_err(|e| CgkaError::DeriveNonce(format!("{:?}", e)))?;
+    key.try_encrypt(nonce, &mut ciphertext)
+        .map_err(CgkaError::Encryption)?;
+    Ok(EncryptedSecret::new(nonce, ciphertext, *paired_pk))
 }

--- a/beehive_core/src/cgka/error.rs
+++ b/beehive_core/src/cgka/error.rs
@@ -9,6 +9,9 @@ pub enum CgkaError {
     #[error("Decryption failed: {0}")]
     Decryption(String),
 
+    #[error("Deriving nonce failed: {0}")]
+    DeriveNonce(String),
+
     #[error("Encryption failed: {0}")]
     Encryption(chacha20poly1305::Error),
 
@@ -44,9 +47,6 @@ pub enum CgkaError {
 
     #[error("Serialization failed: {0}")]
     Serialize(String),
-
-    #[error("Tree index out of bounds")]
-    TreeIndexOutOfBounds,
 
     #[error("Unexpected key conflict")]
     UnexpectedKeyConflict,

--- a/beehive_core/src/context.rs
+++ b/beehive_core/src/context.rs
@@ -1,0 +1,297 @@
+//! The primary API for the library.
+
+use crate::{
+    access::Access,
+    content::reference::ContentRef,
+    crypto::{
+        encrypted::EncryptedContent,
+        share_key::ShareKey,
+        signed::{Signed, SigningError},
+    },
+    principal::{
+        active::Active,
+        agent::{Agent, AgentId},
+        document::{id::DocumentId, store::DocumentStore, DecryptError, Document, EncryptError},
+        group::{
+            id::GroupId,
+            operation::delegation::{Delegation, DelegationError},
+            store::GroupStore,
+            Group,
+        },
+        identifier::Identifier,
+        individual::{id::IndividualId, Individual},
+        membered::Membered,
+        verifiable::Verifiable,
+    },
+};
+use dupe::Dupe;
+use nonempty::NonEmpty;
+use serde::Serialize;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashSet},
+    rc::Rc,
+};
+
+/// The main object for a user agent & top-level owned stores.
+#[derive(Debug)]
+pub struct Context<T: ContentRef, R: rand::CryptoRng + rand::RngCore> {
+    /// The [`Active`] user agent.
+    pub active: Rc<RefCell<Active>>,
+
+    /// The [`Individual`]s that are known to this agent.
+    pub individuals: BTreeMap<IndividualId, Rc<RefCell<Individual>>>,
+
+    /// The [`Group`]s that are known to this agent.
+    pub groups: GroupStore<T>,
+
+    /// The [`Document`]s that are known to this agent.
+    pub docs: DocumentStore<T>,
+
+    /// Cryptographically secure (pseudo)random number generator.
+    pub csprng: R,
+}
+
+impl<T: ContentRef, R: rand::CryptoRng + rand::RngCore> Context<T, R> {
+    pub fn id(&self) -> IndividualId {
+        self.active.borrow().id()
+    }
+
+    pub fn agent_id(&self) -> AgentId {
+        self.active.borrow().agent_id()
+    }
+
+    pub fn generate(
+        signing_key: ed25519_dalek::SigningKey,
+        mut csprng: R,
+    ) -> Result<Self, SigningError> {
+        Ok(Self {
+            active: Rc::new(RefCell::new(Active::generate(signing_key, &mut csprng)?)),
+            individuals: BTreeMap::new(),
+            groups: GroupStore::new(),
+            docs: DocumentStore::new(),
+            csprng,
+        })
+    }
+
+    pub fn generate_group(
+        &mut self,
+        coparents: Vec<Agent<T>>,
+    ) -> Result<Rc<RefCell<Group<T>>>, SigningError> {
+        self.groups.generate_group(NonEmpty {
+            head: self.active.dupe().into(),
+            tail: coparents,
+        })
+    }
+
+    pub fn generate_doc(
+        &mut self,
+        coparents: Vec<Agent<T>>,
+    ) -> Result<DocumentId, DelegationError> {
+        let parents = NonEmpty {
+            head: self.active.dupe().into(),
+            tail: coparents,
+        };
+        self.docs.generate_document(parents, &mut self.csprng)
+    }
+
+    pub fn rotate_prekey(&mut self, prekey: ShareKey) -> Result<ShareKey, SigningError> {
+        self.active
+            .borrow_mut()
+            .rotate_prekey(prekey, &mut self.csprng)
+    }
+
+    pub fn expand_prekeys(&mut self) -> Result<ShareKey, SigningError> {
+        self.active.borrow_mut().expand_prekeys(&mut self.csprng)
+    }
+
+    pub fn try_sign<U: Serialize>(&self, data: U) -> Result<Signed<U>, SigningError> {
+        self.active.borrow().try_sign(data)
+    }
+
+    pub fn register_individual(&mut self, individual: Individual) {
+        self.individuals
+            .insert(individual.id(), Rc::new(RefCell::new(individual)));
+    }
+
+    pub fn add_member(
+        &mut self,
+        to_add: Agent<T>,
+        resource: &mut Membered<T>,
+        can: Access,
+        after_content: BTreeMap<DocumentId, (Rc<RefCell<Document<T>>>, Vec<T>)>,
+    ) -> Result<(), DelegationError> {
+        let proof = resource
+            .get_capability(&self.active.borrow().agent_id())
+            .ok_or(DelegationError::Escalation)?;
+
+        if can > proof.payload().can {
+            return Err(DelegationError::Escalation);
+        }
+
+        let after_revocations = resource.get_agent_revocations(&to_add);
+
+        let dlg = self.try_sign(Delegation {
+            delegate: to_add,
+            proof: Some(proof),
+            can,
+            after_revocations,
+            after_content,
+        })?;
+
+        resource.add_member(dlg);
+        Ok(())
+    }
+
+    pub fn revoke_member(
+        &mut self,
+        to_revoke: AgentId,
+        resource: &mut Membered<T>,
+    ) -> Result<(), SigningError> {
+        let relevant_docs = vec![]; // FIXME calculate reachable for revoked or just all known docs
+
+        resource.revoke_member(
+            to_revoke,
+            &self.active.borrow().signer,
+            relevant_docs.as_slice(),
+        )
+    }
+
+    pub fn try_encrypt_content(
+        &mut self,
+        doc: Rc<RefCell<Document<T>>>,
+        content_ref: &T,
+        pred_refs: &Vec<T>,
+        content: &[u8],
+    ) -> Result<EncryptedContent<Vec<u8>, T>, EncryptError> {
+        let (encrypted, _maybe_update_op) = doc.borrow_mut().try_encrypt_content(
+            content_ref,
+            content,
+            pred_refs,
+            &mut self.csprng,
+        )?;
+        // FIXME: We need to handle the optional op as well
+        Ok(encrypted)
+    }
+
+    pub fn try_decrypt_content(
+        &mut self,
+        doc: Rc<RefCell<Document<T>>>,
+        encrypted: &EncryptedContent<Vec<u8>, T>,
+    ) -> Result<Vec<u8>, DecryptError> {
+        doc.borrow_mut().try_decrypt_content(encrypted)
+    }
+
+    pub fn force_pcs_update(&mut self, doc: Rc<RefCell<Document<T>>>) -> Result<(), EncryptError> {
+        doc.borrow_mut().pcs_update(&mut self.csprng)
+    }
+
+    pub fn reachable_docs(&self) -> BTreeMap<DocumentId, (&Rc<RefCell<Document<T>>>, Access)> {
+        self.docs_reachable_by_agent(self.active.dupe().into())
+    }
+
+    pub fn reachable_members(
+        &self,
+        membered: Membered<T>,
+    ) -> BTreeMap<AgentId, (Agent<T>, Access)> {
+        match membered {
+            Membered::Group(group) => self.groups.transitive_members(&group.borrow()),
+            Membered::Document(doc) => self.docs.transitive_members(&doc.borrow()),
+        }
+    }
+
+    pub fn docs_reachable_by_agent(
+        &self,
+        agent: Agent<T>,
+    ) -> BTreeMap<DocumentId, (&Rc<RefCell<Document<T>>>, Access)> {
+        let mut explore: Vec<(Rc<RefCell<Group<T>>>, Access)> = vec![];
+        let mut caps: BTreeMap<DocumentId, (&Rc<RefCell<Document<T>>>, Access)> = BTreeMap::new();
+        let mut seen: HashSet<AgentId> = HashSet::new();
+
+        let agent_id = agent.agent_id();
+
+        for doc in self.docs.docs.values() {
+            seen.insert(doc.clone().borrow().agent_id());
+
+            let doc_id = doc.borrow().doc_id();
+
+            if let Some(proofs) = doc.borrow().members().get(&agent_id) {
+                for proof in proofs {
+                    caps.insert(doc_id, (doc, proof.payload().can));
+                }
+            }
+        }
+
+        for group in self.groups.values() {
+            seen.insert(group.borrow().agent_id());
+
+            if let Some(proofs) = group.borrow().members().get(&agent_id) {
+                for proof in proofs {
+                    explore.push((group.dupe(), proof.payload().can));
+                }
+            }
+        }
+
+        while let Some((group, _access)) = explore.pop() {
+            for doc in self.docs.docs.values() {
+                if seen.contains(&doc.borrow().agent_id()) {
+                    continue;
+                }
+
+                let doc_id = doc.borrow().doc_id();
+
+                if let Some(proofs) = doc.borrow().members().get(&agent_id) {
+                    for proof in proofs {
+                        caps.insert(doc_id, (doc, proof.payload().can));
+                    }
+                }
+            }
+
+            for (group_id, focus_group) in self.groups.iter() {
+                if seen.contains(&focus_group.borrow().agent_id()) {
+                    continue;
+                }
+
+                if group.borrow().id() == (*group_id).into() {
+                    continue;
+                }
+
+                if let Some(proofs) = focus_group.borrow().members().get(&agent_id) {
+                    for proof in proofs {
+                        explore.push((focus_group.dupe(), proof.payload().can));
+                    }
+                }
+            }
+        }
+
+        caps
+    }
+
+    pub fn get_agent(&self, id: Identifier) -> Option<Agent<T>> {
+        if let Some(doc) = self.docs.get(&DocumentId(id)) {
+            return Some(doc.into());
+        }
+
+        if let Some(group) = self.groups.get(&GroupId::new(id)) {
+            return Some(group.into());
+        }
+
+        if let Some(indie) = self.individuals.get(&id.into()) {
+            return Some(indie.clone().into());
+        }
+
+        None
+    }
+}
+
+impl<T: ContentRef, R: rand::CryptoRng + rand::RngCore> Verifiable for Context<T, R> {
+    fn verifying_key(&self) -> ed25519_dalek::VerifyingKey {
+        self.active.borrow().verifying_key()
+    }
+}
+
+impl<T: ContentRef, R: rand::CryptoRng + rand::RngCore> From<&Context<T, R>> for Agent<T> {
+    fn from(context: &Context<T, R>) -> Self {
+        context.active.dupe().into()
+    }
+}

--- a/beehive_core/src/crypto/application_secret.rs
+++ b/beehive_core/src/crypto/application_secret.rs
@@ -2,11 +2,12 @@ use crate::{
     cgka::operation::CgkaOperation,
     content::reference::ContentRef,
     crypto::{
-        digest::Digest, encrypted::Encrypted, separable::Separable, share_key::ShareSecretKey,
-        siv::Siv, symmetric_key::SymmetricKey,
+        digest::Digest, encrypted::EncryptedContent, separable::Separable,
+        share_key::ShareSecretKey, siv::Siv, symmetric_key::SymmetricKey,
     },
 };
 use serde::{Deserialize, Serialize};
+
 const STATIC_CONTEXT: &str = "/automerge/beehive/beekem/app_secret/";
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -45,10 +46,10 @@ impl<Cr: ContentRef> ApplicationSecret<Cr> {
     pub fn try_encrypt<T>(
         &self,
         plaintext: &[u8],
-    ) -> Result<Encrypted<T, Cr>, chacha20poly1305::Error> {
+    ) -> Result<EncryptedContent<T, Cr>, chacha20poly1305::Error> {
         let mut ciphertext = plaintext.to_vec();
         self.key.try_encrypt(self.nonce, &mut ciphertext)?;
-        Ok(Encrypted::new(
+        Ok(EncryptedContent::new(
             self.nonce,
             ciphertext,
             self.pcs_key_hash,

--- a/beehive_core/src/crypto/encrypted.rs
+++ b/beehive_core/src/crypto/encrypted.rs
@@ -5,28 +5,21 @@ use super::{
     digest::Digest,
     share_key::{ShareKey, ShareSecretKey},
     siv::Siv,
-    symmetric_key::SymmetricKey,
 };
-use crate::{
-    cgka::operation::CgkaOperation, content::reference::ContentRef,
-    principal::document::id::DocumentId,
-};
-use nonempty::NonEmpty;
-use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use crate::{cgka::operation::CgkaOperation, content::reference::ContentRef};
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
-/// The public information for a ciphertext.
+/// The public information for an encrypted content ciphertext.
 ///
 /// This wraps a ciphertext that includes the [`Siv`] and the type of the data
 /// that was encrypted (or that the plaintext is _expected_ to be).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Encrypted<T, Cr: ContentRef> {
+pub struct EncryptedContent<T, Cr: ContentRef> {
     /// The nonce used to encrypt the data.
     pub nonce: Siv,
-
     /// The encrypted data.
     pub ciphertext: Vec<u8>,
-
     /// Hash of the PCS key used to derive the application secret for encrypting.
     pub pcs_key_hash: Digest<PcsKey>,
     /// Hash of the PCS update operation corresponding to the PCS key
@@ -36,12 +29,11 @@ pub struct Encrypted<T, Cr: ContentRef> {
     /// The predecessor content ref hashes used to derive the application secret
     /// for encrypting.
     pub pred_refs: Digest<Vec<Cr>>,
-
     /// The type of the data that was encrypted.
     _plaintext_tag: PhantomData<T>,
 }
 
-impl<T, Cr: ContentRef> Encrypted<T, Cr> {
+impl<T, Cr: ContentRef> EncryptedContent<T, Cr> {
     /// Associate a nonce with a ciphertext and assert the plaintext type.
     pub fn new(
         nonce: Siv,
@@ -50,8 +42,8 @@ impl<T, Cr: ContentRef> Encrypted<T, Cr> {
         pcs_update_op_hash: Digest<CgkaOperation>,
         content_ref: Digest<Cr>,
         pred_refs: Digest<Vec<Cr>>,
-    ) -> Encrypted<T, Cr> {
-        Encrypted {
+    ) -> EncryptedContent<T, Cr> {
+        EncryptedContent {
             nonce,
             ciphertext,
             pcs_key_hash,
@@ -63,164 +55,43 @@ impl<T, Cr: ContentRef> Encrypted<T, Cr> {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct NestedEncrypted<T> {
-    /// The nonce used to encrypt the data and
-    /// the public keys the encrypter used as DH partners when doing the
-    /// nested encryption.
-    pub layers: NonEmpty<(ShareKey, Siv)>,
+/// The public information for an encrypted secret ciphertext.
+///
+/// This wraps a ciphertext that includes the [`Siv`] and the type of the data
+/// that was encrypted (or that the plaintext is _expected_ to be).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct EncryptedSecret<T> {
+    /// The nonce used to encrypt the data.
+    pub nonce: Siv,
 
-    /// The outermost layer (most encrypted) of the nested encrypted data.
+    /// The encrypted data.
     pub ciphertext: Vec<u8>,
+
+    /// The [`ShareKey`] used as a Diffie Hellman partner when encrypting.
+    pub paired_pk: ShareKey,
 
     /// The type of the data that was encrypted.
     _plaintext_tag: PhantomData<T>,
 }
 
-impl<T> NestedEncrypted<T> {
+impl<T> EncryptedSecret<T> {
     /// Associate a nonce with a ciphertext and assert the plaintext type.
-    pub fn new(layers: NonEmpty<(ShareKey, Siv)>, ciphertext: Vec<u8>) -> Self {
-        Self {
-            layers,
+    pub fn new(nonce: Siv, ciphertext: Vec<u8>, paired_pk: ShareKey) -> EncryptedSecret<T> {
+        EncryptedSecret {
+            nonce,
             ciphertext,
+            paired_pk,
             _plaintext_tag: PhantomData,
         }
     }
 
-    pub fn try_encrypt<U>(
-        doc_id: DocumentId,
-        secret: U,
-        encrypter_sk: &ShareSecretKey,
-        paired_share_keys: &NonEmpty<ShareKey>,
-    ) -> Result<Self, chacha20poly1305::Error>
-    where
-        Vec<u8>: From<U>,
-    {
-        let mut ciphertext: Vec<u8> = secret.into();
-        let mut layer_vec: Vec<(ShareKey, Siv)> = vec![];
-
-        for pk in paired_share_keys.iter() {
-            let key = encrypter_sk.derive_symmetric_key(pk);
-            let nonce = Siv::new(&key, &ciphertext, doc_id).expect("FIXME");
-            layer_vec.push((*pk, nonce));
-            // FIXME lift the errors into one type
-            key.try_encrypt(nonce, &mut ciphertext)?
-        }
-
-        Ok(NestedEncrypted {
-            layers: NonEmpty::from_vec(layer_vec)
-                .expect("must be nonempty since we iterated over a nonempty argument"),
-            ciphertext,
-            _plaintext_tag: PhantomData,
-        })
-    }
-
-    // TODO validate nonce & AEAD
     pub fn try_encrypter_decrypt(
         &self,
         encrypter_secret_key: &ShareSecretKey,
     ) -> Result<Vec<u8>, chacha20poly1305::Error> {
         let mut buf: Vec<u8> = self.ciphertext.clone();
-        for (pk, nonce) in self.layers.iter().rev() {
-            let key = encrypter_secret_key.derive_symmetric_key(pk);
-            key.try_decrypt(*nonce, &mut buf)?;
-        }
+        let key = encrypter_secret_key.derive_symmetric_key(&self.paired_pk);
+        key.try_decrypt(self.nonce, &mut buf)?;
         Ok(buf)
-    }
-
-    // TODO validate nonce & AEAD
-    pub fn try_sibling_decrypt(
-        &self,
-        decrypt_keys: &[SymmetricKey],
-    ) -> Result<Vec<u8>, chacha20poly1305::Error> {
-        let mut buf: Vec<u8> = self.ciphertext.clone();
-        for (idx, (_pk, nonce)) in self.layers.iter().enumerate().rev() {
-            let key = &decrypt_keys[idx];
-            key.try_decrypt(*nonce, &mut buf)?;
-        }
-        Ok(buf)
-    }
-}
-
-impl<T: Serialize> Serialize for NestedEncrypted<T> {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut ser = serializer.serialize_struct("NestedEncrypted", 3)?;
-        ser.serialize_field("layers", &Vec::<_>::from(self.layers.clone()))?;
-        ser.serialize_field("ciphertext", &self.ciphertext)?;
-        ser.end()
-    }
-}
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for NestedEncrypted<T> {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        struct NestedEncryptedHelper {
-            layers: Vec<(ShareKey, Siv)>,
-            ciphertext: Vec<u8>,
-        }
-
-        let helper = NestedEncryptedHelper::deserialize(deserializer)?;
-        Ok(NestedEncrypted::new(
-            NonEmpty::from_slice(&helper.layers).ok_or_else(|| {
-                serde::de::Error::custom("nested encrypted data must have at least one layer")
-            })?,
-            helper.ciphertext,
-        ))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use nonempty::nonempty;
-
-    use super::super::share_key::ShareSecretKey;
-    use super::NestedEncrypted;
-    use crate::crypto::symmetric_key::SymmetricKey;
-    use crate::principal::document::id::DocumentId;
-    use crate::principal::identifier::Identifier;
-
-    #[test]
-    pub(crate) fn test_encrypt_and_decrypt() -> Result<(), chacha20poly1305::Error> {
-        let csprng = &mut rand::thread_rng();
-        let secret = ShareSecretKey::generate(csprng);
-        let id = Identifier(
-            ed25519_dalek::SigningKey::generate(&mut rand::thread_rng()).verifying_key(),
-        );
-        let doc_id = DocumentId(id);
-
-        let encrypter_share_secret_key = ShareSecretKey::generate(csprng);
-        let encrypter_share_key = encrypter_share_secret_key.share_key();
-
-        let share_secret_key = ShareSecretKey::generate(csprng);
-        let share_key = share_secret_key.share_key();
-        let mut encrypt_paired_pks = nonempty![share_key];
-        let mut encrypt_paired_sks = nonempty![share_secret_key];
-        for _ in 0..5 {
-            let share_secret_key = ShareSecretKey::generate(csprng);
-            let share_key = share_secret_key.share_key();
-            encrypt_paired_pks.push(share_key);
-            encrypt_paired_sks.push(share_secret_key);
-        }
-
-        let nested_encrypted = NestedEncrypted::<ShareSecretKey>::try_encrypt(
-            doc_id,
-            secret.to_bytes(),
-            &encrypter_share_secret_key,
-            &encrypt_paired_pks,
-        )?;
-
-        let decrypt_keys: Vec<SymmetricKey> = encrypt_paired_sks
-            .iter()
-            .map(|sk| sk.derive_symmetric_key(&encrypter_share_key))
-            .collect();
-
-        let decrypted = nested_encrypted.try_sibling_decrypt(&decrypt_keys)?;
-
-        assert_eq!(secret.to_bytes(), decrypted.as_slice());
-
-        let encrypters_decrypted =
-            nested_encrypted.try_encrypter_decrypt(&encrypter_share_secret_key)?;
-        assert_eq!(secret.to_bytes(), encrypters_decrypted.as_slice());
-        Ok(())
     }
 }

--- a/beehive_core/src/principal/document.rs
+++ b/beehive_core/src/principal/document.rs
@@ -7,7 +7,7 @@ use crate::{
     content::reference::ContentRef,
     crypto::{
         digest::Digest,
-        encrypted::Encrypted,
+        encrypted::EncryptedContent,
         share_key::{ShareKey, ShareSecretKey},
         signed::Signed,
     },
@@ -262,7 +262,7 @@ impl<T: ContentRef> Document<T> {
         content: &[u8],
         pred_refs: &Vec<T>,
         csprng: &mut R,
-    ) -> Result<(Encrypted<Vec<u8>, T>, Option<CgkaOperation>), EncryptError> {
+    ) -> Result<(EncryptedContent<Vec<u8>, T>, Option<CgkaOperation>), EncryptError> {
         let (app_secret, maybe_update_op) = self
             .cgka
             .new_app_secret_for(content_ref, content, pred_refs, csprng)
@@ -278,7 +278,7 @@ impl<T: ContentRef> Document<T> {
 
     pub fn try_decrypt_content(
         &mut self,
-        encrypted_content: &Encrypted<Vec<u8>, T>,
+        encrypted_content: &EncryptedContent<Vec<u8>, T>,
     ) -> Result<Vec<u8>, DecryptError> {
         let decrypt_key = self
             .cgka

--- a/beehive_wasm/src/js/encrypted.rs
+++ b/beehive_wasm/src/js/encrypted.rs
@@ -1,11 +1,11 @@
 use super::change_ref::JsChangeRef;
-use beehive_core::crypto::encrypted::Encrypted;
+use beehive_core::crypto::encrypted::EncryptedContent;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = Encrypted)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct JsEncrypted(pub(crate) Encrypted<Vec<u8>, JsChangeRef>);
+pub struct JsEncrypted(pub(crate) EncryptedContent<Vec<u8>, JsChangeRef>);
 
 #[wasm_bindgen(js_class = Encrypted)]
 impl JsEncrypted {
@@ -40,8 +40,8 @@ impl JsEncrypted {
     }
 }
 
-impl From<Encrypted<Vec<u8>, JsChangeRef>> for JsEncrypted {
-    fn from(encrypted: Encrypted<Vec<u8>, JsChangeRef>) -> Self {
+impl From<EncryptedContent<Vec<u8>, JsChangeRef>> for JsEncrypted {
+    fn from(encrypted: EncryptedContent<Vec<u8>, JsChangeRef>) -> Self {
         JsEncrypted(encrypted)
     }
 }

--- a/beehive_wasm/src/js/signing_key.rs
+++ b/beehive_wasm/src/js/signing_key.rs
@@ -1,5 +1,5 @@
-use beehive_core::crypto::signed::{Signed, SigningError};
 use super::signed::JsSigned;
+use beehive_core::crypto::signed::{Signed, SigningError};
 use rand::Fill;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
In BeeKEM, we now define the resolution of a node as either (1) the node `ShareKey` if there is one or (2) the set of highest non-blank, non-conflict descendents of the node.

When encrypting a parent node with a sibling node with conflict keys, we now take the resolution of that node instead of doing a nested encryption of those conflict keys.