### PR TITLE
Beelay session expiry

### DIFF
--- a/beelay/TODO.md
+++ b/beelay/TODO.md
@@ -11,7 +11,6 @@
   * Handle encryption of bundles and commits at the type level
 * Implement ticks
   * On each tick:
-    * Expire old sessions
     * Rerun sync for sessions older than 1 minute
 * Ensure that when a document is loaded we have incorporated any decrypted
 events we received since the load was started into the return value so that

--- a/beelay/beelay-core/src/config.rs
+++ b/beelay/beelay-core/src/config.rs
@@ -5,6 +5,7 @@ use ed25519_dalek::VerifyingKey;
 use crate::loading;
 
 pub struct Config<R> {
+    pub(crate) session_duration: Duration,
     pub(crate) verifying_key: VerifyingKey,
     pub(crate) rng: R,
 }
@@ -12,8 +13,17 @@ pub struct Config<R> {
 impl<R: rand::Rng + rand::CryptoRng> Config<R> {
     pub fn new(rng: R, verifying_key: VerifyingKey) -> Self {
         Config {
+            session_duration: Duration::from_secs(5 * 60),
             verifying_key,
             rng,
+        }
+    }
+
+    pub fn session_duration(self, session_duration: Duration) -> Self {
+        Self {
+            session_duration,
+            rng: self.rng,
+            verifying_key: self.verifying_key,
         }
     }
 }

--- a/beelay/beelay-core/src/event.rs
+++ b/beelay/beelay-core/src/event.rs
@@ -241,6 +241,10 @@ impl Event {
         ));
         (command_id, event)
     }
+
+    pub fn tick() -> Event {
+        Event(EventInner::Tick)
+    }
 }
 
 #[derive(Debug)]
@@ -248,4 +252,5 @@ pub(super) enum EventInner {
     IoComplete(io::IoResult),
     HandleResponse(OutboundRequestId, InnerRpcResponse),
     BeginCommand(CommandId, Command),
+    Tick,
 }

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -130,6 +130,8 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
                 now: spawn_args.now,
                 rx_commands: spawn_args.rx_commands,
                 tx_driver_events: spawn_args.tx_driver_events,
+                rx_tick: spawn_args.rx_tick,
+
                 verifying_key: config.verifying_key,
                 load_complete: tx_load_complete,
             })
@@ -171,6 +173,9 @@ impl<R: rand::Rng + rand::CryptoRng> Beelay<R> {
             }
             EventInner::BeginCommand(command_id, command) => {
                 self.driver.dispatch_command(command_id, command);
+            }
+            EventInner::Tick => {
+                self.driver.tick();
             }
         };
 

--- a/beelay/beelay-core/src/lib.rs
+++ b/beelay/beelay-core/src/lib.rs
@@ -33,10 +33,8 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 pub use auth::audience::Audience;
 mod sync_loops;
 use commands::Command;
-use ed25519_dalek::VerifyingKey;
 use futures::channel::oneshot;
 use io::Signer;
-use keyhive_core::contact_card::ContactCard;
 use network::messages::{Request, Response};
 use serialization::parse;
 use tracing::Instrument;
@@ -134,6 +132,7 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
 
                 verifying_key: config.verifying_key,
                 load_complete: tx_load_complete,
+                session_duration: config.session_duration,
             })
             .instrument(run_span)
         });
@@ -153,6 +152,14 @@ impl<R: rand::Rng + rand::CryptoRng + Clone + 'static> Beelay<R> {
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
+    }
+
+    pub(crate) fn state(&self) -> state::StateAccessor<'_, R> {
+        state::StateAccessor::new(&self.state)
+    }
+
+    pub fn num_sessions(&self) -> usize {
+        self.state().sessions().num_sessions()
     }
 }
 

