### PR TITLE
keyhive_core: Add various is_missing_dependency functions

### DIFF
--- a/keyhive_core/src/cgka/error.rs
+++ b/keyhive_core/src/cgka/error.rs
@@ -71,3 +71,12 @@ pub enum CgkaError {
     #[error(transparent)]
     SigningError(#[from] SigningError),
 }
+
+impl CgkaError {
+    pub fn is_missing_dependency(&self) -> bool {
+        match self {
+            Self::IdentifierNotFound => true,
+            _ => false,
+        }
+    }
+}

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -183,6 +183,15 @@ pub enum ReceivePrekeyOpError {
     NewOpError(#[from] state::NewOpError),
 }
 
+impl ReceivePrekeyOpError {
+    pub fn is_missing_dependency(&self) -> bool {
+        match self {
+            Self::IncorrectSigner => false,
+            Self::NewOpError(err) => err.is_missing_dependency(),
+        }
+    }
+}
+
 fn clamp(bytes: [u8; 8], offset_bits: u8) -> usize {
     let bound = u64::from_be_bytes(bytes)
         .checked_shl(offset_bits as u32)

--- a/keyhive_core/src/principal/individual/state.rs
+++ b/keyhive_core/src/principal/individual/state.rs
@@ -195,6 +195,15 @@ pub enum NewOpError {
     MissingDependency(#[from] MissingDependency<ShareKey>),
 }
 
+impl NewOpError {
+    pub fn is_missing_dependency(&self) -> bool {
+        match self {
+            Self::VerificationError(_) => false,
+            Self::MissingDependency(_) => true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Keyhive can throw errors when processing events. Some of these errors indicate that there are missing dependencies, and some of them indicate more serious problems. Users need to be able to distinguish between these cases in order to log errors without drowning the logs in noise related to causal delivery.

This commit adds an `is_missing_dependency` function to the various error types thrown by op ingestion routines.