### PR TITLE
keyhive_core: Add keyhive_core::ContactCard

### DIFF
--- a/keyhive_core/src/cgka/operation.rs
+++ b/keyhive_core/src/cgka/operation.rs
@@ -97,7 +97,7 @@ impl CgkaOperation {
     }
 
     /// Document id
-    pub(crate) fn doc_id(&self) -> &DocumentId {
+    pub fn doc_id(&self) -> &DocumentId {
         match self {
             CgkaOperation::Add { doc_id, .. } => doc_id,
             CgkaOperation::Remove { doc_id, .. } => doc_id,

--- a/keyhive_core/src/contact_card.rs
+++ b/keyhive_core/src/contact_card.rs
@@ -1,0 +1,32 @@
+use crate::{
+    principal::individual::{op::KeyOp, Individual},
+    util::hex,
+};
+
+#[derive(Debug)]
+pub struct ContactCard(KeyOp);
+
+impl std::fmt::Display for ContactCard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ContactCard for ",)?;
+        hex::bytes_as_hex(self.0.issuer().as_bytes().iter(), f)
+    }
+}
+
+impl From<KeyOp> for ContactCard {
+    fn from(key_op: KeyOp) -> ContactCard {
+        ContactCard(key_op)
+    }
+}
+
+impl<'a> From<&'a ContactCard> for Individual {
+    fn from(contact_card: &'a ContactCard) -> Individual {
+        Individual::new(contact_card.0.clone())
+    }
+}
+
+impl From<ContactCard> for Individual {
+    fn from(contact_card: ContactCard) -> Individual {
+        Individual::new(contact_card.0)
+    }
+}

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -56,7 +56,6 @@ use std::{
     rc::Rc,
 };
 use thiserror::Error;
-use tracing::Instrument;
 
 /// The main object for a user agent & top-level owned stores.
 #[derive(Debug, Derivative)]
@@ -214,6 +213,16 @@ impl<
         self.docs.insert(doc_id, doc.dupe());
 
         Ok(doc)
+    }
+
+    pub async fn contact_card(&mut self) -> Result<ContactCard, SigningError> {
+        let rot_key_op = self
+            .active
+            .borrow_mut()
+            .generate_private_prekey(&mut self.csprng)
+            .await?;
+
+        Ok(ContactCard(KeyOp::Rotate(rot_key_op)))
     }
 
     pub async fn rotate_prekey(
@@ -1374,10 +1383,6 @@ impl<
         self.ingest_unsorted_static_events(
             events.values().cloned().map(Into::into).collect::<Vec<_>>(),
         )
-    }
-
-    pub fn contact_card(&self) -> ContactCard {
-        self.active.borrow().individual().contact_card()
     }
 }
 

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -5,6 +5,7 @@ use crate::{
     access::Access,
     archive::Archive,
     cgka::{error::CgkaError, operation::CgkaOperation},
+    contact_card::ContactCard,
     content::reference::ContentRef,
     crypto::{
         digest::Digest,
@@ -1373,6 +1374,10 @@ impl<
         self.ingest_unsorted_static_events(
             events.values().cloned().map(Into::into).collect::<Vec<_>>(),
         )
+    }
+
+    pub fn contact_card(&self) -> ContactCard {
+        self.active.borrow().individual().contact_card()
     }
 }
 

--- a/keyhive_core/src/lib.rs
+++ b/keyhive_core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ability;
 pub mod access;
 pub mod archive;
 pub mod cgka;
+pub mod contact_card;
 pub mod content;
 pub mod crypto;
 pub mod error;

