### PR TITLE
beelay_core: don't generate a contact card on every load

### DIFF
--- a/beelay/TODO.md
+++ b/beelay/TODO.md
@@ -4,7 +4,6 @@
 
 ## The big list
 
-* Don't generate a contact card on load, instead do it on demand (i.e. create a command for creating a contact card). Otherwise we do a prekey rotation on every load!
 * Make sure we are incrementally saving ShareSecretKeys
 * Find a better name than `sync_loops`
 * Move change forwarding into it's own top level thing alongside the sync loop manager in run_inner
@@ -19,6 +18,5 @@ events we received since the load was started into the return value so that
 callers know they only have to listen to events from the point the document is
 returned.
 * Stop using async for stream processing, it's confusing
-* Figure out how to turn the async keyhive APIs (e.g. `Keyhive::revoke_member`) into a two stage API which produces signing requests and accepts signing responses. Otherwise we have to lock the whole event loop for every signing request.
 * Make connection tests clearer
 * Consider whether we can get rid of the list-one-level thing by keeping an index of all documents somewhere

--- a/beelay/beelay-core/src/driver.rs
+++ b/beelay/beelay-core/src/driver.rs
@@ -192,18 +192,13 @@ async fn run_inner<R: rand::Rng + rand::CryptoRng + Clone + 'static>(
 
         let load_docs = loading::load_docs(io.clone());
         let load_keyhive = loading::load_keyhive(io, rng.clone(), signer.clone());
-        let (docs, (mut keyhive, keyhive_rx)) =
-            futures::future::join(load_docs, load_keyhive).await;
+        let (docs, (keyhive, keyhive_rx)) = futures::future::join(load_docs, load_keyhive).await;
         let peer_id = keyhive.active().borrow().verifying_key().into();
-
-        // FIXME: return an error when loading faiils here
-        let contact_card = keyhive.contact_card().await.unwrap();
 
         let state = Rc::new(RefCell::new(State::new(rng, signer, keyhive, docs)));
         if let Err(_) = load_complete.send(loading::LoadedParts {
             state: state.clone(),
             peer_id,
-            contact_card,
         }) {
             tracing::warn!("load complete listener went away, stopping driver");
             return;

--- a/beelay/beelay-core/src/event.rs
+++ b/beelay/beelay-core/src/event.rs
@@ -232,6 +232,15 @@ impl Event {
         ));
         (command_id, event)
     }
+
+    pub fn create_contact_card() -> (CommandId, Event) {
+        let command_id = CommandId::new();
+        let event = Event(EventInner::BeginCommand(
+            command_id,
+            Command::Keyhive(keyhive::KeyhiveCommand::CreateContactCard),
+        ));
+        (command_id, event)
+    }
 }
 
 #[derive(Debug)]

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -96,7 +96,6 @@ mod sync;
 pub struct Beelay<R: rand::Rng + rand::CryptoRng> {
     #[allow(dead_code)]
     state: Rc<RefCell<state::State<R>>>,
-    contact_card: ContactCard,
     peer_id: PeerId,
     driver: driver::Driver,
 }
@@ -136,16 +135,11 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
     }
 
     pub(crate) fn loaded(
-        loading::LoadedParts {
-            state,
-            peer_id,
-            contact_card,
-        }: loading::LoadedParts<R>,
+        loading::LoadedParts { state, peer_id }: loading::LoadedParts<R>,
         driver: driver::Driver,
     ) -> Beelay<R> {
         Beelay {
             state,
-            contact_card,
             peer_id,
             driver,
         }
@@ -153,10 +147,6 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
-    }
-
-    pub fn contact_card(&self) -> &ContactCard {
-        &self.contact_card
     }
 }
 