--- a/beelay/beelay-core/src/network/messages.rs
+++ b/beelay/beelay-core/src/network/messages.rs
@@ -15,6 +15,8 @@ use crate::{
 mod decode;
 mod encode;
 mod encoding_types;
+mod session_response;
+pub(crate) use session_response::SessionResponse;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
@@ -31,15 +33,17 @@ pub(crate) enum Response {
         session_id: crate::sync::SessionId,
         first_symbols: Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>,
     },
-    FetchMembershipSymbols(Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>),
-    DownloadMembershipOps(Vec<StaticEvent<CommitHash>>),
+    FetchMembershipSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>>),
+    DownloadMembershipOps(SessionResponse<Vec<StaticEvent<CommitHash>>>),
     UploadMembershipOps,
-    FetchCgkaSymbols(Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>),
+    FetchCgkaSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>>),
     DownloadCgkaOps(
-        Vec<keyhive_core::crypto::signed::Signed<keyhive_core::cgka::operation::CgkaOperation>>,
+        SessionResponse<
+            Vec<keyhive_core::crypto::signed::Signed<keyhive_core::cgka::operation::CgkaOperation>>,
+        >,
     ),
     UploadCgkaOps,
-    FetchDocStateSymbols(Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>),
+    FetchDocStateSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>>),
 }
 
 impl Parse<'_> for Response {
@@ -85,21 +89,31 @@ impl std::fmt::Display for Response {
                 )
             }
             Response::FetchMembershipSymbols(s) => {
-                write!(f, "FetchMembershipSymbols({} symbols)", s.len())
+                write!(f, "FetchMembershipSymbols(")?;
+                s.fmt_contents(f, |f, contents| write!(f, "{} symbols", contents.len()))?;
+                write!(f, ")")
             }
             Response::DownloadMembershipOps(ops) => {
-                write!(f, "DownloadMembershipOps({} ops)", ops.len())
+                write!(f, "DownloadMembershipOps(")?;
+                ops.fmt_contents(f, |f, contents| write!(f, "{} ops", contents.len()))?;
+                write!(f, ")")
             }
             Response::UploadMembershipOps => write!(f, "UploadMembershipOps"),
             Response::FetchCgkaSymbols(s) => {
-                write!(f, "FetchCgkaSymbols({} symbols)", s.len())
+                write!(f, "FetchCgkaSymbols(")?;
+                s.fmt_contents(f, |f, contents| write!(f, "{} symbols", contents.len()))?;
+                write!(f, ")")
             }
             Response::DownloadCgkaOps(ops) => {
-                write!(f, "DownloadCgkaOps({} ops)", ops.len())
+                write!(f, "DownloadCgkaOps(")?;
+                ops.fmt_contents(f, |f, contents| write!(f, "{} ops", contents.len()))?;
+                write!(f, ")")
             }
             Response::UploadCgkaOps => write!(f, "UploadCgkaOps"),
             Response::FetchDocStateSymbols(s) => {
-                write!(f, "FetchDocStateSymbols({} symbols)", s.len())
+                write!(f, "FetchDocStateSymbols(")?;
+                s.fmt_contents(f, |f, contents| write!(f, "{} symbols", contents.len()))?;
+                write!(f, ")")
             }
         }
     }

