### PR TITLE
beelay-core: Add a debug_events command to dump keyhive events

### DIFF
--- a/beelay/beelay-core/Cargo.toml
+++ b/beelay/beelay-core/Cargo.toml
@@ -32,8 +32,10 @@ nonempty = { workspace = true, features = ["arbitrary"] }
 [dev-dependencies]
 keyhive_core = { path = "../../keyhive_core", features = [
     "arbitrary",
+    "debug_events",
     "test_utils",
 ] }
+beelay-core = { path = ".", features = ["debug_events"] }
 test-utils = { path = "../test-utils" }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 bolero = { version = "0.11.1", features = ["arbitrary"] }
@@ -48,3 +50,6 @@ resvg = { version = "0.43.0", default-features = false, features = [
 termion = "4.0.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 viuer = "0.7.1"
+
+[features]
+debug_events = ["keyhive_core/debug_events"]

--- a/beelay/beelay-core/src/commands/keyhive.rs
+++ b/beelay/beelay-core/src/commands/keyhive.rs
@@ -16,6 +16,8 @@ pub enum KeyhiveCommand {
     AddMemberToDoc(DocumentId, ContactCard, MemberAccess),
     RemoveMemberFromDoc(DocumentId, KeyhiveEntityId),
     QueryAccess(DocumentId),
+    #[cfg(feature = "debug_events")]
+    DebugEvents(keyhive_core::debug_events::Nicknames),
 }
 
 #[derive(Debug)]
@@ -26,6 +28,8 @@ pub enum KeyhiveCommandResult {
     AddMemberToDoc,
     RemoveMemberFromDoc(Result<(), error::RemoveMember>),
     QueryAccess(Result<HashMap<PeerId, MemberAccess>, error::QueryAccess>),
+    #[cfg(feature = "debug_events")]
+    DebugEvents(keyhive_core::debug_events::DebugEventTable),
 }
 
 #[derive(Debug)]
@@ -149,6 +153,11 @@ where
         KeyhiveCommand::RemoveMemberFromGroup(remove) => {
             let result = remove_member_from_group(ctx, remove).await;
             KeyhiveCommandResult::RemoveMemberFromGroup(result)
+        }
+        #[cfg(feature = "debug_events")]
+        KeyhiveCommand::DebugEvents(nicknames) => {
+            let result = ctx.state().keyhive().debug_events(nicknames).await;
+            KeyhiveCommandResult::DebugEvents(result)
         }
     }
 }

--- a/beelay/beelay-core/src/event.rs
+++ b/beelay/beelay-core/src/event.rs
@@ -220,6 +220,18 @@ impl Event {
         ));
         (command_id, event)
     }
+
+    #[cfg(feature = "debug_events")]
+    pub fn log_keyhive_events(
+        nicknames: keyhive_core::debug_events::Nicknames,
+    ) -> (CommandId, Event) {
+        let command_id = CommandId::new();
+        let event = Event(EventInner::BeginCommand(
+            command_id,
+            Command::Keyhive(keyhive::KeyhiveCommand::DebugEvents(nicknames)),
+        ));
+        (command_id, event)
+    }
 }
 
 #[derive(Debug)]

--- a/beelay/beelay-core/src/state/keyhive.rs
+++ b/beelay/beelay-core/src/state/keyhive.rs
@@ -712,6 +712,24 @@ impl<'a, R: rand::Rng + rand::CryptoRng> KeyhiveCtx<'a, R> {
             .map(|d| d.into())
             .collect()
     }
+
+    #[cfg(feature = "debug_events")]
+    pub(crate) async fn debug_events(
+        &self,
+        nicknames: keyhive_core::debug_events::Nicknames,
+    ) -> keyhive_core::debug_events::DebugEventTable {
+        let k_mutex = self.0.borrow().keyhive.clone();
+        let keyhive = k_mutex.lock().await;
+
+        let events = keyhive
+            .events_for_agent(&keyhive.active().clone().into())
+            .unwrap();
+        let table = keyhive_core::debug_events::DebugEventTable::from_events(
+            events.into_values().collect(),
+            nicknames,
+        );
+        table
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/beelay/beelay-core/tests/smoke.rs
+++ b/beelay/beelay-core/tests/smoke.rs
@@ -111,6 +111,14 @@ fn create_and_sync_via_stream() {
         .into_iter()
         .collect::<HashSet<_>>();
 
+    let table = network.beelay(&peer2).log_keyhive_events(
+        keyhive_core::debug_events::Nicknames::default()
+            .with_nickname(doc1_id.as_bytes(), "doc1")
+            .with_nickname(peer1.as_bytes(), "peer1")
+            .with_nickname(peer2.as_bytes(), "peer2"),
+    );
+    keyhive_core::debug_events::terminal::print_event_table_verbose(table);
+
     assert_eq!(commits_on_2, expected_commits);
 }
 


### PR DESCRIPTION
The debug event table in keyhive_core has turned out to be quite useful when debugging so we epose it (behind a flag) in beelay as well.