### PR TITLE
beelay-core: Add a UnixTimestampMillis type

### DIFF
--- a/beelay/beelay-core/src/auth.rs
+++ b/beelay/beelay-core/src/auth.rs
@@ -7,7 +7,6 @@ pub(crate) use message::Message;
 pub mod offset_seconds;
 pub mod signed;
 pub(crate) use signed::Signed;
-pub mod unix_timestamp;
 
 #[derive(Debug)]
 pub(crate) struct Authenticated<T> {

--- a/beelay/beelay-core/src/auth/manager.rs
+++ b/beelay/beelay-core/src/auth/manager.rs
@@ -1,13 +1,12 @@
 use keyhive_core::crypto::verifiable::Verifiable;
 
-use crate::{Signer, TaskContext};
+use crate::{Signer, TaskContext, UnixTimestamp};
 
 use super::{
     audience::Audience,
     message::{Message, MessageValidationError},
     offset_seconds::OffsetSeconds,
     signed::Signed,
-    unix_timestamp::UnixTimestamp,
 };
 use std::{collections::HashMap, future::Future, time::Duration};
 

--- a/beelay/beelay-core/src/auth/message.rs
+++ b/beelay/beelay-core/src/auth/message.rs
@@ -1,6 +1,9 @@
-use crate::serialization::{parse, Encode, Parse};
+use crate::{
+    serialization::{parse, Encode, Parse},
+    UnixTimestamp,
+};
 
-use super::{audience::Audience, offset_seconds::OffsetSeconds, unix_timestamp::UnixTimestamp};
+use super::{audience::Audience, offset_seconds::OffsetSeconds};
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/beelay/beelay-core/src/commands.rs
+++ b/beelay/beelay-core/src/commands.rs
@@ -88,7 +88,7 @@ where
                 Ok(r) => InnerRpcResponse::Response(Box::new(
                     ctx.state()
                         .auth()
-                        .sign_message(ctx.now(), r.audience, r.response)
+                        .sign_message(ctx.now().as_secs(), r.audience, r.response)
                         .await,
                 )),
                 Err(_) => InnerRpcResponse::AuthFailed,

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -30,7 +30,7 @@
 
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
-pub use auth::{audience::Audience, unix_timestamp::UnixTimestamp};
+pub use auth::audience::Audience;
 mod sync_loops;
 use commands::Command;
 use ed25519_dalek::VerifyingKey;
@@ -60,6 +60,8 @@ mod sedimentree;
 mod state;
 mod task_context;
 use task_context::TaskContext;
+mod unix_timestamp;
+pub use unix_timestamp::{UnixTimestamp, UnixTimestampMillis};
 
 mod peer_id;
 pub use peer_id::PeerId;
@@ -116,7 +118,7 @@ pub struct Beelay<R: rand::Rng + rand::CryptoRng> {
 unsafe impl<R: rand::Rng + rand::CryptoRng> Send for Beelay<R> {}
 
 impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
-    pub fn load(rng: R, now: UnixTimestamp, verifying_key: VerifyingKey) -> loading::Step<R> {
+    pub fn load(rng: R, now: UnixTimestampMillis, verifying_key: VerifyingKey) -> loading::Step<R> {
         let (tx_load_complete, rx_load_complete) = oneshot::channel();
         let local_peer_id = PeerId::from(verifying_key.clone());
         let run_span = tracing::info_span!("run", %local_peer_id);
@@ -154,7 +156,7 @@ impl<R: rand::Rng + rand::CryptoRng> Beelay<R> {
     #[tracing::instrument(skip(self, event), fields(local_peer=%self.peer_id))]
     pub fn handle_event(
         &mut self,
-        now: UnixTimestamp,
+        now: UnixTimestampMillis,
         event: Event,
     ) -> Result<EventResults, Stopped> {
         match event.0 {

--- a/beelay/beelay-core/src/loading.rs
+++ b/beelay/beelay-core/src/loading.rs
@@ -10,7 +10,7 @@ use crate::io::{IoHandle, IoResult};
 use crate::state::State;
 use crate::task_context::Storage;
 use crate::{driver, DocumentId, PeerId, Signer};
-use crate::{io::IoTask, task_context::DocStorage, Beelay, StorageKey, UnixTimestamp};
+use crate::{io::IoTask, task_context::DocStorage, Beelay, StorageKey, UnixTimestampMillis};
 
 pub struct Loading<R: rand::Rng + rand::CryptoRng + Clone + 'static> {
     driver: driver::Driver,
@@ -29,7 +29,7 @@ pub enum Step<R: rand::Rng + rand::CryptoRng + Clone + 'static> {
 
 impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Loading<R> {
     pub(crate) fn new(
-        now: UnixTimestamp,
+        now: UnixTimestampMillis,
         driver: driver::Driver,
         rx_loaded: oneshot::Receiver<LoadedParts<R>>,
     ) -> Step<R> {
@@ -40,7 +40,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Loading<R> {
         loading.step(now)
     }
 
-    fn step(mut self, now: UnixTimestamp) -> Step<R> {
+    fn step(mut self, now: UnixTimestampMillis) -> Step<R> {
         let new_events = self.driver.step(now);
         if let Ok(Some(parts)) = self.result.try_recv() {
             Step::Loaded(Beelay::loaded(parts, self.driver), new_events.new_tasks)
@@ -49,7 +49,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Loading<R> {
         }
     }
 
-    pub fn handle_io_complete(mut self, now: UnixTimestamp, result: IoResult) -> Step<R> {
+    pub fn handle_io_complete(mut self, now: UnixTimestampMillis, result: IoResult) -> Step<R> {
         self.driver.handle_io_complete(result);
         self.step(now)
     }

--- a/beelay/beelay-core/src/network/streams/connection.rs
+++ b/beelay/beelay-core/src/network/streams/connection.rs
@@ -69,7 +69,7 @@ impl<R: rand::Rng + rand::CryptoRng> AuthCtx for TaskContext<R> {
     {
         self.state()
             .auth()
-            .authenticate_received_msg(self.now(), msg, receive_audience)
+            .authenticate_received_msg(self.now().as_secs(), msg, receive_audience)
     }
 
     async fn sign_message<T>(
@@ -82,18 +82,18 @@ impl<R: rand::Rng + rand::CryptoRng> AuthCtx for TaskContext<R> {
     {
         self.state()
             .auth()
-            .sign_message(self.now(), audience, msg)
+            .sign_message(self.now().as_secs(), audience, msg)
             .await
     }
 
     fn update_offset(&self, remote_audience: Audience, their_clock: UnixTimestamp) {
         self.state()
             .auth()
-            .update_offset(self.now(), remote_audience, their_clock)
+            .update_offset(self.now().as_secs(), remote_audience, their_clock)
     }
 
     fn now(&self) -> UnixTimestamp {
-        self.now()
+        self.now().as_secs()
     }
 
     fn our_peer_id(&self) -> crate::PeerId {

--- a/beelay/beelay-core/src/network/streams/run_streams.rs
+++ b/beelay/beelay-core/src/network/streams/run_streams.rs
@@ -322,7 +322,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> StreamToRun<R> {
                         }
                         tracing::debug!(?req, remote_peer=%connection.their_peer_id(), "sending outbound request");
                         let signed = ctx.state().auth().sign_message(
-                            ctx.now(),
+                            ctx.now().as_secs(),
                             crate::Audience::peer(&connection.their_peer_id()),
                             req,
                         ).await; //TODO: Move this future into a FuturesUnordered so we don't block everything evry time we sign
@@ -340,7 +340,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> StreamToRun<R> {
                         let response = match resp {
                             Ok(r) => {
                                 let signed = ctx.state().auth().sign_message(
-                                    ctx.now(),
+                                    ctx.now().as_secs(),
                                     crate::Audience::peer(&connection.their_peer_id()),
                                     r.response,
                                 ).await; // TODO: move this future into a FuturesUnordered so we don't block everything evry time we sign

--- a/beelay/beelay-core/src/request_handlers.rs
+++ b/beelay/beelay-core/src/request_handlers.rs
@@ -27,7 +27,7 @@ where
         match ctx
             .state()
             .auth()
-            .authenticate_received_msg(ctx.now(), request, recv_aud)
+            .authenticate_received_msg(ctx.now().as_secs(), request, recv_aud)
         {
             Ok(authed) => (authed.content, PeerId::from(authed.from)),
             Err(e) => {

--- a/beelay/beelay-core/src/task_context.rs
+++ b/beelay/beelay-core/src/task_context.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, future::Future, rc::Rc};
 
-use crate::{state::State, UnixTimestamp};
+use crate::{state::State, UnixTimestampMillis};
 
 mod requests;
 pub(crate) use requests::Requests;
@@ -11,7 +11,7 @@ mod job_future;
 pub(crate) use job_future::JobFuture;
 
 pub(crate) struct TaskContext<R: rand::Rng + rand::CryptoRng> {
-    now: Rc<RefCell<UnixTimestamp>>,
+    now: Rc<RefCell<UnixTimestampMillis>>,
     state: Rc<RefCell<State<R>>>,
     io_handle: crate::io::IoHandle,
     stopper: crate::stopper::Stopper,
@@ -30,7 +30,7 @@ impl<R: rand::Rng + rand::CryptoRng> std::clone::Clone for TaskContext<R> {
 
 impl<R: rand::Rng + rand::CryptoRng> TaskContext<R> {
     pub(crate) fn new(
-        now: Rc<RefCell<UnixTimestamp>>,
+        now: Rc<RefCell<UnixTimestampMillis>>,
         state: Rc<RefCell<State<R>>>,
         io_handle: crate::io::IoHandle,
         stopper: crate::stopper::Stopper,
@@ -43,7 +43,7 @@ impl<R: rand::Rng + rand::CryptoRng> TaskContext<R> {
         }
     }
 
-    pub(crate) fn now(&self) -> UnixTimestamp {
+    pub(crate) fn now(&self) -> UnixTimestampMillis {
         self.now.borrow().clone()
     }
 

--- a/beelay/beelay-core/src/unix_timestamp.rs
+++ b/beelay/beelay-core/src/unix_timestamp.rs
@@ -1,0 +1,146 @@
+use crate::serialization::{parse, Encode, Parse};
+
+use crate::auth::offset_seconds::OffsetSeconds;
+use std::{
+    ops::{Add, AddAssign, Sub},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub struct UnixTimestamp(pub u64);
+
+impl UnixTimestamp {
+    pub fn now() -> Self {
+        Self(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+    }
+
+    pub fn now_with_offset(offset: OffsetSeconds) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let adjusted = now as i128 + offset.0 as i128;
+        Self(adjusted as u64)
+    }
+}
+
+impl Encode for UnixTimestamp {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.0.to_be_bytes());
+    }
+}
+
+impl Parse<'_> for UnixTimestamp {
+    fn parse(input: parse::Input<'_>) -> Result<(parse::Input<'_>, Self), parse::ParseError> {
+        let (input, seconds) = parse::u64_be(input)?;
+        Ok((input, Self(seconds)))
+    }
+}
+
+impl From<u64> for UnixTimestamp {
+    fn from(seconds: u64) -> Self {
+        Self(seconds)
+    }
+}
+
+impl From<UnixTimestamp> for Vec<u8> {
+    fn from(ts: UnixTimestamp) -> Self {
+        ts.0.to_be_bytes().to_vec()
+    }
+}
+
+impl Add<OffsetSeconds> for UnixTimestamp {
+    type Output = Self;
+
+    fn add(self, rhs: OffsetSeconds) -> Self::Output {
+        let big_time = self.0 as i128 + rhs.0 as i128;
+        Self(big_time as u64)
+    }
+}
+
+impl AddAssign<Duration> for UnixTimestamp {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.0 += rhs.as_secs();
+    }
+}
+
+impl Add<Duration> for UnixTimestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0 + rhs.as_secs())
+    }
+}
+
+impl Sub for UnixTimestamp {
+    type Output = OffsetSeconds;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let big_time = self.0 as i128 - rhs.0 as i128;
+        OffsetSeconds(big_time as i64)
+    }
+}
+
+impl Sub<OffsetSeconds> for UnixTimestamp {
+    type Output = Self;
+
+    fn sub(self, rhs: OffsetSeconds) -> Self::Output {
+        let big_time = self.0 as i128 - rhs.0 as i128;
+        Self(big_time as u64)
+    }
+}
+
+impl Sub<Duration> for UnixTimestamp {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self(self.0 - rhs.as_secs())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnixTimestampMillis(u128);
+
+impl UnixTimestampMillis {
+    pub fn now() -> Self {
+        Self(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+    }
+
+    pub fn as_secs(&self) -> UnixTimestamp {
+        UnixTimestamp((self.0 / 1000) as u64)
+    }
+}
+
+impl AddAssign<Duration> for UnixTimestampMillis {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.0 += rhs.as_millis();
+    }
+}
+
+impl Add<Duration> for UnixTimestampMillis {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0 + rhs.as_millis())
+    }
+}
+
+impl Sub<Duration> for UnixTimestampMillis {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self(self.0 - rhs.as_millis())
+    }
+}

--- a/beelay/beelay-core/tests/network/mod.rs
+++ b/beelay/beelay-core/tests/network/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use beelay_core::{
     io::{IoAction, IoResult},
     keyhive::{KeyhiveCommandResult, KeyhiveEntityId, MemberAccess},
-    BundleSpec, CommitHash, CommitOrBundle, DocumentId, Event, PeerId, UnixTimestamp,
+    BundleSpec, CommitHash, CommitOrBundle, DocumentId, Event, PeerId, UnixTimestampMillis,
 };
 use ed25519_dalek::SigningKey;
 use keyhive_core::contact_card::ContactCard;
@@ -377,7 +377,7 @@ impl Network {
         test_utils::add_rewrite(peer_id.to_string(), nickname);
         let mut step = beelay_core::Beelay::load(
             rand::thread_rng(),
-            UnixTimestamp::now(),
+            UnixTimestampMillis::now(),
             signing_key.verifying_key(),
         );
         let mut completed_tasks = Vec::new();
@@ -389,7 +389,7 @@ impl Network {
                         completed_tasks.push(result);
                     }
                     if let Some(task_result) = completed_tasks.pop() {
-                        step = loading.handle_io_complete(UnixTimestamp::now(), task_result);
+                        step = loading.handle_io_complete(UnixTimestampMillis::now(), task_result);
                         continue;
                     } else {
                         panic!("no tasks completed but still loading");
@@ -596,7 +596,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> BeelayWrapper<R> {
         while let Some(event) = self.inbox.pop_front() {
             let results = self
                 .core
-                .handle_event(beelay_core::UnixTimestamp::now(), event)
+                .handle_event(beelay_core::UnixTimestampMillis::now(), event)
                 .unwrap();
             for task in results.new_tasks.into_iter() {
                 let event = self.handle_task(task);


### PR DESCRIPTION
Problem: We have a UnixTimestamp type which represents time as the number of seconds since 1970. This type was originally introduced to be used as the timestamp on messages to avoid replay attacks. In this context second resolution is great. I have since used this type elsewhere for other measurements of time where we _do_ need millisecond precision.

Solution: Add a second UnixTimestampMillis type which represents time as milliseconds since 1970. The reason to introduce a second type is that we still want to use a u64 on the wire and second precision is fine for preventing replay attacks.