### PR TITLE
Remove references to Public from beelay

### DIFF
--- a/beelay/TODO.md
+++ b/beelay/TODO.md
@@ -14,7 +14,6 @@
   * On each tick:
     * Expire old sessions
     * Rerun sync for sessions older than 1 minute
-* Remove `Public`
 * Ensure that when a document is loaded we have incorporated any decrypted
 events we received since the load was started into the return value so that
 callers know they only have to listen to events from the point the document is

--- a/beelay/beelay-core/src/commands/keyhive.rs
+++ b/beelay/beelay-core/src/commands/keyhive.rs
@@ -82,12 +82,6 @@ pub enum KeyhiveEntityId {
     Doc(DocumentId),
 }
 
-impl KeyhiveEntityId {
-    pub fn public() -> Self {
-        Self::Peer(keyhive_core::principal::public::Public.id().0.into())
-    }
-}
-
 impl From<KeyhiveEntityId> for keyhive_core::principal::identifier::Identifier {
     fn from(id: KeyhiveEntityId) -> Self {
         match id {

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -36,9 +36,7 @@ use commands::Command;
 use ed25519_dalek::VerifyingKey;
 use futures::channel::oneshot;
 use io::Signer;
-use keyhive_core::{
-    contact_card::ContactCard, crypto::verifiable::Verifiable, principal::public::Public,
-};
+use keyhive_core::contact_card::ContactCard;
 use network::messages::{Request, Response};
 use serialization::parse;
 use tracing::Instrument;
@@ -155,10 +153,6 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
-    }
-
-    pub fn public_peer_id(&self) -> PeerId {
-        Public.id().verifying_key().into()
     }
 
     pub fn contact_card(&self) -> &ContactCard {


### PR DESCRIPTION
Problem: Now that Beelay syncs everything you have access to the Public identity is problematic. If every application uses the same well known public identity then anyone connecting to a busy sync server would have to sync everything on the server, which would likely end up being many things the user doesn't care about.

Solution: don't use the Public identity at all in Beelay. This does mean we currently have no way to handle public content at all, we will likely need to solve this by adding some way of signing a message with multiple identities so that applications which wish to have public content can ship a public identity as part of the application which is then used to perform sync. We'll handle that later.