### PR TITLE
keyhive_core: Add arbitrary implementations

### DIFF
--- a/keyhive_core/src/cgka/beekem.rs
+++ b/keyhive_core/src/cgka/beekem.rs
@@ -20,6 +20,7 @@ pub type InnerNode = SecretStore;
 /// This includes both the new public keys for each node and the keys that have
 /// been removed as part of this change.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct PathChange {
     pub leaf_id: IndividualId,
     pub leaf_idx: u32,

--- a/keyhive_core/src/cgka/keys.rs
+++ b/keyhive_core/src/cgka/keys.rs
@@ -56,6 +56,7 @@ impl std::hash::Hash for ShareKeyMap {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum NodeKey {
     ShareKey(ShareKey),
     ConflictKeys(ConflictKeys),
@@ -69,6 +70,7 @@ impl From<ShareKey> for NodeKey {
 
 /// Keys that were concurrently added to the same node.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct ConflictKeys {
     pub first: ShareKey,
     pub second: ShareKey,

--- a/keyhive_core/src/cgka/operation.rs
+++ b/keyhive_core/src/cgka/operation.rs
@@ -44,6 +44,7 @@ impl IntoIterator for CgkaEpoch {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum CgkaOperation {
     Add {
         added_id: IndividualId,

--- a/keyhive_core/src/cgka/secret_store.rs
+++ b/keyhive_core/src/cgka/secret_store.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct SecretStore {
     /// Every encrypted secret key (and hence version) corresponds to a single
     /// public key.
@@ -104,6 +105,7 @@ impl SecretStore {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub(crate) struct SecretStoreVersion {
     /// Every encrypted secret key (and hence version) corresponds to a single public
     /// key.

--- a/keyhive_core/src/cgka/treemath.rs
+++ b/keyhive_core/src/cgka/treemath.rs
@@ -170,6 +170,14 @@ pub enum TreeNodeIndex {
     Inner(InnerNodeIndex),
 }
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'_> for TreeNodeIndex {
+    fn arbitrary(g: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let index = u32::arbitrary(g)?;
+        Ok(TreeNodeIndex::new(index))
+    }
+}
+
 impl TreeNodeIndex {
     /// Create a new `TreeNodeIndex` from a `u32`.
     fn new(index: u32) -> Self {

--- a/keyhive_core/src/crypto/encrypted.rs
+++ b/keyhive_core/src/crypto/encrypted.rs
@@ -61,6 +61,7 @@ impl<T, Cr: ContentRef> EncryptedContent<T, Cr> {
 /// This wraps a ciphertext that includes the [`Siv`] and the type of the data
 /// that was encrypted (or that the plaintext is _expected_ to be).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct EncryptedSecret<T> {
     /// The nonce used to encrypt the data.
     pub nonce: Siv,

--- a/keyhive_core/src/crypto/share_key.rs
+++ b/keyhive_core/src/crypto/share_key.rs
@@ -11,6 +11,15 @@ use std::fmt;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ShareKey(x25519_dalek::PublicKey);
 
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for ShareKey {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let bytes = u.bytes(32)?;
+        let arr = <[u8; 32]>::try_from(bytes).unwrap();
+        Ok(Self(x25519_dalek::PublicKey::from(arr)))
+    }
+}
+
 impl ShareKey {
     pub fn generate<R: rand::CryptoRng + rand::RngCore>(csprng: &mut R) -> Self {
         Self(x25519_dalek::PublicKey::from(
@@ -76,6 +85,7 @@ impl From<x25519_dalek::PublicKey> for ShareKey {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct ShareSecretKey([u8; 32]);
 
 impl ShareSecretKey {

--- a/keyhive_core/src/crypto/siv.rs
+++ b/keyhive_core/src/crypto/siv.rs
@@ -27,6 +27,7 @@ use std::io::Read;
 /// [Invisible Salamanders]: https://eprint.iacr.org/2019/016.pdf
 /// [chacha20-docs]: https://docs.rs/chacha20poly1305/0.10.1/chacha20poly1305/trait.AeadCore.html#method.generate_nonce
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct Siv([u8; 24]);
 
 impl Siv {

--- a/keyhive_core/src/event/static_event.rs
+++ b/keyhive_core/src/event/static_event.rs
@@ -23,3 +23,18 @@ pub enum StaticEvent<T: ContentRef = [u8; 32]> {
     Delegated(Signed<StaticDelegation<T>>),
     Revoked(Signed<StaticRevocation<T>>),
 }
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, T: arbitrary::Arbitrary<'a> + ContentRef> arbitrary::Arbitrary<'a> for StaticEvent<T> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let variant = u.int_in_range(0..=4)?;
+        match variant {
+            0 => Ok(Self::PrekeysExpanded(Signed::arbitrary(u)?)),
+            1 => Ok(Self::PrekeyRotated(Signed::arbitrary(u)?)),
+            2 => Ok(Self::CgkaOperation(Signed::arbitrary(u)?)),
+            3 => Ok(Self::Delegated(Signed::arbitrary(u)?)),
+            4 => Ok(Self::Revoked(Signed::arbitrary(u)?)),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/keyhive_core/src/principal/group/delegation.rs
+++ b/keyhive_core/src/principal/group/delegation.rs
@@ -150,7 +150,6 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Serialize for D
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct StaticDelegation<T: ContentRef> {
     pub can: Access,
 
@@ -159,6 +158,27 @@ pub struct StaticDelegation<T: ContentRef> {
 
     pub after_revocations: Vec<Digest<Signed<StaticRevocation<T>>>>,
     pub after_content: BTreeMap<DocumentId, Vec<T>>,
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, T: ContentRef + arbitrary::Arbitrary<'a>> arbitrary::Arbitrary<'a>
+    for StaticDelegation<T>
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let can = Access::arbitrary(u)?;
+        let proof = u.arbitrary()?;
+        let delegate = Identifier::arbitrary(u)?;
+        let after_revocations = u.arbitrary()?;
+        let after_content = u.arbitrary()?;
+
+        Ok(Self {
+            can,
+            proof,
+            delegate,
+            after_revocations,
+            after_content,
+        })
+    }
 }
 
 impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> From<Delegation<S, T, L>>

--- a/keyhive_core/src/principal/individual/id.rs
+++ b/keyhive_core/src/principal/individual/id.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Debug, Display, Copy, Dupe, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize,
 )]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct IndividualId(pub Identifier);
 
 impl IndividualId {

--- a/keyhive_core/src/principal/individual/op/add_key.rs
+++ b/keyhive_core/src/principal/individual/op/add_key.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Add a new key to the prekeys.
 #[derive(Debug, Clone, Dupe, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct AddKeyOp {
     /// The key to add.
     pub share_key: ShareKey,

--- a/keyhive_core/src/principal/individual/op/rotate_key.rs
+++ b/keyhive_core/src/principal/individual/op/rotate_key.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Retire a prekey and replace it with a new one.
 #[derive(Debug, Clone, Dupe, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct RotateKeyOp {
     /// The prekey to remove.
     pub old: ShareKey,


### PR DESCRIPTION
This just adds a bunch of arbitrary implementations which are useful in the proptests for message encoding in Beelay.