--- a/beelay/beelay-core/src/network/messages/decode.rs
+++ b/beelay/beelay-core/src/network/messages/decode.rs
@@ -2,7 +2,6 @@ use keyhive_core::{
     cgka::operation::CgkaOperation,
     crypto::{digest::Digest, signed::Signed},
     event::static_event::StaticEvent,
-    principal::group::membership_operation::StaticMembershipOperation,
 };
 
 use crate::{
@@ -12,7 +11,7 @@ use crate::{
 
 use super::{
     encoding_types::{RequestType, ResponseType},
-    riblt, FetchedSedimentree, UploadItem,
+    riblt, FetchedSedimentree, SessionResponse, UploadItem,
 };
 
 pub(super) fn parse_request(
@@ -184,33 +183,39 @@ pub(crate) fn parse_response(
         }),
         ResponseType::FetchMembershipSymbols => {
             input.parse_in_ctx("FetchMembershipSymbols", |input| {
-                let (input, symbols) =
-                    Vec::<riblt::CodedSymbol<crate::sync::MembershipSymbol>>::parse(input)?;
+                let (input, symbols) = SessionResponse::<
+                    Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>,
+                >::parse(input)?;
                 Ok((input, super::Response::FetchMembershipSymbols(symbols)))
             })
         }
         ResponseType::DownloadMembershipOps => {
             input.parse_in_ctx("DownloadMembershipOps", |input| {
-                let (input, ops) = Vec::<StaticEvent<CommitHash>>::parse(input)?;
+                let (input, ops) = SessionResponse::<Vec<StaticEvent<CommitHash>>>::parse(input)?;
                 Ok((input, super::Response::DownloadMembershipOps(ops)))
             })
         }
         ResponseType::UploadMembershipOps => Ok((input, super::Response::UploadMembershipOps)),
         ResponseType::FetchCgkaSymbols => input.parse_in_ctx("FetchCgkaSymbols", |input| {
             let (input, symbols) =
-                Vec::<riblt::CodedSymbol<crate::sync::CgkaSymbol>>::parse(input)?;
+                SessionResponse::<Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>>::parse(input)?;
             Ok((input, super::Response::FetchCgkaSymbols(symbols)))
         }),
         ResponseType::DownloadCgkaOps => input.parse_in_ctx("DownloadCgkaOps", |input| {
-            let (input, ops) = Vec::<
-                keyhive_core::crypto::signed::Signed<keyhive_core::cgka::operation::CgkaOperation>,
+            let (input, ops) = SessionResponse::<
+                Vec<
+                    keyhive_core::crypto::signed::Signed<
+                        keyhive_core::cgka::operation::CgkaOperation,
+                    >,
+                >,
             >::parse(input)?;
             Ok((input, super::Response::DownloadCgkaOps(ops)))
         }),
         ResponseType::UploadCgkaOps => Ok((input, super::Response::UploadCgkaOps)),
         ResponseType::FetchDocStateSymbols => input.parse_in_ctx("FetchDocStateSymbols", |input| {
-            let (input, symbols) =
-                Vec::<riblt::CodedSymbol<crate::sync::DocStateHash>>::parse(input)?;
+            let (input, symbols) = SessionResponse::<
+                Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>,
+            >::parse(input)?;
             Ok((input, super::Response::FetchDocStateSymbols(symbols)))
         }),
         ResponseType::UploadBlob => Ok((input, super::Response::UploadBlob)),

--- a/beelay/beelay-core/src/network/messages/session_response.rs
+++ b/beelay/beelay-core/src/network/messages/session_response.rs
@@ -1,0 +1,75 @@
+use std::fmt;
+
+use crate::{
+    parse::{self, Parse},
+    serialization::Encode,
+    sync::sessions::SessionError,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+pub(crate) enum SessionResponse<R> {
+    Ok(R),
+    SessionNotFound,
+    SessionExpired,
+}
+
+impl<R> SessionResponse<R> {
+    pub(super) fn fmt_contents<F: Fn(&mut fmt::Formatter, &R) -> fmt::Result>(
+        &self,
+        formatter: &mut fmt::Formatter,
+        f: F,
+    ) -> fmt::Result {
+        match self {
+            SessionResponse::Ok(response) => f(formatter, response),
+            SessionResponse::SessionNotFound => write!(formatter, "Session not found"),
+            SessionResponse::SessionExpired => write!(formatter, "Session expired"),
+        }
+    }
+}
+
+const OK_CODE: u8 = 1;
+const NOT_FOUND_CODE: u8 = 2;
+const EXPIRED_CODE: u8 = 3;
+
+impl<R: Encode> Encode for SessionResponse<R> {
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        match self {
+            Self::Ok(r) => {
+                out.push(OK_CODE);
+                r.encode_into(out);
+            }
+            Self::SessionNotFound => {
+                out.push(NOT_FOUND_CODE);
+            }
+            Self::SessionExpired => {
+                out.push(EXPIRED_CODE);
+            }
+        }
+    }
+}
+
+impl<'a, R: Parse<'a>> Parse<'a> for SessionResponse<R> {
+    fn parse(input: parse::Input<'a>) -> Result<(parse::Input<'a>, Self), parse::ParseError> {
+        let (input, tag) = parse::u8(input)?;
+        match tag {
+            OK_CODE => {
+                let (input, response) = R::parse(input)?;
+                Ok((input, SessionResponse::Ok(response)))
+            }
+            NOT_FOUND_CODE => Ok((input, SessionResponse::SessionNotFound)),
+            EXPIRED_CODE => Ok((input, SessionResponse::SessionExpired)),
+            other => Err(input.error(format!("unknown success response tag: {}", other))),
+        }
+    }
+}
+
+impl<R> From<Result<R, SessionError>> for SessionResponse<R> {
+    fn from(result: Result<R, SessionError>) -> Self {
+        match result {
+            Ok(response) => SessionResponse::Ok(response),
+            Err(SessionError::NotFound) => SessionResponse::SessionNotFound,
+            Err(SessionError::Expired) => SessionResponse::SessionExpired,
+        }
+    }
+}

--- a/beelay/beelay-core/src/state/sessions.rs
+++ b/beelay/beelay-core/src/state/sessions.rs
@@ -3,11 +3,10 @@ use std::{borrow::Cow, cell::RefCell, rc::Rc};
 use crate::{
     riblt,
     sync::{
-        local_state::LocalState,
-        server_session::{MakeSymbols, Session},
-        CgkaSymbol, DocStateHash, MembershipSymbol, SessionId,
+        local_state::LocalState, server_session::MakeSymbols, sessions::SessionError, CgkaSymbol,
+        DocStateHash, MembershipSymbol, SessionId,
     },
-    DocumentId,
+    DocumentId, UnixTimestampMillis,
 };
 
 use keyhive_core::{crypto::digest::Digest, event::static_event::StaticEvent};
@@ -24,34 +23,19 @@ impl<'a, R: rand::Rng + rand::CryptoRng> Sessions<'a, R> {
     /// Create a new sync session and return the session ID and initial membership symbols
     pub(crate) fn create_session(
         &self,
+        now: UnixTimestampMillis,
         local_state: LocalState,
         // ctx: crate::TaskContext<R>,
     ) -> Result<
         (SessionId, Vec<riblt::CodedSymbol<MembershipSymbol>>),
         crate::sync::local_state::Error,
     > {
-        // Create a new session ID
-        let session_id = {
-            let state_ref = RefCell::borrow_mut(&self.state);
-            let mut rng_ref = state_ref.rng.borrow_mut();
-            SessionId::new(&mut *rng_ref)
-        };
-
-        // Create a ServerSession from the LocalState
-        let mut session = Session::new(local_state);
-
-        // Generate initial membership symbols
-        let first_symbols = session.membership_symbols(MakeSymbols {
-            offset: 0,
-            count: 10,
-        });
-
-        // Store the session
-        RefCell::borrow_mut(&self.state)
+        let rng = self.state.borrow().rng.clone();
+        let mut state = self.state.borrow_mut();
+        let result = state
             .sync_sessions
-            .insert(session_id, session);
-
-        Ok((session_id, first_symbols))
+            .create(&mut *rng.borrow_mut(), now, local_state);
+        Ok(result)
     }
 
     /// Get membership symbols for a session
@@ -59,12 +43,11 @@ impl<'a, R: rand::Rng + rand::CryptoRng> Sessions<'a, R> {
         &self,
         session_id: &SessionId,
         make_symbols: MakeSymbols,
-    ) -> Option<Vec<riblt::CodedSymbol<MembershipSymbol>>> {
-        let mut state = RefCell::borrow_mut(&self.state);
-        state
+    ) -> Result<Vec<riblt::CodedSymbol<MembershipSymbol>>, SessionError> {
+        self.state
+            .borrow_mut()
             .sync_sessions
-            .get_mut(session_id)
-            .map(|session| session.membership_symbols(make_symbols))
+            .membership_symbols(session_id, make_symbols)
     }
 
     /// Get document state symbols for a session
@@ -72,12 +55,11 @@ impl<'a, R: rand::Rng + rand::CryptoRng> Sessions<'a, R> {
         &self,
         session_id: &SessionId,
         make_symbols: MakeSymbols,
-    ) -> Option<Vec<riblt::CodedSymbol<DocStateHash>>> {
-        let mut state = RefCell::borrow_mut(&self.state);
-        state
+    ) -> Result<Vec<riblt::CodedSymbol<DocStateHash>>, SessionError> {
+        self.state
+            .borrow_mut()
             .sync_sessions
-            .get_mut(session_id)
-            .map(|session| session.collection_state_symbols(make_symbols))
+            .doc_state_symbols(session_id, make_symbols)
     }
 
     /// Get CGKA symbols for a document in a session
@@ -86,12 +68,11 @@ impl<'a, R: rand::Rng + rand::CryptoRng> Sessions<'a, R> {
         session_id: &SessionId,
         doc_id: &DocumentId,
         make_symbols: MakeSymbols,
-    ) -> Option<Vec<riblt::CodedSymbol<CgkaSymbol>>> {
-        let mut state = RefCell::borrow_mut(&self.state);
-        state
+    ) -> Result<Vec<riblt::CodedSymbol<CgkaSymbol>>, SessionError> {
+        self.state
+            .borrow_mut()
             .sync_sessions
-            .get_mut(session_id)
-            .map(|session| session.doc_cgka_symbols(doc_id, make_symbols))
+            .cgka_symbols(session_id, doc_id, make_symbols)
     }
 
     /// Get membership operations for given hashes from a session
@@ -99,18 +80,23 @@ impl<'a, R: rand::Rng + rand::CryptoRng> Sessions<'a, R> {
         &self,
         session_id: &SessionId,
         op_hashes: Vec<Digest<StaticEvent<crate::CommitHash>>>,
-    ) -> Option<Vec<StaticEvent<crate::CommitHash>>> {
-        let mut state = RefCell::borrow_mut(&self.state);
-        state
+    ) -> Result<Vec<StaticEvent<crate::CommitHash>>, SessionError> {
+        self.state
+            .borrow_mut()
             .sync_sessions
-            .get_mut(session_id)
-            .map(|session| session.membership_and_prekey_ops(op_hashes))
+            .get_membership_ops(session_id, op_hashes)
     }
 
     /// Check if a session exists
     pub(crate) fn session_exists(&self, session_id: &SessionId) -> bool {
-        RefCell::borrow(&self.state)
-            .sync_sessions
-            .contains_key(session_id)
+        self.state.borrow().sync_sessions.session_exists(session_id)
+    }
+
+    pub(crate) fn expire_sessions(&self, now: UnixTimestampMillis) {
+        self.state.borrow_mut().sync_sessions.expire_sessions(now);
+    }
+
+    pub(crate) fn num_sessions(&self) -> usize {
+        self.state.borrow().sync_sessions.num_sessions()
     }
 }

--- a/beelay/beelay-core/src/sync/sessions.rs
+++ b/beelay/beelay-core/src/sync/sessions.rs
@@ -1,0 +1,169 @@
+use std::{
+    collections::{BinaryHeap, HashMap, HashSet},
+    time::Duration,
+};
+
+use keyhive_core::{crypto::digest::Digest, event::static_event::StaticEvent};
+
+use crate::{riblt, DocumentId, UnixTimestampMillis};
+
+mod expiry_key;
+use expiry_key::ExpiryKey;
+
+use super::{
+    server_session::{MakeSymbols, Session},
+    CgkaSymbol, DocStateHash, LocalState, MembershipSymbol, SessionId,
+};
+
+pub(crate) struct Sessions {
+    session_duration: Duration,
+    sessions: HashMap<SessionId, Session>,
+    sessions_by_expiry: BinaryHeap<ExpiryKey>,
+    expired_sessions_by_expiry: BinaryHeap<ExpiryKey>,
+    expired_sessions: HashSet<SessionId>,
+}
+
+impl Sessions {
+    pub(crate) fn new(session_timeout: Duration) -> Self {
+        Self {
+            session_duration: session_timeout,
+            sessions: HashMap::new(),
+            sessions_by_expiry: BinaryHeap::new(),
+            expired_sessions_by_expiry: BinaryHeap::new(),
+            expired_sessions: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn create<R: rand::Rng>(
+        &mut self,
+        rng: &mut R,
+        now: UnixTimestampMillis,
+        local_state: LocalState,
+    ) -> (SessionId, Vec<riblt::CodedSymbol<MembershipSymbol>>) {
+        let session_id = SessionId::new(rng);
+
+        let mut session = Session::new(local_state);
+
+        let first_symbols = session.membership_symbols(MakeSymbols {
+            offset: 0,
+            count: 10,
+        });
+
+        self.sessions.insert(session_id, session);
+
+        let expiry_key = ExpiryKey {
+            session_id,
+            expires_at: now + self.session_duration,
+        };
+        self.sessions_by_expiry.push(expiry_key);
+
+        (session_id, first_symbols)
+    }
+
+    /// Get membership symbols for a session
+    pub(crate) fn membership_symbols(
+        &mut self,
+        session_id: &SessionId,
+        make_symbols: MakeSymbols,
+    ) -> Result<Vec<riblt::CodedSymbol<MembershipSymbol>>, SessionError> {
+        Ok(self
+            .get_session(session_id)?
+            .membership_symbols(make_symbols))
+    }
+
+    /// Get document state symbols for a session
+    pub(crate) fn doc_state_symbols(
+        &mut self,
+        session_id: &SessionId,
+        make_symbols: MakeSymbols,
+    ) -> Result<Vec<riblt::CodedSymbol<DocStateHash>>, SessionError> {
+        Ok(self
+            .get_session(session_id)?
+            .collection_state_symbols(make_symbols))
+    }
+
+    /// Get CGKA symbols for a document in a session
+    pub(crate) fn cgka_symbols(
+        &mut self,
+        session_id: &SessionId,
+        doc_id: &DocumentId,
+        make_symbols: MakeSymbols,
+    ) -> Result<Vec<riblt::CodedSymbol<CgkaSymbol>>, SessionError> {
+        Ok(self
+            .get_session(session_id)?
+            .doc_cgka_symbols(doc_id, make_symbols))
+    }
+
+    /// Get membership operations for given hashes from a session
+    pub(crate) fn get_membership_ops(
+        &mut self,
+        session_id: &SessionId,
+        op_hashes: Vec<Digest<StaticEvent<crate::CommitHash>>>,
+    ) -> Result<Vec<StaticEvent<crate::CommitHash>>, SessionError> {
+        Ok(self
+            .get_session(session_id)?
+            .membership_and_prekey_ops(op_hashes))
+    }
+
+    pub(crate) fn session_exists(&self, session_id: &SessionId) -> bool {
+        self.sessions.contains_key(session_id)
+    }
+
+    pub(crate) fn expire_sessions(&mut self, now: UnixTimestampMillis) {
+        // When we expire sessions we remove them from the active sessions but
+        // we retain them in the expired sessions list for some time so that we
+        // can return a message saying that a session has expired. The idea is
+        // to make it easier to decide whether to retry or bail on the client
+        // side.
+
+        // First expire active sessions
+        while let Some(expiry_key) = self.sessions_by_expiry.peek() {
+            if expiry_key.expires_at <= now {
+                let key = self.sessions_by_expiry.pop().expect("we just peeked this");
+                tracing::trace!(session_id = %key.session_id, "expiring session");
+                self.sessions.remove(&key.session_id);
+                self.expired_sessions.insert(key.session_id);
+                self.expired_sessions_by_expiry.push(key);
+            } else {
+                break;
+            }
+        }
+
+        // Now remove old expired session keys
+        const EXPIRED_SESSIONS_RETENTION: Duration = Duration::from_secs(60);
+        while let Some(expiry_key) = self.expired_sessions_by_expiry.peek() {
+            if expiry_key.expires_at <= now + EXPIRED_SESSIONS_RETENTION {
+                let key = self
+                    .expired_sessions_by_expiry
+                    .pop()
+                    .expect("we just peeked this");
+                self.expired_sessions.remove(&key.session_id);
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub(crate) fn num_sessions(&self) -> usize {
+        self.sessions.len()
+    }
+
+    fn get_session(&mut self, session_id: &SessionId) -> Result<&mut Session, SessionError> {
+        if let Some(session) = self.sessions.get_mut(&session_id) {
+            return Ok(session);
+        };
+        if self.expired_sessions.contains(&session_id) {
+            Err(SessionError::Expired)
+        } else {
+            Err(SessionError::NotFound)
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SessionError {
+    #[error("session not found")]
+    NotFound,
+    #[error("session expired")]
+    Expired,
+}

--- a/beelay/beelay-core/src/sync/sessions/expiry_key.rs
+++ b/beelay/beelay-core/src/sync/sessions/expiry_key.rs
@@ -1,0 +1,29 @@
+use std::cmp::Ordering;
+
+use crate::{sync::SessionId, UnixTimestampMillis};
+
+pub(super) struct ExpiryKey {
+    pub(super) expires_at: UnixTimestampMillis,
+    pub(super) session_id: SessionId,
+}
+
+impl Ord for ExpiryKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Invert the order because we want the oldest item to be first in the heap
+        other.expires_at.cmp(&self.expires_at)
+    }
+}
+
+impl PartialOrd for ExpiryKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for ExpiryKey {}
+
+impl PartialEq for ExpiryKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.expires_at == other.expires_at
+    }
+}

--- a/beelay/beelay-core/src/sync/sync_doc.rs
+++ b/beelay/beelay-core/src/sync/sync_doc.rs
@@ -31,6 +31,20 @@ pub(crate) mod error {
         #[error(transparent)]
         Sedimentree(#[from] super::sync_sedimentree::SyncSedimentreeError),
         #[error(transparent)]
-        Cgka(#[from] super::sync_cgka::SyncCgkaError),
+        Cgka(super::sync_cgka::SyncCgkaError),
+        #[error("session expired")]
+        SessionExpired,
+        #[error("session not found")]
+        SessionNotFound,
+    }
+
+    impl From<super::sync_cgka::SyncCgkaError> for SyncDocError {
+        fn from(err: super::sync_cgka::SyncCgkaError) -> Self {
+            match err {
+                super::sync_cgka::SyncCgkaError::SessionExpired => Self::SessionExpired,
+                super::sync_cgka::SyncCgkaError::SessionNotFound => Self::SessionNotFound,
+                other => Self::Cgka(other),
+            }
+        }
     }
 }

--- a/beelay/beelay-core/src/task_context/requests.rs
+++ b/beelay/beelay-core/src/task_context/requests.rs
@@ -8,7 +8,7 @@ use keyhive_core::{
 use crate::{
     auth,
     network::{
-        messages::{self, Response},
+        messages::{self, Response, SessionResponse},
         InnerRpcResponse, PeerAddress, RpcError,
     },
     riblt::{self},
@@ -146,8 +146,12 @@ where
         from_peer: PeerAddress,
         session: crate::sync::SessionId,
         MakeSymbols { count, offset }: MakeSymbols,
-    ) -> impl Future<Output = Result<Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>, RpcError>>
-           + 'static {
+    ) -> impl Future<
+        Output = Result<
+            SessionResponse<Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>>,
+            RpcError,
+        >,
+    > + 'static {
         let request = crate::Request::FetchDocStateSymbols {
             session_id: session,
             count,
@@ -168,8 +172,12 @@ where
         from_peer: PeerAddress,
         session_id: crate::sync::SessionId,
         MakeSymbols { count, offset }: MakeSymbols,
-    ) -> impl Future<Output = Result<Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>, RpcError>>
-           + 'static {
+    ) -> impl Future<
+        Output = Result<
+            SessionResponse<Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>>,
+            RpcError,
+        >,
+    > + 'static {
         let request = crate::Request::FetchMembershipSymbols {
             session_id,
             count,
@@ -190,7 +198,8 @@ where
         from_peer: PeerAddress,
         session_id: crate::sync::SessionId,
         op_hashes: Vec<Digest<StaticEvent<CommitHash>>>,
-    ) -> impl Future<Output = Result<Vec<StaticEvent<CommitHash>>, RpcError>> + 'static {
+    ) -> impl Future<Output = Result<SessionResponse<Vec<StaticEvent<CommitHash>>>, RpcError>> + 'static
+    {
         let request = crate::Request::DownloadMembershipOps {
             session_id,
             op_hashes,
@@ -228,8 +237,12 @@ where
         session_id: crate::sync::SessionId,
         doc_id: DocumentId,
         MakeSymbols { count, offset }: MakeSymbols,
-    ) -> impl Future<Output = Result<Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>, RpcError>> + 'static
-    {
+    ) -> impl Future<
+        Output = Result<
+            SessionResponse<Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>>,
+            RpcError,
+        >,
+    > + 'static {
         let request = crate::Request::FetchCgkaSymbols {
             doc_id,
             session_id,
@@ -253,7 +266,10 @@ where
         doc_id: DocumentId,
         op_hashes: Vec<Digest<keyhive_core::crypto::signed::Signed<CgkaOperation>>>,
     ) -> impl Future<
-        Output = Result<Vec<keyhive_core::crypto::signed::Signed<CgkaOperation>>, RpcError>,
+        Output = Result<
+            SessionResponse<Vec<keyhive_core::crypto::signed::Signed<CgkaOperation>>>,
+            RpcError,
+        >,
     > + 'static {
         let request = crate::Request::DownloadCgkaOps {
             session_id,
@@ -401,14 +417,16 @@ enum NonErrorPayload {
         session_id: crate::sync::SessionId,
         first_symbols: Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>,
     },
-    FetchMembershipSymbols(Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>),
-    DownloadMembershipOps(Vec<StaticEvent<CommitHash>>),
+    FetchMembershipSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::MembershipSymbol>>>),
+    DownloadMembershipOps(SessionResponse<Vec<StaticEvent<CommitHash>>>),
     UploadMembershipOps,
-    FetchCgkaSymbols(Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>),
+    FetchCgkaSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::CgkaSymbol>>>),
     DownloadCgkaOps(
-        Vec<keyhive_core::crypto::signed::Signed<keyhive_core::cgka::operation::CgkaOperation>>,
+        SessionResponse<
+            Vec<keyhive_core::crypto::signed::Signed<keyhive_core::cgka::operation::CgkaOperation>>,
+        >,
     ),
-    FetchDocStateSymbols(Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>),
+    FetchDocStateSymbols(SessionResponse<Vec<riblt::CodedSymbol<crate::sync::DocStateHash>>>),
     UploadCgkaOps,
 }
 

--- a/beelay/beelay-core/tests/sessions.rs
+++ b/beelay/beelay-core/tests/sessions.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use beelay_core::UnixTimestampMillis;
+use network::Network;
+use test_utils::init_logging;
+
+mod network;
+
+#[test]
+fn sessions_are_expired() {
+    init_logging();
+    tracing::trace!(time=?UnixTimestampMillis::now(), "time at start");
+    let mut network = Network::new();
+    let client = network.create_peer("client").build();
+    let server = network
+        .create_peer("server")
+        .session_duration(Duration::from_secs(1))
+        .build();
+
+    assert_eq!(network.beelay(&server).num_sessions(), 0);
+
+    network.connect_stream(&client, &server);
+
+    assert_eq!(network.beelay(&server).num_sessions(), 1);
+
+    network.beelay(&server).advance_time(Duration::from_secs(2));
+    assert_eq!(network.beelay(&server).num_sessions(), 0);
+}


### PR DESCRIPTION
Problem: So far sessions live forever. Session state is not large, it's mostly a bunch of pointers to parts of the keyhive, but obviously we still don't want an unbounded number of them.

Solution: expire sessions after a configurable timeout. This introduces the question of how to handle requests for sessions which have timed out. The simplest option is to treat this the same as a request for a session which does not exist and return an error. This seems like it would make things harder to debug though, session timeouts will occur during normal operation and we would probably like clients to retry. On the other hand, if there is some error on either end and the session ID just doesn't exist, it would be nice to be able to detect this and bail. To accomodate this workflow we retain the IDs of expired sessions for 5 minutes and return a SessionExpired error if a client requests an expired session.