@@ -215,7 +205,9 @@ pub struct NewRequest {
 pub mod error {
     pub use crate::commands::error::{AddCommits, Create};
     pub use crate::documents::error::{InvalidCommitHash, InvalidDocumentId};
-    pub use crate::keyhive::error::{AddMember, CreateGroup, QueryAccess, RemoveMember};
+    pub use crate::keyhive::error::{
+        AddMember, CreateContactCard, CreateGroup, QueryAccess, RemoveMember,
+    };
     use crate::network::RpcError;
     pub use crate::peer_id::error::InvalidPeerId;
 

--- a/beelay/beelay-core/src/loading.rs
+++ b/beelay/beelay-core/src/loading.rs
@@ -3,7 +3,6 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use futures::channel::mpsc;
 use futures::channel::oneshot;
-use keyhive_core::contact_card::ContactCard;
 use keyhive_core::keyhive::Keyhive;
 
 use crate::doc_state::DocState;
@@ -21,7 +20,6 @@ pub struct Loading<R: rand::Rng + rand::CryptoRng + Clone + 'static> {
 pub(crate) struct LoadedParts<R: rand::Rng + rand::CryptoRng> {
     pub(crate) state: Rc<RefCell<State<R>>>,
     pub(crate) peer_id: PeerId,
-    pub(crate) contact_card: ContactCard,
 }
 
 pub enum Step<R: rand::Rng + rand::CryptoRng + Clone + 'static> {

--- a/beelay/beelay-core/src/state/keyhive.rs
+++ b/beelay/beelay-core/src/state/keyhive.rs
@@ -9,7 +9,11 @@ use keyhive_core::{
     access::Access as KeyhiveAccess,
     cgka::{error::CgkaError, operation::CgkaOperation},
     contact_card::ContactCard,
-    crypto::{digest::Digest, signed::Signed, verifiable::Verifiable},
+    crypto::{
+        digest::Digest,
+        signed::{Signed, SigningError},
+        verifiable::Verifiable,
+    },
     event::{static_event::StaticEvent, Event},
     principal::{
         document::id::DocumentId as KeyhiveDocumentId, group::RevokeMemberError,
@@ -680,6 +684,15 @@ impl<'a, R: rand::Rng + rand::CryptoRng> KeyhiveCtx<'a, R> {
             nicknames,
         );
         table
+    }
+
+    pub(crate) async fn contact_card(
+        &self,
+    ) -> Result<keyhive_core::contact_card::ContactCard, SigningError> {
+        let k_mutex = self.0.borrow().keyhive.clone();
+        let mut keyhive = k_mutex.lock().await;
+
+        keyhive.contact_card().await
     }
 }
 

--- a/beelay/beelay-core/tests/events.rs
+++ b/beelay/beelay-core/tests/events.rs
@@ -14,7 +14,7 @@ fn sync_emits_local_notifications() {
     let mut network = Network::new();
     let peer1 = network.create_peer("peer1");
     let peer2 = network.create_peer("peer2");
-    let peer2_contact = network.beelay(&peer2).contact_card();
+    let peer2_contact = network.beelay(&peer2).contact_card().unwrap();
 
     // Now, create a document on left
     let (doc_id, initial_commit) = network
@@ -48,14 +48,14 @@ fn listen_emits_local_notifications() {
     let mut network = Network::new();
     let peer1 = network.create_peer("peer1");
     let peer2 = network.create_peer("peer2");
-    let peer2_contact_card = network.beelay(&peer2).contact_card();
+    let peer2_contact_card = network.beelay(&peer2).contact_card().unwrap();
 
     // Now, create a document on left
     let (doc_id, initial_commit) = network
         .beelay(&peer1)
         .create_doc(vec![peer2_contact_card])
         .unwrap();
-    let peer2_contact = network.beelay(&peer2).contact_card();
+    let peer2_contact = network.beelay(&peer2).contact_card().unwrap();
     network
         .beelay(&peer1)
         .add_member_to_doc(doc_id.clone(), peer2_contact, MemberAccess::Write);

--- a/beelay/beelay-core/tests/smoke.rs
+++ b/beelay/beelay-core/tests/smoke.rs
@@ -45,7 +45,7 @@ fn create_and_sync_via_stream() {
     let mut network = Network::new();
     let peer1 = network.create_peer("peer1");
     let peer2 = network.create_peer("peer2");
-    let peer2_contact = network.beelay(&peer2).contact_card();
+    let peer2_contact = network.beelay(&peer2).contact_card().unwrap();
 
     // First create the doc
     let (doc1_id, initial_commit) = network
@@ -131,7 +131,7 @@ fn changes_published_after_sync() {
 
     // First create the doc
     let (doc1_id, initial_commit) = network.beelay(&peer1).create_doc(vec![]).unwrap();
-    let peer2_contact = network.beelay(&peer2).contact_card();
+    let peer2_contact = network.beelay(&peer2).contact_card().unwrap();
     network
         .beelay(&peer1)
         .add_member_to_doc(doc1_id, peer2_contact, MemberAccess::Read);


### PR DESCRIPTION
Problem: the code to load Beelay created a keyhive contact card on every load, incurring a key rotation every time you load the Beelay. This is a vestige from a previous implementation of the contact card which did not incur a key rotation but just saved a KeyOp.

Solution: don't create the contact card on load but instead add a command to beelay to create a new contact card when needed.