### PR TITLE
keyhive_core: in Document::add_member add delegation to the doc cgka

### DIFF
--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -46,6 +46,7 @@ proptest-derive = { version = "0.5.0", optional = true }
 arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 
 [dev-dependencies]
+keyhive_core = { path = ".", features = ["test_utils"] }
 
 arbitrary = { version = "1.4.1", features = ["derive"] }
 tokio = { version = "1.43", features = ["macros", "rt"] }

--- a/keyhive_core/src/access.rs
+++ b/keyhive_core/src/access.rs
@@ -39,6 +39,16 @@ pub enum Access {
     Admin,
 }
 
+impl Access {
+    pub fn is_reader(self) -> bool {
+        self >= Access::Read
+    }
+
+    pub fn is_writer(self) -> bool {
+        self >= Access::Write
+    }
+}
+
 impl fmt::Display for Access {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1846,9 +1846,7 @@ mod tests {
         // Now add bob to alices document using the new op
         let add_op = KeyOp::Add(add_bob_op);
         let bob_on_alice = Rc::new(RefCell::new(Individual::new(add_op.dupe())));
-        dbg!(&bob_on_alice);
         let og_bob = Rc::new(RefCell::new(bob.individual())); // Rc::new(RefCell::new(Individual::new(add_op.dupe())));
-        dbg!(&og_bob);
         assert!(alice.register_individual(bob_on_alice.clone()));
         alice
             .add_member(

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1347,16 +1347,17 @@ impl<
     pub fn ingest_unsorted_static_events(
         &mut self,
         events: Vec<StaticEvent<T>>,
-    ) -> Result<(), MissingDependency<StaticEvent<T>>> {
+    ) -> Result<(), ReceiveStaticEventError<S, T, L>> {
         let mut epoch = events;
 
         loop {
             let mut next_epoch = vec![];
-            let mut epoch_len = 0;
+            let mut err = None;
+            let epoch_len = epoch.len();
 
             for event in epoch {
-                epoch_len += 1;
-                if self.receive_static_event(event.clone()).is_err() {
+                if let Err(e) = self.receive_static_event(event.clone()) {
+                    err = Some(e);
                     next_epoch.push(event);
                 }
             }
@@ -1367,8 +1368,7 @@ impl<
 
             if next_epoch.len() == epoch_len {
                 // Stuck on a fixed point
-                let exemplar = next_epoch.first().unwrap().clone();
-                Err(MissingDependency(exemplar))?;
+                return Err(err.unwrap());
             }
 
             epoch = next_epoch
@@ -1379,7 +1379,7 @@ impl<
     pub fn ingest_event_table(
         &mut self,
         events: HashMap<Digest<Event<S, T, L>>, Event<S, T, L>>,
-    ) -> Result<(), MissingDependency<StaticEvent<T>>> {
+    ) -> Result<(), ReceiveStaticEventError<S, T, L>> {
         self.ingest_unsorted_static_events(
             events.values().cloned().map(Into::into).collect::<Vec<_>>(),
         )
@@ -1845,11 +1845,14 @@ mod tests {
 
         // Now add bob to alices document using the new op
         let add_op = KeyOp::Add(add_bob_op);
-        let bob_on_alice = Rc::new(RefCell::new(Individual::new(add_op.clone())));
+        let bob_on_alice = Rc::new(RefCell::new(Individual::new(add_op.dupe())));
+        dbg!(&bob_on_alice);
+        let og_bob = Rc::new(RefCell::new(bob.individual())); // Rc::new(RefCell::new(Individual::new(add_op.dupe())));
+        dbg!(&og_bob);
         assert!(alice.register_individual(bob_on_alice.clone()));
         alice
             .add_member(
-                bob_on_alice.into(),
+                bob_on_alice.dupe().into(),
                 &mut doc.dupe().into(),
                 Access::Read,
                 &[],
@@ -1858,11 +1861,7 @@ mod tests {
             .unwrap();
 
         // Now receive alices events
-        let events = alice
-            .events_for_agent(&bob.active().clone().into())
-            .unwrap();
-
-        dbg!(events.keys().collect::<Vec<_>>());
+        let events = alice.events_for_agent(&bob_on_alice.into()).unwrap();
 
         // ensure that we are able to process the add op
         bob.ingest_event_table(events).unwrap();

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1850,7 +1850,7 @@ mod tests {
         alice
             .add_member(
                 bob_on_alice.into(),
-                &mut doc.clone().into(),
+                &mut doc.dupe().into(),
                 Access::Read,
                 &[],
             )
@@ -1861,6 +1861,9 @@ mod tests {
         let events = alice
             .events_for_agent(&bob.active().clone().into())
             .unwrap();
+
+        dbg!(events.keys().collect::<Vec<_>>());
+
         // ensure that we are able to process the add op
         bob.ingest_event_table(events).unwrap();
 

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -232,7 +232,7 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Document<S, T, 
         // transitive document members of the group, but not to the group itself
         // (because the group might not be a document), so we add the member to
         // the group here and add any extra resulting cgka ops to the update.
-        if can >= Access::Read {
+        if can.is_reader() {
             update.cgka_ops.extend(
                 self.add_cgka_member(&update.delegation, signer)
                     .await?

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -41,7 +41,6 @@ use derivative::Derivative;
 use derive_where::derive_where;
 use dupe::Dupe;
 use ed25519_dalek::VerifyingKey;
-use futures::{stream, TryStreamExt};
 use id::DocumentId;
 use nonempty::NonEmpty;
 use std::{
@@ -228,50 +227,34 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Document<S, T, 
             .add_member_with_manual_content(member_to_add.dupe(), can, signer, after_content)
             .await?;
 
-        // Group::add_member_with_manual_content adds the member to the CGKA for
-        // transitive document members of the group, but not to the group itself
-        // (because the group might not be a document), so we add the member to
-        // the group here and add any extra resulting cgka ops to the update.
         if can.is_reader() {
-            update.cgka_ops.extend(
-                self.add_cgka_member(&update.delegation, signer)
-                    .await?
-                    .into_iter(),
-            );
+            // Group::add_member_with_manual_content adds the member to the CGKA for
+            // transitive document members of the group, but not to the group itself
+            // (because the group might not be a document), so we add the member to
+            // the group here and add any extra resulting cgka ops to the update.
+            let cgka_ops_for_this_doc = self.add_cgka_member(&update.delegation, signer).await?;
+            update.cgka_ops.extend(cgka_ops_for_this_doc.into_iter());
         }
         Ok(update)
     }
 
-    pub async fn add_cgka_member(
+    pub(crate) async fn add_cgka_member(
         &mut self,
         delegation: &Signed<Delegation<S, T, L>>,
         signer: &S,
     ) -> Result<Vec<Signed<CgkaOperation>>, CgkaError> {
-        if delegation.payload.can < Access::Read {
-            return Ok(vec![]);
-        }
-
         let prekeys = delegation
-            .dupe()
-            .payload()
+            .payload
             .delegate
             .pick_individual_prekeys(self.doc_id());
 
-        let cell = Rc::new(RefCell::new(self));
-
-        stream::iter(prekeys.iter().map(Ok::<_, CgkaError>))
-            .try_fold(vec![], |mut acc, (id, pre_key)| async {
-                if let Some(op) = cell
-                    .borrow_mut()
-                    .cgka_mut()?
-                    .add(*id, *pre_key, signer)
-                    .await?
-                {
-                    acc.push(op);
-                }
-                Ok::<_, CgkaError>(acc)
-            })
-            .await
+        let mut acc = vec![];
+        for (id, prekey) in prekeys.iter() {
+            if let Some(op) = self.cgka_mut()?.add(*id, *prekey, signer).await? {
+                acc.push(op);
+            }
+        }
+        Ok(acc)
     }
 
     pub async fn revoke_member(

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -411,22 +411,22 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
             .await?;
 
         let rc = Rc::new(delegation);
-        self.listener.on_delegation(&rc).await;
         let _digest = self.receive_delegation(rc.dupe())?;
+        self.listener.on_delegation(&rc).await;
 
-        let cgka_ops = if can.is_reader() {
-            self.add_cgka_member(rc.dupe(), signer).await?,
+        let cgka_ops = if rc.payload.can.is_reader() {
+            self.add_cgka_member(rc.dupe(), signer).await?
         } else {
             vec![]
         };
 
         Ok(AddMemberUpdate {
-            delegation: rc,
             cgka_ops,
+            delegation: rc,
         })
     }
 
-    pub async fn add_cgka_member(
+    pub(crate) async fn add_cgka_member(
         &mut self,
         delegation: Rc<Signed<Delegation<S, T, L>>>,
         signer: &S,

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -414,7 +414,7 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
         self.listener.on_delegation(&rc).await;
         let _digest = self.receive_delegation(rc.dupe())?;
 
-        let cgka_ops = if can >= Access::Read {
+        let cgka_ops = if can.is_reader() {
             self.add_cgka_member(rc.dupe(), signer).await?,
         } else {
             vec![]

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -414,9 +414,15 @@ impl<S: AsyncSigner, T: ContentRef, L: MembershipListener<S, T>> Group<S, T, L> 
         self.listener.on_delegation(&rc).await;
         let _digest = self.receive_delegation(rc.dupe())?;
 
+        let cgka_ops = if can >= Access::Read {
+            self.add_cgka_member(rc.dupe(), signer).await?,
+        } else {
+            vec![]
+        };
+
         Ok(AddMemberUpdate {
-            cgka_ops: self.add_cgka_member(rc.dupe(), signer).await?,
             delegation: rc,
+            cgka_ops,
         })
     }
 

--- a/keyhive_core/tests/encrypt.rs
+++ b/keyhive_core/tests/encrypt.rs
@@ -1,15 +1,8 @@
-use std::{cell::RefCell, rc::Rc};
-
-use nonempty::nonempty;
-
 use keyhive_core::{
-    access::Access,
-    crypto::signer::memory::MemorySigner,
-    event::{static_event::StaticEvent, Event},
-    keyhive::Keyhive,
+    access::Access, crypto::signer::memory::MemorySigner, keyhive::Keyhive,
     listener::no_listener::NoListener,
-    principal::individual::Individual,
 };
+use nonempty::nonempty;
 
 async fn make_keyhive() -> Keyhive<MemorySigner> {
     let sk = MemorySigner::generate(&mut rand::thread_rng());

--- a/keyhive_core/tests/encrypt.rs
+++ b/keyhive_core/tests/encrypt.rs
@@ -1,0 +1,64 @@
+use std::{cell::RefCell, rc::Rc};
+
+use nonempty::nonempty;
+
+use keyhive_core::{
+    access::Access,
+    crypto::signer::memory::MemorySigner,
+    event::{static_event::StaticEvent, Event},
+    keyhive::Keyhive,
+    listener::no_listener::NoListener,
+    principal::individual::Individual,
+};
+
+async fn make_keyhive() -> Keyhive<MemorySigner> {
+    let sk = MemorySigner::generate(&mut rand::thread_rng());
+    Keyhive::generate(sk, NoListener, rand::thread_rng())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_encrypt_to_added_member() {
+    let mut alice = make_keyhive().await;
+
+    let init_content = "hello world".as_bytes().to_vec();
+    let init_hash = blake3::hash(&init_content);
+
+    let doc = alice
+        .generate_doc(vec![], nonempty![init_hash.into()])
+        .await
+        .unwrap();
+
+    let mut bob = make_keyhive().await;
+
+    alice
+        .add_member(
+            bob.active().clone().into(),
+            &mut doc.clone().into(),
+            Access::Read,
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let encrypted = alice
+        .try_encrypt_content(doc.clone(), &init_hash.into(), &vec![], &init_content)
+        .await
+        .unwrap();
+
+    // now sync everything to bob
+    let events = alice
+        .static_events_for_agent(&bob.active().clone().into())
+        .unwrap();
+    bob.ingest_unsorted_static_events(events.into_values().collect())
+        .unwrap();
+
+    // Now attempt to decrypt on bob
+    let doc_on_bob = bob.get_document(doc.borrow().doc_id()).unwrap();
+    let decrypted = bob
+        .try_decrypt_content(doc_on_bob.clone(), encrypted.encrypted_content())
+        .unwrap();
+
+    assert_eq!(decrypted, init_content);
+}


### PR DESCRIPTION
Problem: agents added to a document with Document::add_member are unable to decrypt the content of the document because they have not been added to the Document::cgka. This occurs because documents are groups and so Document::add_member forwards to Group::add_member_with_manual_content. add_member_with_manual_content adds the agent to each transitively included document beneath it, but it doesn't add the agent to the group itself - because a group is not a document and thus might not have a cgka.

Solution: Add the agent to the Document::cgka once the Group::add_member_with_manual_content call completes.


I added a test but I put in a (newly created) integration test in keyhive_core/tests/encrypt.rs. The keyhive_core/src/keyhive.rs file felt like it was getting a little unwieldy with all the tests in it. It should be easier to maintain these tests split across a number of files in the integration tests.
