### PR TITLE
Share genesis Cgka Add and use to trigger initial Cgka construction

### DIFF
--- a/keyhive_core/src/cgka/error.rs
+++ b/keyhive_core/src/cgka/error.rs
@@ -32,8 +32,14 @@ pub enum CgkaError {
     #[error("No root key")]
     NoRootKey,
 
+    #[error("Cgka is not initialized")]
+    NotInitialized,
+
     #[error("Operation not found")]
     OperationNotFound,
+
+    #[error("Operation was not received in causal order")]
+    OutOfOrderOperation,
 
     #[error("Owner Identifier not found")]
     OwnerIdentifierNotFound,
@@ -52,6 +58,9 @@ pub enum CgkaError {
 
     #[error("Unexpected key conflict")]
     UnexpectedKeyConflict,
+
+    #[error("Expected CgkaOperation::Add for initial operation")]
+    UnexpectedInitialOperation,
 
     #[error("Expected CgkaOperation::Add for invite")]
     UnexpectedInviteOperation,

--- a/keyhive_core/src/cgka/operation.rs
+++ b/keyhive_core/src/cgka/operation.rs
@@ -69,6 +69,17 @@ pub enum CgkaOperation {
 }
 
 impl CgkaOperation {
+    pub(crate) fn init_add(doc_id: DocumentId, added_id: IndividualId, pk: ShareKey) -> Self {
+        Self::Add {
+            added_id,
+            pk,
+            leaf_index: 0,
+            predecessors: Vec::new(),
+            add_predecessors: Vec::new(),
+            doc_id,
+        }
+    }
+
     /// The zero or more immediate causal predecessors of this operation.
     pub(crate) fn predecessors(&self) -> HashSet<Digest<Signed<CgkaOperation>>> {
         match self {
@@ -133,6 +144,13 @@ impl CgkaOperationGraph {
 
     pub(crate) fn contains_op_hash(&self, op_hash: &Digest<Signed<CgkaOperation>>) -> bool {
         self.cgka_ops.contains_key(op_hash)
+    }
+
+    pub(crate) fn contains_predecessors(
+        &self,
+        preds: &HashSet<Digest<Signed<CgkaOperation>>>,
+    ) -> bool {
+        preds.iter().all(|hash| self.cgka_ops.contains_key(hash))
     }
 
     /// Whether the causal graph has a single head. More than one head indicates

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1633,7 +1633,7 @@ mod tests {
             .is_none()); // NOTE *not* included because Public is not a member
 
         let left_to_mid_ops = left.events_for_agent(&Public.individual().into()).unwrap();
-        assert_eq!(left_to_mid_ops.len(), 13);
+        assert_eq!(left_to_mid_ops.len(), 14);
 
         middle.ingest_event_table(left_to_mid_ops).unwrap();
 
@@ -1667,7 +1667,7 @@ mod tests {
         let mid_to_right_ops = middle
             .events_for_agent(&Public.individual().into())
             .unwrap();
-        assert_eq!(mid_to_right_ops.len(), 20);
+        assert_eq!(mid_to_right_ops.len(), 21);
 
         right.ingest_event_table(mid_to_right_ops).unwrap();
 
@@ -1723,7 +1723,7 @@ mod tests {
         // Check transitivity
         let transitive_right_to_mid_ops =
             right.events_for_agent(&Public.individual().into()).unwrap();
-        assert_eq!(transitive_right_to_mid_ops.len(), 22);
+        assert_eq!(transitive_right_to_mid_ops.len(), 23);
 
         middle
             .ingest_event_table(transitive_right_to_mid_ops)

--- a/keyhive_core/src/principal/document/archive.rs
+++ b/keyhive_core/src/principal/document/archive.rs
@@ -13,5 +13,5 @@ pub struct DocumentArchive<T: ContentRef> {
     pub(crate) reader_keys: HashMap<IndividualId, ShareKey>,
     pub(crate) content_heads: HashSet<T>,
     pub(crate) content_state: HashSet<T>,
-    pub(crate) cgka: Cgka,
+    pub(crate) cgka: Option<Cgka>,
 }

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -656,10 +656,10 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
             match op {
                 MembershipOperation::Delegation(d) => {
                     if revoked_dlgs.contains(&d.signature.to_bytes()) {
-                        dbg!("0");
+                        // dbg!("0");
                         continue;
                     }
-                    dbg!("1");
+                    // dbg!("1");
 
                     // NOTE: friendly reminder that the topsort already includes all ancestors
                     if let Some(found_proof) = &d.payload.proof {
@@ -670,7 +670,7 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
                             })
                             .or_insert_with(|| HashSet::from_iter([d.signature.to_bytes()]));
 
-                        dbg!("2");
+                        // dbg!("2");
                         // If the proof was directly revoked, then check if they've been
                         // re-added some other way. Since `rebuild` recurses,
                         // we only need to check one level.
@@ -678,34 +678,34 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
                             || !dlgs_in_play.contains_key(&found_proof.signature.to_bytes())
                         {
                             if let Some(alt_proofs) = self.members.get(&found_proof.issuer.into()) {
-                                dbg!("3");
+                                // dbg!("3");
                                 if alt_proofs.iter().filter(|d| *d != found_proof).all(
                                     |alt_proof| {
-                                        dbg!("BOP BOOP BOOOOP");
-                                        dbg!(d.payload.delegate.id());
-                                        dbg!(alt_proof.payload.delegate.id());
+                                        // dbg!("BOP BOOP BOOOOP");
+                                        // dbg!(d.payload.delegate.id());
+                                        // dbg!(alt_proof.payload.delegate.id());
 
                                         alt_proof.payload.can < found_proof.payload.can
                                     },
                                 ) {
                                     // No suitable proofs
-                                    dbg!("3.5");
+                                    // dbg!("3.5");
                                     continue;
                                 }
                             } else if found_proof.issuer != self.verifying_key() {
-                                dbg!(Identifier::from(found_proof.issuer));
-                                dbg!(d.payload.delegate.id());
-                                dbg!("4");
+                                // dbg!(Identifier::from(found_proof.issuer));
+                                // dbg!(d.payload.delegate.id());
+                                // dbg!("4");
                                 continue;
                             }
                         }
                     } else if d.issuer != self.verifying_key() {
-                        dbg!("5");
+                        // dbg!("5");
                         debug_assert!(false, "Delegation without valid root proof");
                         continue;
                     }
 
-                    dbg!("6");
+                    // dbg!("6");
                     dlgs_in_play.insert(d.signature.to_bytes(), d.dupe());
 
                     if let Some(mut_dlgs) = self.members.get_mut(&d.payload.delegate.id()) {


### PR DESCRIPTION
This ports the changes in 327403028c668a2dc2940054c3dcaba089aeab70 onto `main`