--- a/keyhive_core/src/principal/agent.rs
+++ b/keyhive_core/src/principal/agent.rs
@@ -80,18 +80,12 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Agent<S, T, L> 
     pub fn pick_individual_prekeys(&self, doc_id: DocumentId) -> HashMap<IndividualId, ShareKey> {
         match self {
             Agent::Active(a) => {
-                if let Some(prekey) = a.borrow().pick_prekey(doc_id) {
-                    HashMap::from_iter([(a.borrow().id(), prekey)])
-                } else {
-                    HashMap::new()
-                }
+                let prekey = *a.borrow().pick_prekey(doc_id);
+                HashMap::from_iter([(a.borrow().id(), prekey)])
             }
             Agent::Individual(i) => {
-                if let Some(prekey) = i.borrow().pick_prekey(doc_id) {
-                    HashMap::from_iter([(i.borrow().id(), prekey)])
-                } else {
-                    HashMap::new()
-                }
+                let prekey = *i.borrow().pick_prekey(doc_id);
+                HashMap::from_iter([(i.borrow().id(), prekey)])
             }
             Agent::Group(g) => g.borrow().pick_individual_prekeys(doc_id),
             Agent::Document(d) => d.borrow().group.pick_individual_prekeys(doc_id),

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -8,6 +8,7 @@ use self::op::KeyOp;
 
 use super::{agent::id::AgentId, document::id::DocumentId};
 use crate::{
+    contact_card::ContactCard,
     crypto::{
         share_key::ShareKey,
         signed::{Signed, SigningError},
@@ -86,6 +87,11 @@ impl Individual {
             prekeys: prekey_state.build(),
             prekey_state,
         })
+    }
+
+    pub fn contact_card(&self) -> ContactCard {
+        let op = self.prekey_state.ops().0.iter().next().unwrap().1;
+        ContactCard::from(Rc::unwrap_or_clone(op.clone()))
     }
 
     pub fn id(&self) -> IndividualId {

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -112,14 +112,14 @@ impl Individual {
         Ok(())
     }
 
-    pub fn pick_prekey(&self, doc_id: DocumentId) -> Option<ShareKey> {
+    pub fn pick_prekey(&self, doc_id: DocumentId) -> &ShareKey {
         let mut bytes: Vec<u8> = self.id.to_bytes().to_vec();
         bytes.extend_from_slice(&doc_id.to_bytes());
 
         let prekeys_len = self.prekeys.len();
         let idx = pseudorandom_in_range(bytes.as_slice(), prekeys_len);
 
-        self.prekeys.iter().nth(idx).cloned()
+        self.prekeys.iter().nth(idx).expect("index to be in range")
     }
 
     pub fn prekey_ops(&self) -> &CaMap<KeyOp> {

--- a/keyhive_core/src/principal/individual/op.rs
+++ b/keyhive_core/src/principal/individual/op.rs
@@ -23,6 +23,7 @@ use std::{
 /// This prevents the case where all keys are remved and the user is unable to be
 /// added to a [`Cgka`][crate::cgka::Cgka].
 #[derive(Debug, Clone, Dupe, PartialEq, Eq, Hash, Serialize, Deserialize, From, TryInto)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum KeyOp {
     /// Add a new key.
     Add(Rc<Signed<AddKeyOp>>),

--- a/keyhive_core/src/principal/peer.rs
+++ b/keyhive_core/src/principal/peer.rs
@@ -58,11 +58,8 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Peer<S, T, L> {
     pub fn pick_individual_prekeys(&self, doc_id: DocumentId) -> HashMap<IndividualId, ShareKey> {
         match self {
             Peer::Individual(i) => {
-                if let Some(prekey) = i.borrow().pick_prekey(doc_id) {
-                    HashMap::from_iter([(i.borrow().id(), prekey)])
-                } else {
-                    HashMap::new()
-                }
+                let prekey = *i.borrow().pick_prekey(doc_id);
+                HashMap::from_iter([(i.borrow().id(), prekey)])
             }
             Peer::Group(g) => g.borrow().pick_individual_prekeys(doc_id),
             Peer::Document(d) => d.borrow().group.pick_individual_prekeys(doc_id),

--- a/keyhive_wasm/src/js.rs
+++ b/keyhive_wasm/src/js.rs
@@ -5,6 +5,7 @@ pub mod archive;
 pub mod capability;
 pub mod cgka_operation;
 pub mod change_ref;
+pub mod contact_card;
 pub mod delegation;
 pub mod doc_content_refs;
 pub mod document;

--- a/keyhive_wasm/src/js/contact_card.rs
+++ b/keyhive_wasm/src/js/contact_card.rs
@@ -1,0 +1,28 @@
+use derive_more::{Deref, Display, From, Into};
+use keyhive_core::{contact_card::ContactCard, crypto::verifiable::Verifiable};
+use wasm_bindgen::prelude::*;
+
+use super::{individual_id::JsIndividualId, share_key::JsShareKey};
+
+#[wasm_bindgen(js_name = ContactCard)]
+#[derive(Debug, Clone, From, Into, Deref, Display)]
+pub struct JsContactCard(ContactCard);
+
+#[wasm_bindgen(js_class = ContactCard)]
+impl JsContactCard {
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> JsIndividualId {
+        self.0.id().into()
+    }
+
+    #[wasm_bindgen(getter, js_name = "shareKey")]
+    pub fn share_key(&self) -> JsShareKey {
+        (*self.0.share_key()).into()
+    }
+}
+
+impl Verifiable for JsContactCard {
+    fn verifying_key(&self) -> ed25519_dalek::VerifyingKey {
+        self.0.verifying_key()
+    }
+}

--- a/keyhive_wasm/src/js/individual.rs
+++ b/keyhive_wasm/src/js/individual.rs
@@ -35,7 +35,7 @@ impl JsIndividual {
     }
 
     #[wasm_bindgen(js_name = pickPrekey)]
-    pub fn pick_prekey(&self, doc_id: JsDocumentId) -> Option<JsShareKey> {
-        self.0.borrow().pick_prekey(doc_id.0).map(JsShareKey)
+    pub fn pick_prekey(&self, doc_id: JsDocumentId) -> JsShareKey {
+        JsShareKey(*self.0.borrow().pick_prekey(doc_id.0))
     }
 }

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -1,3 +1,4 @@
+use super::contact_card::JsContactCard;
 use super::{
     access::JsAccess, add_member_error::JsAddMemberError, agent::JsAgent, archive::JsArchive,
     change_ref::JsChangeRef, document::JsDocument, encrypted::JsEncrypted,
@@ -224,6 +225,15 @@ impl JsKeyhive {
     pub async fn expand_prekeys(&mut self) -> Result<JsShareKey, JsSigningError> {
         let op = self.0.expand_prekeys().await?;
         Ok(JsShareKey(op.payload().share_key))
+    }
+
+    #[wasm_bindgen(js_name = contactCard)]
+    pub async fn contact_card(&mut self) -> Result<JsContactCard, JsSigningError> {
+        self.0
+            .contact_card()
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     #[wasm_bindgen(js_name = getAgent)]

--- a/keyhive_wasm/src/js/share_key.rs
+++ b/keyhive_wasm/src/js/share_key.rs
@@ -1,5 +1,7 @@
+use derive_more::{From, Into};
 use keyhive_core::crypto::share_key::ShareKey;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = ShareKey)]
+#[derive(Debug, Clone, Copy, Into, From)]
 pub struct JsShareKey(pub(crate) ShareKey);


### PR DESCRIPTION
When adding an individual to a document we need to have at least one prekey for the individual. This commit introduces a `ContactCard` struct which conveniently packages a prekey up with the invidual ID in order to make this flow easier.