### PR TITLE
keyhive_core: update Active::prekey_pairs on prekey add and rotation

### DIFF
--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1829,4 +1829,65 @@ mod tests {
 
         assert_eq!(dlg.delegation.subject_id(), doc.borrow().doc_id().into());
     }
+
+    #[tokio::test]
+    async fn receiving_an_event_with_added_or_rotated_prekeys_works() {
+        let mut alice = make_keyhive().await;
+        let mut bob = make_keyhive().await;
+
+        let doc = alice
+            .generate_doc(vec![], nonempty![[0u8; 32]])
+            .await
+            .unwrap();
+
+        // Create a new prekey op by expanding prekeys on bob
+        let add_bob_op = bob.expand_prekeys().await.unwrap();
+
+        // Now add bob to alices document using the new op
+        let add_op = KeyOp::Add(add_bob_op);
+        let bob_on_alice = Rc::new(RefCell::new(Individual::new(add_op.clone())));
+        assert!(alice.register_individual(bob_on_alice.clone()));
+        alice
+            .add_member(
+                bob_on_alice.into(),
+                &mut doc.clone().into(),
+                Access::Read,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Now receive alices events
+        let events = alice
+            .events_for_agent(&bob.active().clone().into())
+            .unwrap();
+        // ensure that we are able to process the add op
+        bob.ingest_event_table(events).unwrap();
+
+        // Now create a new prekey op by rotating on bob
+        let rotate_op = bob.rotate_prekey(*add_op.new_key()).await.unwrap();
+
+        // Create a new document (on a new keyhive) and share it with bob using the rotated key
+        let mut charlie = make_keyhive().await;
+        let doc2 = charlie
+            .generate_doc(vec![], nonempty![[1u8; 32]])
+            .await
+            .unwrap();
+        let bob_on_charlie = Rc::new(RefCell::new(Individual::new(KeyOp::Rotate(rotate_op))));
+        assert!(charlie.register_individual(bob_on_charlie.clone()));
+        charlie
+            .add_member(
+                bob_on_charlie.into(),
+                &mut doc2.clone().into(),
+                Access::Read,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let events = charlie
+            .events_for_agent(&bob.active().clone().into())
+            .unwrap();
+        bob.ingest_event_table(events).unwrap();
+    }
 }

--- a/keyhive_core/src/principal/individual/new_share_key.rs
+++ b/keyhive_core/src/principal/individual/new_share_key.rs
@@ -1,0 +1,8 @@
+use crate::crypto::share_key::ShareSecretKey;
+
+#[derive(Debug, Clone)]
+pub struct NewShareKey<Op> {
+    pub new_secret: ShareSecretKey,
+    // This is either a RotateKeyOp or an AddKeyOp
+    pub op: Op,
+}


### PR DESCRIPTION
Problem: when we rotate or add a prekey, we don't update the Active::prekey_pairs map, which stores the ShareSecretKey for each ShareKey. This means that if we receive a CGKA op adding us to a document using any prekey other than those used at initial creation time, we don't have the secret key available to do the decryption.

Solution: update the prekey_pairs field on adding or rotating prekeys. This is achieved by adding a new
`keyhive_core::principal::individual::NewShareKey` type which is returned by `Individual::expand_prekeys` and
`Individual::rotate_prekey`.