### PR TITLE
Causal Decryption ⏳🔀🔓

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/inkandswitch/keyhive"
-rust-version = "1.83.0"
+rust-version = "1.85.0"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/beelay/beelay-core/src/state/keyhive.rs
+++ b/beelay/beelay-core/src/state/keyhive.rs
@@ -565,7 +565,7 @@ impl<'a, R: rand::Rng + rand::CryptoRng> KeyhiveCtx<'a, R> {
             wrapper.ciphertext,
             wrapper.pcs_key_hash,
             wrapper.pcs_update_op_hash,
-            Digest::hash(&hash),
+            hash,
             Digest::hash(&parents.to_vec()),
         );
 
@@ -613,7 +613,7 @@ impl<'a, R: rand::Rng + rand::CryptoRng> KeyhiveCtx<'a, R> {
                 wrapper.ciphertext,
                 wrapper.pcs_key_hash,
                 wrapper.pcs_update_op_hash,
-                Digest::hash(&hash),
+                hash,
                 Digest::hash(&parents.to_vec()),
             );
 

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1741024097,
-        "narHash": "sha256-FajasIJupTJiZefbz7c79nNOCuYdJ69nfXNjGSene6Q=",
+        "lastModified": 1742230170,
+        "narHash": "sha256-BEny83HblVcCGgSG3NHljafuWQE6+yP8XNUIydsIyoA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "789d5d063318f3897eca448abb2e6f658de1d6fc",
+        "rev": "0f80da4f5e0dbe1f917f6f3643a262bae7dbb34e",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1740932899,
-        "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
+        "lastModified": 1742136038,
+        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1546c45c538633ae40b93e2d14e0bb6fd8f13347",
+        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740969088,
-        "narHash": "sha256-BajboqzFnDhxVT0SXTDKVJCKtFP96lZXccBlT/43mao=",
+        "lastModified": 1742178793,
+        "narHash": "sha256-S2onMdoDS4tIYd3/Jc5oFEZBr2dJOgPrh9KzSO/bfDw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fdb02098fdda9a25a2939b975abdd7bc03f62d",
+        "rev": "954582a766a50ebef5695a9616c93b5386418c08",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,9 @@
           config.allowUnfree = true;
         };
 
-        rustVersion = "1.83.0";
+        rustVersion = "1.85.0";
 
-        rust-toolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+        rust-toolchain = unstable.rust-bin.stable.${rustVersion}.default.override {
           extensions = [
             "cargo"
             "clippy"
@@ -59,7 +59,6 @@
             "aarch64-unknown-linux-musl"
 
             "wasm32-unknown-unknown"
-            "wasm32-wasi"
           ];
         };
 
@@ -91,7 +90,7 @@
           wasm-tools
         ];
 
-        cargo = "${pkgs.cargo}/bin/cargo";
+        cargo = "${unstable.cargo}/bin/cargo";
         gzip = "${pkgs.gzip}/bin/gzip";
         node = "${unstable.nodejs_20}/bin/node";
         pnpm = "${unstable.pnpm}/bin/pnpm";

--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -47,9 +47,6 @@ proptest-derive = { version = "0.5.0", optional = true }
 arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 prettytable-rs = { version = "0.10.0", optional = true }
 
-# FIXME REMOVE ME
-tokio = { version = "1.43", features = ["macros", "rt", "sync"] }
-
 [dev-dependencies]
 keyhive_core = { path = ".", features = ["test_utils", "debug_events"] }
 
@@ -65,8 +62,10 @@ hex = "0.4.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [features]
+default = []
 debug_events = ["prettytable-rs"]
 mermaid_docs = ["aquamarine"]
+sendable = []
 test_utils = ["proptest", "proptest-derive"]
 
 [[bench]]

--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -47,6 +47,9 @@ proptest-derive = { version = "0.5.0", optional = true }
 arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 prettytable-rs = { version = "0.10.0", optional = true }
 
+# FIXME REMOVE ME
+tokio = { version = "1.43", features = ["macros", "rt", "sync"] }
+
 [dev-dependencies]
 keyhive_core = { path = ".", features = ["test_utils", "debug_events"] }
 

--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -39,6 +39,7 @@ futures = { workspace = true }
 nonempty = { workspace = true }
 topological-sort = "0.2"
 tracing = { workspace = true }
+trait-variant = "0.1.2"
 
 # Testing
 proptest = { version = "1.5", optional = true }

--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -67,7 +67,6 @@ mermaid_docs = ["aquamarine"]
 test_utils = ["proptest", "proptest-derive"]
 
 [[bench]]
-
 name = "bench_cgka"
 harness = false
 required-features = ["test_utils"]

--- a/keyhive_core/src/cgka.rs
+++ b/keyhive_core/src/cgka.rs
@@ -173,7 +173,7 @@ impl Cgka {
         Ok((
             current_pcs_key.derive_application_secret(
                 &nonce,
-                &Digest::hash(content_ref),
+                &content_ref,
                 &Digest::hash(pred_refs),
                 self.pcs_key_ops
                     .get(&pcs_key_hash)

--- a/keyhive_core/src/content/reference.rs
+++ b/keyhive_core/src/content/reference.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
-pub trait ContentRef: Debug + Serialize + Clone + Eq + PartialOrd + std::hash::Hash {}
-impl<T: Debug + Serialize + Clone + Eq + PartialOrd + std::hash::Hash> ContentRef for T {}
+pub trait ContentRef: Debug + Serialize + Clone + Eq + PartialOrd + Hash {}
+impl<T: Debug + Serialize + Clone + Eq + PartialOrd + Hash> ContentRef for T {}

--- a/keyhive_core/src/crypto/encrypted.rs
+++ b/keyhive_core/src/crypto/encrypted.rs
@@ -27,7 +27,7 @@ pub struct EncryptedContent<T, Cr: ContentRef> {
     /// Hash of the PCS update operation corresponding to the PCS key
     pub pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
     /// The content ref hash used to derive the application secret for encrypting.
-    pub content_ref: Digest<Cr>, // FIXME make obsfucating hash?
+    pub content_ref: Cr,
     /// The predecessor content ref hashes used to derive the application secret
     /// for encrypting.
     pub pred_refs: Digest<Vec<Cr>>,
@@ -42,7 +42,7 @@ impl<T, Cr: ContentRef> EncryptedContent<T, Cr> {
         ciphertext: Vec<u8>,
         pcs_key_hash: Digest<PcsKey>,
         pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
-        content_ref: Digest<Cr>,
+        content_ref: Cr,
         pred_refs: Digest<Vec<Cr>>,
     ) -> EncryptedContent<T, Cr> {
         EncryptedContent {

--- a/keyhive_core/src/crypto/encrypted.rs
+++ b/keyhive_core/src/crypto/encrypted.rs
@@ -23,7 +23,7 @@ pub struct EncryptedContent<T, Cr: ContentRef> {
     /// The encrypted data.
     pub ciphertext: Vec<u8>,
     /// Hash of the PCS key used to derive the application secret for encrypting.
-    pub pcs_key_hash: Digest<PcsKey>,
+    pub pcs_key_hash: Digest<PcsKey>, // FIXME use pubkey instead of hash?
     /// Hash of the PCS update operation corresponding to the PCS key
     pub pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
     /// The content ref hash used to derive the application secret for encrypting.

--- a/keyhive_core/src/crypto/encrypted.rs
+++ b/keyhive_core/src/crypto/encrypted.rs
@@ -3,20 +3,14 @@
 use super::{
     application_secret::PcsKey,
     digest::Digest,
-    envelope::Envelope,
     share_key::{ShareKey, ShareSecretKey},
     signed::Signed,
     siv::Siv,
     symmetric_key::SymmetricKey,
 };
 use crate::{cgka::operation::CgkaOperation, content::reference::ContentRef};
-use nonempty::{nonempty, NonEmpty};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    marker::PhantomData,
-};
-use thiserror::Error;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 
 /// The public information for an encrypted content ciphertext.
 ///
@@ -67,39 +61,6 @@ impl<T, Cr: ContentRef> EncryptedContent<T, Cr> {
         key.try_decrypt(self.nonce, &mut buf)?;
         Ok(buf)
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct CausalDecryptionState<T, Cr: ContentRef> {
-    pub complete: Vec<(Digest<Cr>, T)>,
-    pub keys: HashMap<Digest<Cr>, SymmetricKey>,
-    pub next: HashMap<Digest<Cr>, SymmetricKey>,
-}
-
-impl<T, Cr: ContentRef> CausalDecryptionState<T, Cr> {
-    pub fn new() -> Self {
-        CausalDecryptionState {
-            complete: vec![],
-            keys: HashMap::new(),
-            next: HashMap::new(),
-        }
-    }
-}
-
-#[derive(Debug, Error)]
-#[error("Causal decryption error: {cannot}")]
-pub struct CausalDecryptionError<T, Cr: ContentRef> {
-    pub cannot: HashMap<Digest<Cr>, Reason>,
-    pub progress: CausalDecryptionState<T, Cr>,
-}
-
-#[derive(Debug, Error)]
-pub enum Reason {
-    #[error("Decryption failed")]
-    DecryptionFailed(SymmetricKey),
-
-    #[error(transparent)]
-    DeserializationFailed(Box<bincode::Error>),
 }
 
 /// The public information for an encrypted secret ciphertext.

--- a/keyhive_core/src/crypto/encrypted.rs
+++ b/keyhive_core/src/crypto/encrypted.rs
@@ -10,8 +10,13 @@ use super::{
     symmetric_key::SymmetricKey,
 };
 use crate::{cgka::operation::CgkaOperation, content::reference::ContentRef};
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, marker::PhantomData};
+use nonempty::{nonempty, NonEmpty};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    marker::PhantomData,
+};
+use thiserror::Error;
 
 /// The public information for an encrypted content ciphertext.
 ///
@@ -28,7 +33,7 @@ pub struct EncryptedContent<T, Cr: ContentRef> {
     /// Hash of the PCS update operation corresponding to the PCS key
     pub pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
     /// The content ref hash used to derive the application secret for encrypting.
-    pub content_ref: Digest<Cr>,
+    pub content_ref: Digest<Cr>, // FIXME make obsfucating hash?
     /// The predecessor content ref hashes used to derive the application secret
     /// for encrypting.
     pub pred_refs: Digest<Vec<Cr>>,
@@ -62,30 +67,39 @@ impl<T, Cr: ContentRef> EncryptedContent<T, Cr> {
         key.try_decrypt(self.nonce, &mut buf)?;
         Ok(buf)
     }
+}
 
-    pub fn try_causal_decrypt<'de>(
-        &self,
-        key: SymmetricKey,
-        store: HashMap<Digest<Cr>, Self>, // FIXME make a storgae trait
-    ) -> Result<(), chacha20poly1305::Error>
-    where
-        T: Serialize + Deserialize<'de>,
-        Cr: Deserialize<'de>,
-    {
-        let mut buf: Vec<u8> = self.ciphertext.clone();
-        key.try_decrypt(self.nonce, &mut buf)?;
-        let envelope: Envelope<Cr, T> = bincode::deserialize(buf.as_slice())?;
+#[derive(Debug, Clone)]
+pub struct CausalDecryptionState<T, Cr: ContentRef> {
+    pub complete: Vec<(Digest<Cr>, T)>,
+    pub keys: HashMap<Digest<Cr>, SymmetricKey>,
+    pub next: HashMap<Digest<Cr>, SymmetricKey>,
+}
 
-        fn inner_fn() {}
-
-        for (ancestor_id, ancestor_key) in envelope.ancestors {
-            if let Some(ciphertext) = store.get(&ancestor_id) {
-                ciphertext.try_causal_decrypt(ancestor_key, store.clone())?;
-            }
+impl<T, Cr: ContentRef> CausalDecryptionState<T, Cr> {
+    pub fn new() -> Self {
+        CausalDecryptionState {
+            complete: vec![],
+            keys: HashMap::new(),
+            next: HashMap::new(),
         }
-
-        Ok(())
     }
+}
+
+#[derive(Debug, Error)]
+#[error("Causal decryption error: {cannot}")]
+pub struct CausalDecryptionError<T, Cr: ContentRef> {
+    pub cannot: HashMap<Digest<Cr>, Reason>,
+    pub progress: CausalDecryptionState<T, Cr>,
+}
+
+#[derive(Debug, Error)]
+pub enum Reason {
+    #[error("Decryption failed")]
+    DecryptionFailed(SymmetricKey),
+
+    #[error(transparent)]
+    DeserializationFailed(Box<bincode::Error>),
 }
 
 /// The public information for an encrypted secret ciphertext.

--- a/keyhive_core/src/store.rs
+++ b/keyhive_core/src/store.rs
@@ -1,4 +1,5 @@
 //! Top-level storage.
 
+pub mod ciphertext;
 pub mod delegation;
 pub mod revocation;

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -1,0 +1,64 @@
+use crate::{
+    content::reference::ContentRef,
+    crypto::{
+        digest::Digest,
+        encrypted::{CausalDecryptionError, CausalDecryptionState, EncryptedContent, Reason},
+        envelope::Envelope,
+        symmetric_key::SymmetricKey,
+    },
+};
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::{HashMap, HashSet};
+
+// FIXME feature flag
+#[trait_variant::make(SendableCiphertextStore: Send)]
+pub trait CiphertextStore<T: Send, Cr: ContentRef + Send> {
+    async fn get(&self, id: &Digest<Cr>) -> Option<EncryptedContent<T, Cr>>;
+
+    async fn try_causal_decrypt(
+        &self,
+        to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
+    ) -> Result<CausalDecryptionState<T, Cr>, CausalDecryptionError<T, Cr>>
+    where
+        T: Serialize + DeserializeOwned + Clone,
+        Cr: DeserializeOwned,
+    {
+        let mut acc = CausalDecryptionState::new();
+        let mut seen = HashSet::new();
+
+        while let Some((ciphertext, key)) = to_decrypt.pop() {
+            if !seen.insert(ciphertext.content_ref) {
+                continue;
+            }
+
+            if let Ok(decrypted) = ciphertext.try_decrypt(key) {
+                let envelope: Envelope<Cr, T> = bincode::deserialize(decrypted.as_slice())
+                    .map_err(|e| CausalDecryptionError {
+                        progress: acc.clone(),
+                        cannot: HashMap::from_iter([(
+                            ciphertext.content_ref,
+                            Reason::DeserializationFailed(e.into()),
+                        )]),
+                    })?;
+
+                for (ancestor_hash, ancestor_key) in envelope.ancestors.iter() {
+                    let ancestor = self.get(&Digest::hash(ancestor_hash)).await.expect("FIXME");
+                    to_decrypt.push((ancestor, *ancestor_key));
+                }
+
+                acc.complete
+                    .push((ciphertext.content_ref, envelope.plaintext));
+            } else {
+                Err(CausalDecryptionError {
+                    progress: acc.clone(),
+                    cannot: HashMap::from_iter([(
+                        ciphertext.content_ref,
+                        Reason::DecryptionFailed(key),
+                    )]),
+                })?;
+            }
+        }
+
+        Ok(acc)
+    }
+}

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -80,41 +80,6 @@ use thiserror::Error;
 /// ```
 ///
 /// There are `!Send` and `Send` variants: if you need `Send`, enable the `sendable` feature.
-///
-/// # `!Send` Implementations
-///
-/// A `!Send` implementation is available on [`HashMap`]:
-///
-/// ```rust
-/// impl<T: Clone, Cr: ContentRef> CiphertextStore<T, Cr> for HashMap<Cr, EncryptedContent<T, Cr>> {
-///     type WorkFuture<'a>
-///         = NonSendWorkFuture<'a, dyn Future<Output = Option<EncryptedContent<T, Cr>>>>
-///     where
-///         Self: 'a,
-///         Cr: 'a;
-///
-///     fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
-///         HashMap::get(self, id).cloned()
-///     }
-/// }
-/// ```
-///
-/// # `Send` Implementations
-///
-/// In many ways, `Send` implementations are closer to what you'd expect:
-///
-/// ```rust
-/// #[derive(Debug, Clone)]
-/// struct Foo<T: Send, Cr: ContentRef + Send + Sync>(
-///     Arc<tokio::sync::Mutex<HashMap<Cr, EncryptedContent<T, Cr>>>>,
-/// );
-///
-/// impl<T: Send + Clone, Cr: ContentRef + Send + Sync> CiphertextStore<T, Cr> for Foo<T, Cr> {
-///     fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> impl Future<Output = Option<EncryptedContent<T, Cr>>> + Send> {
-///         self.0.lock().await.get(&id).cloned()
-///     }
-/// }
-/// ```
 pub trait CiphertextStore<T, Cr: ContentRef> {
     #[cfg(feature = "sendable")]
     fn get_ciphertext(

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -11,7 +11,6 @@ use std::{
 };
 use thiserror::Error;
 
-#[cfg_attr(all(doc, feature = "mermaid_docs"), aquamarine::aquamarine)]
 /// An async storage interface for ciphertexts.
 ///
 /// There are `!Send` and `Send` variants of this trait:
@@ -19,7 +18,7 @@ use thiserror::Error;
 ///
 /// This includes functionality for "causal decryption":
 /// the ability to decrypt a set of causally-related ciphertexts.
-/// See [`try_causal_decrypt`] for more information.
+/// See [`try_causal_decrypt`][CiphertextStore::try_causal_decrypt] for more information.
 ///
 /// The `get_ciphertext` method generally fails on items that have already been decrypted.
 /// This is generally accomplished by either removing the decrypted values from the store,
@@ -35,6 +34,7 @@ pub trait CiphertextStore<T, Cr: ContentRef> {
     #[cfg(not(feature = "sendable"))]
     fn get_ciphertext(&self, id: &Cr) -> impl Future<Output = Option<EncryptedContent<T, Cr>>>;
 
+    #[cfg_attr(all(doc, feature = "mermaid_docs"), aquamarine::aquamarine)]
     /// Recursively decryptsa set of causally-related ciphertexts.
     ///
     /// Consider the following causally encrypted graph:

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -1,3 +1,5 @@
+//! A store for encrypted content plus some metadata.
+
 use crate::{
     content::reference::ContentRef,
     crypto::{encrypted::EncryptedContent, envelope::Envelope, symmetric_key::SymmetricKey},
@@ -6,17 +8,122 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
-    pin::Pin,
 };
 use thiserror::Error;
 
+#[cfg_attr(all(doc, feature = "mermaid_docs"), aquamarine::aquamarine)]
+/// An async storage interface for ciphertexts.
+///
+/// This includes functionality for "causal decryption":
+/// the ability to decrypt a set of causally related ciphertexts.
+///
+/// ```mermaid
+/// flowchart
+///     subgraph genesis["oUz 🔓"]
+///       a[New Doc]
+///     end
+///
+///     subgraph block1["g6z 🔓"]
+///       op1[Op 1]
+///
+///       subgraph block1ancestors[Ancestors]
+///         subgraph block1ancestor1[Ancestor 1]
+///           pointer1_1["Pointer #️⃣"]
+///           key1_1["Key 🔑"]
+///         end
+///       end
+///     end
+///
+///     pointer1_1 --> genesis
+///
+///     subgraph block2["Xa2 🔓"]
+///         op2[Op 2]
+///         op3[Op 3]
+///         op4[Op 4]
+///
+///       subgraph block2ancestors[Ancestors]
+///         subgraph block2ancestor1[Ancestor 1]
+///           pointer2_1["Pointer #️⃣"]
+///           key2_1["Key 🔑"]
+///         end
+///       end
+///     end
+///
+///     pointer2_1 --> genesis
+///
+///     subgraph block3["e9j 🔓"]
+///       op5[Op 5]
+///       op6[Op 6]
+///
+///       subgraph block3ancestors[Ancestors]
+///         subgraph block3ancestor1[Ancestor 1]
+///           pointer3_1["Pointer #️⃣"]
+///           key3_1["Key 🔑"]
+///         end
+///
+///         subgraph block3ancestor2[Ancestor 2]
+///           pointer3_2["Pointer #️⃣"]
+///           key3_2["Key 🔑"]
+///         end
+///       end
+///     end
+///
+///     pointer3_1 --> block1
+///     pointer3_2 --> block2
+///
+///     subgraph head[Read Capabilty]
+///       pointer_head["Pointer #️⃣"]
+///       key_head["Key 🔑"]
+///     end
+///
+///     pointer_head --> block3
+/// ```
+///
+/// There are `!Send` and `Send` variants: if you need `Send`, enable the `sendable` feature.
+///
+/// # `!Send` Implementations
+///
+/// A `!Send` implementation is available on [`HashMap`]:
+///
+/// ```rust
+/// impl<T: Clone, Cr: ContentRef> CiphertextStore<T, Cr> for HashMap<Cr, EncryptedContent<T, Cr>> {
+///     type WorkFuture<'a>
+///         = NonSendWorkFuture<'a, dyn Future<Output = Option<EncryptedContent<T, Cr>>>>
+///     where
+///         Self: 'a,
+///         Cr: 'a;
+///
+///     fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
+///         HashMap::get(self, id).cloned()
+///     }
+/// }
+/// ```
+///
+/// # `Send` Implementations
+///
+/// In many ways, `Send` implementations are closer to what you'd expect:
+///
+/// ```rust
+/// #[derive(Debug, Clone)]
+/// struct Foo<T: Send, Cr: ContentRef + Send + Sync>(
+///     Arc<tokio::sync::Mutex<HashMap<Cr, EncryptedContent<T, Cr>>>>,
+/// );
+///
+/// impl<T: Send + Clone, Cr: ContentRef + Send + Sync> CiphertextStore<T, Cr> for Foo<T, Cr> {
+///     fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> impl Future<Output = Option<EncryptedContent<T, Cr>>> + Send> {
+///         self.0.lock().await.get(&id).cloned()
+///     }
+/// }
+/// ```
 pub trait CiphertextStore<T, Cr: ContentRef> {
-    type WorkFuture<'a>: Future<Output = Option<EncryptedContent<T, Cr>>>
-    where
-        Self: 'a,
-        Cr: 'a;
+    #[cfg(feature = "sendable")]
+    fn get_ciphertext(
+        &self,
+        id: &Cr,
+    ) -> impl Future<Output = Option<EncryptedContent<T, Cr>>> + Send;
 
-    fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a>;
+    #[cfg(not(feature = "sendable"))]
+    fn get_ciphertext(&self, id: &Cr) -> impl Future<Output = Option<EncryptedContent<T, Cr>>>;
 
     #[allow(async_fn_in_trait)]
     async fn try_causal_decrypt(
@@ -90,15 +197,10 @@ impl<T, Cr: ContentRef> CausalDecryptionState<T, Cr> {
     }
 }
 
+#[cfg(not(feature = "sendable"))]
 impl<T: Clone, Cr: ContentRef> CiphertextStore<T, Cr> for HashMap<Cr, EncryptedContent<T, Cr>> {
-    type WorkFuture<'a>
-        = Pin<Box<dyn Future<Output = Option<EncryptedContent<T, Cr>>> + 'a>>
-    where
-        Self: 'a,
-        Cr: 'a;
-
-    fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
-        Box::pin(async move { HashMap::get(self, id).cloned() })
+    async fn get_ciphertext(&self, id: &Cr) -> Option<EncryptedContent<T, Cr>> {
+        HashMap::get(self, id).cloned()
     }
 }
 
@@ -170,600 +272,388 @@ mod tests {
         )
     }
 
-    mod single_threaded {
-        use super::*;
+    #[tokio::test]
+    async fn test_hash_map_get_ciphertext() {
+        let mut csprng = rand::thread_rng();
+        let doc_id = DocumentId::generate(&mut csprng);
+        let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+            raw: blake3::hash(b"PcsOp"),
+            _phantom: PhantomData,
+        };
 
-        #[tokio::test]
-        async fn test_hash_map_get_ciphertext() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
+        let one_ref = [0u8; 32];
+        let two_ref = [1u8; 32];
 
-            let one_ref = [0u8; 32];
-            let two_ref = [1u8; 32];
-
-            let (one, one_key) = setup(
-                "one".to_string(),
-                one_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (two, _two_key) = setup(
-                "two".to_string(),
-                two_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(one_ref, one_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
-                (one_ref, one.clone()),
-                (two_ref, two.clone()),
-            ]);
-
-            assert_eq!(store.get_ciphertext(&one_ref).await, Some(one));
-            assert_eq!(store.get_ciphertext(&two_ref).await, Some(two));
-        }
-
-        #[tokio::test]
-        async fn test_try_causal_decrypt() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
-
-            let genesis_ref = [0u8; 32];
-            let left_ref = [1u8; 32];
-            let right_ref = [2u8; 32];
-            let head_ref = [3u8; 32];
-
-            let (genesis, genesis_key) = setup(
-                "genesis".to_string(),
-                genesis_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (left, left_key) = setup(
-                "left".to_string(),
-                left_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis_ref, genesis_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (right, right_key) = setup(
-                "right".to_string(),
-                right_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis_ref, genesis_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head, head_key) = setup(
-                "head".to_string(),
-                head_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
-                (genesis_ref, genesis.clone()),
-                (left_ref, left.clone()),
-                (right_ref, right.clone()),
-                (head_ref, head.clone()),
-            ]);
-
-            let observed = store
-                .try_causal_decrypt(&mut vec![(head.clone(), head_key)])
-                .await
-                .unwrap();
-
-            assert_eq!(observed.complete.len(), 4);
-            assert!(observed
-                .complete
-                .contains(&(genesis_ref, "genesis".to_string())),);
-            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
-            assert!(observed
-                .complete
-                .contains(&(right_ref, "right".to_string())),);
-            assert!(observed.complete.contains(&(head_ref, "head".to_string())),);
-        }
-
-        #[tokio::test]
-        async fn test_try_causal_decrypt_multiple_heads() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
-
-            let genesis1_ref = [0u8; 32];
-            let genesis2_ref = [1u8; 32];
-
-            let left_ref = [2u8; 32];
-            let right_ref = [3u8; 32];
-
-            let head1_ref = [4u8; 32];
-            let head2_ref = [5u8; 32];
-            let head3_ref = [6u8; 32];
-
-            let (genesis1, genesis1_key) = setup(
-                "genesis1".to_string(),
-                genesis1_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (genesis2, genesis2_key) = setup(
-                "genesis2".to_string(),
-                genesis2_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (left, left_key) = setup(
-                "left".to_string(),
-                left_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (right, right_key) = setup(
-                "right".to_string(),
-                right_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head1, _head1_key) = setup(
-                "head1".to_string(),
-                head1_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head2, head2_key) = setup(
-                "head2".to_string(),
-                head2_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head3, head3_key) = setup(
-                "head3".to_string(),
-                head3_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
-                (genesis1_ref, genesis1.clone()),
-                (genesis2_ref, genesis2.clone()),
-                (left_ref, left.clone()),
-                (right_ref, right.clone()),
-                (head1_ref, head1.clone()),
-                (head2_ref, head2.clone()),
-                (head3_ref, head3.clone()),
-            ]);
-
-            let observed = store
-                .try_causal_decrypt(&mut vec![
-                    (head2.clone(), head2_key),
-                    (head3.clone(), head3_key),
-                ])
-                .await
-                .unwrap();
-
-            // Doesn't have the unused head
-            assert!(!observed
-                .complete
-                .contains(&(head1_ref, "head1".to_string())));
-
-            assert!(observed
-                .complete
-                .contains(&(head2_ref, "head2".to_string())));
-            assert!(observed
-                .complete
-                .contains(&(head3_ref, "head3".to_string())));
-
-            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
-            assert!(observed
-                .complete
-                .contains(&(right_ref, "right".to_string())));
-
-            assert!(observed
-                .complete
-                .contains(&(genesis1_ref, "genesis1".to_string())),);
-            assert!(observed
-                .complete
-                .contains(&(genesis2_ref, "genesis2".to_string())),);
-
-            assert_eq!(observed.complete.len(), 6);
-            assert_eq!(observed.next.len(), 0);
-
-            assert_eq!(observed.keys.len(), 6);
-            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
-            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
-            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
-            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
-            assert_eq!(observed.keys.get(&genesis1_ref), Some(&genesis1_key));
-            assert_eq!(observed.keys.get(&genesis2_ref), Some(&genesis2_key));
-        }
-
-        #[tokio::test]
-        async fn test_incomplete_store() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
-
-            let genesis1_ref = [0u8; 32];
-            let genesis2_ref = [1u8; 32];
-
-            let left_ref = [2u8; 32];
-            let right_ref = [3u8; 32];
-
-            let head1_ref = [4u8; 32];
-            let head2_ref = [5u8; 32];
-            let head3_ref = [6u8; 32];
-
-            let (_genesis1, genesis1_key) = setup(
-                "genesis1".to_string(),
-                genesis1_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (_genesis2, genesis2_key) = setup(
-                "genesis2".to_string(),
-                genesis2_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (left, left_key) = setup(
-                "left".to_string(),
-                left_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (right, right_key) = setup(
-                "right".to_string(),
-                right_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head1, _head1_key) = setup(
-                "head1".to_string(),
-                head1_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head2, head2_key) = setup(
-                "head2".to_string(),
-                head2_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let (head3, head3_key) = setup(
-                "head3".to_string(),
-                head3_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
-
-            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
-                // NOTE: skipping: (genesis1_ref, genesis1.clone()),
-                // NOTE: skipping (genesis2_ref, genesis2.clone()),
-                (left_ref, left.clone()),
-                (right_ref, right.clone()),
-                (head1_ref, head1.clone()),
-                (head2_ref, head2.clone()),
-                (head3_ref, head3.clone()),
-            ]);
-
-            let observed = store
-                .try_causal_decrypt(&mut vec![
-                    (head2.clone(), head2_key),
-                    (head3.clone(), head3_key),
-                ])
-                .await
-                .unwrap();
-
-            // Doesn't have the unused head
-            assert!(!observed
-                .complete
-                .contains(&(head1_ref, "head1".to_string())));
-
-            assert!(observed
-                .complete
-                .contains(&(head2_ref, "head2".to_string())));
-            assert!(observed
-                .complete
-                .contains(&(head3_ref, "head3".to_string())));
-
-            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
-            assert!(observed
-                .complete
-                .contains(&(right_ref, "right".to_string())));
-
-            assert!(!observed
-                .complete
-                .contains(&(genesis1_ref, "genesis1".to_string())),);
-            assert!(!observed
-                .complete
-                .contains(&(genesis2_ref, "genesis2".to_string())),);
-
-            assert_eq!(observed.complete.len(), 4);
-
-            assert_eq!(observed.keys.len(), 4);
-            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
-            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
-            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
-            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
-
-            assert_eq!(observed.next.len(), 2);
-            assert_eq!(observed.next.get(&genesis1_ref), Some(&genesis1_key));
-            assert_eq!(observed.next.get(&genesis2_ref), Some(&genesis2_key));
-        }
-    }
-
-    mod sendable {
-        use super::*;
-        use std::{pin::Pin, sync::Arc};
-
-        #[derive(Debug, Clone)]
-        struct Foo<T: Send, Cr: ContentRef + Send + Sync>(
-            Arc<tokio::sync::Mutex<HashMap<Cr, EncryptedContent<T, Cr>>>>,
+        let (one, one_key) = setup(
+            "one".to_string(),
+            one_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
         );
 
-        impl<T: Send + Clone, Cr: ContentRef + Send + Sync> CiphertextStore<T, Cr> for Foo<T, Cr> {
-            type WorkFuture<'a>
-                = Pin<Box<dyn Future<Output = Option<EncryptedContent<T, Cr>>> + Send + 'a>>
-            where
-                Self: 'a,
-                Cr: 'a;
+        let (two, _two_key) = setup(
+            "two".to_string(),
+            two_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(one_ref, one_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
-                Box::pin(async move { self.0.lock().await.get(&id).cloned() })
-            }
-        }
+        let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+            (one_ref, one.clone()),
+            (two_ref, two.clone()),
+        ]);
 
-        #[tokio::test]
-        async fn test_get() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
+        assert_eq!(store.get_ciphertext(&one_ref).await, Some(one));
+        assert_eq!(store.get_ciphertext(&two_ref).await, Some(two));
+    }
 
-            let one_ref = [0u8; 32];
-            let two_ref = [1u8; 32];
+    #[tokio::test]
+    async fn test_try_causal_decrypt() {
+        let mut csprng = rand::thread_rng();
+        let doc_id = DocumentId::generate(&mut csprng);
+        let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+            raw: blake3::hash(b"PcsOp"),
+            _phantom: PhantomData,
+        };
 
-            let (one, one_key) = setup(
-                "one".to_string(),
-                one_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
+        let genesis_ref = [0u8; 32];
+        let left_ref = [1u8; 32];
+        let right_ref = [2u8; 32];
+        let head_ref = [3u8; 32];
 
-            let (two, _two_key) = setup(
-                "two".to_string(),
-                two_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(one_ref, one_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let (genesis, genesis_key) = setup(
+            "genesis".to_string(),
+            genesis_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
+        );
 
-            let store = Foo(Arc::new(tokio::sync::Mutex::new(HashMap::<
-                [u8; 32],
-                EncryptedContent<String, [u8; 32]>,
-            >::from_iter(
-                [
-                (one_ref, one.clone()),
-                (two_ref, two.clone()),
-            ]
-            ))));
+        let (left, left_key) = setup(
+            "left".to_string(),
+            left_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis_ref, genesis_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            assert_eq!(store.get_ciphertext(&one_ref).await, Some(one));
-            assert_eq!(store.get_ciphertext(&two_ref).await, Some(two));
-        }
+        let (right, right_key) = setup(
+            "right".to_string(),
+            right_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis_ref, genesis_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-        #[tokio::test]
-        async fn test_incomplete_store() {
-            let mut csprng = rand::thread_rng();
-            let doc_id = DocumentId::generate(&mut csprng);
-            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
-                raw: blake3::hash(b"PcsOp"),
-                _phantom: PhantomData,
-            };
+        let (head, head_key) = setup(
+            "head".to_string(),
+            head_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            let genesis1_ref = [0u8; 32];
-            let genesis2_ref = [1u8; 32];
+        let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+            (genesis_ref, genesis.clone()),
+            (left_ref, left.clone()),
+            (right_ref, right.clone()),
+            (head_ref, head.clone()),
+        ]);
 
-            let left_ref = [2u8; 32];
-            let right_ref = [3u8; 32];
+        let observed = store
+            .try_causal_decrypt(&mut vec![(head.clone(), head_key)])
+            .await
+            .unwrap();
 
-            let head1_ref = [4u8; 32];
-            let head2_ref = [5u8; 32];
-            let head3_ref = [6u8; 32];
+        assert_eq!(observed.complete.len(), 4);
+        assert!(observed
+            .complete
+            .contains(&(genesis_ref, "genesis".to_string())),);
+        assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+        assert!(observed
+            .complete
+            .contains(&(right_ref, "right".to_string())),);
+        assert!(observed.complete.contains(&(head_ref, "head".to_string())),);
+    }
 
-            let (_genesis1, genesis1_key) = setup(
-                "genesis1".to_string(),
-                genesis1_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
+    #[tokio::test]
+    async fn test_try_causal_decrypt_multiple_heads() {
+        let mut csprng = rand::thread_rng();
+        let doc_id = DocumentId::generate(&mut csprng);
+        let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+            raw: blake3::hash(b"PcsOp"),
+            _phantom: PhantomData,
+        };
 
-            let (_genesis2, genesis2_key) = setup(
-                "genesis2".to_string(),
-                genesis2_ref,
-                pcs_update_op_hash,
-                HashMap::new(),
-                doc_id,
-                &mut csprng,
-            );
+        let genesis1_ref = [0u8; 32];
+        let genesis2_ref = [1u8; 32];
 
-            let (left, left_key) = setup(
-                "left".to_string(),
-                left_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let left_ref = [2u8; 32];
+        let right_ref = [3u8; 32];
 
-            let (right, right_key) = setup(
-                "right".to_string(),
-                right_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let head1_ref = [4u8; 32];
+        let head2_ref = [5u8; 32];
+        let head3_ref = [6u8; 32];
 
-            let (head1, _head1_key) = setup(
-                "head1".to_string(),
-                head1_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let (genesis1, genesis1_key) = setup(
+            "genesis1".to_string(),
+            genesis1_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
+        );
 
-            let (head2, head2_key) = setup(
-                "head2".to_string(),
-                head2_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(left_ref, left_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let (genesis2, genesis2_key) = setup(
+            "genesis2".to_string(),
+            genesis2_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
+        );
 
-            let (head3, head3_key) = setup(
-                "head3".to_string(),
-                head3_ref,
-                pcs_update_op_hash,
-                HashMap::from_iter([(right_ref, right_key)]),
-                doc_id,
-                &mut csprng,
-            );
+        let (left, left_key) = setup(
+            "left".to_string(),
+            left_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis1_ref, genesis1_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            let store = Foo(Arc::new(tokio::sync::Mutex::new(HashMap::<
-                [u8; 32],
-                EncryptedContent<String, [u8; 32]>,
-            >::from_iter(
-                [
-                // NOTE: skipping: (genesis1_ref, genesis1.clone()),
-                // NOTE: skipping (genesis2_ref, genesis2.clone()),
-                (left_ref, left.clone()),
-                (right_ref, right.clone()),
-                (head1_ref, head1.clone()),
-                (head2_ref, head2.clone()),
-                (head3_ref, head3.clone()),
-            ]
-            ))));
+        let (right, right_key) = setup(
+            "right".to_string(),
+            right_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            let observed = store
-                .try_causal_decrypt(&mut vec![
-                    (head2.clone(), head2_key),
-                    (head3.clone(), head3_key),
-                ])
-                .await
-                .unwrap();
+        let (head1, _head1_key) = setup(
+            "head1".to_string(),
+            head1_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            // Doesn't have the unused head
-            assert!(!observed
-                .complete
-                .contains(&(head1_ref, "head1".to_string())));
+        let (head2, head2_key) = setup(
+            "head2".to_string(),
+            head2_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(left_ref, left_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            assert!(observed
-                .complete
-                .contains(&(head2_ref, "head2".to_string())));
-            assert!(observed
-                .complete
-                .contains(&(head3_ref, "head3".to_string())));
+        let (head3, head3_key) = setup(
+            "head3".to_string(),
+            head3_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(right_ref, right_key)]),
+            doc_id,
+            &mut csprng,
+        );
 
-            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
-            assert!(observed
-                .complete
-                .contains(&(right_ref, "right".to_string())));
+        let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+            (genesis1_ref, genesis1.clone()),
+            (genesis2_ref, genesis2.clone()),
+            (left_ref, left.clone()),
+            (right_ref, right.clone()),
+            (head1_ref, head1.clone()),
+            (head2_ref, head2.clone()),
+            (head3_ref, head3.clone()),
+        ]);
 
-            assert!(!observed
-                .complete
-                .contains(&(genesis1_ref, "genesis1".to_string())),);
-            assert!(!observed
-                .complete
-                .contains(&(genesis2_ref, "genesis2".to_string())),);
+        let observed = store
+            .try_causal_decrypt(&mut vec![
+                (head2.clone(), head2_key),
+                (head3.clone(), head3_key),
+            ])
+            .await
+            .unwrap();
 
-            assert_eq!(observed.complete.len(), 4);
+        // Doesn't have the unused head
+        assert!(!observed
+            .complete
+            .contains(&(head1_ref, "head1".to_string())));
 
-            assert_eq!(observed.keys.len(), 4);
-            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
-            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
-            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
-            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+        assert!(observed
+            .complete
+            .contains(&(head2_ref, "head2".to_string())));
+        assert!(observed
+            .complete
+            .contains(&(head3_ref, "head3".to_string())));
 
-            assert_eq!(observed.next.len(), 2);
-            assert_eq!(observed.next.get(&genesis1_ref), Some(&genesis1_key));
-            assert_eq!(observed.next.get(&genesis2_ref), Some(&genesis2_key));
-        }
+        assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+        assert!(observed
+            .complete
+            .contains(&(right_ref, "right".to_string())));
+
+        assert!(observed
+            .complete
+            .contains(&(genesis1_ref, "genesis1".to_string())),);
+        assert!(observed
+            .complete
+            .contains(&(genesis2_ref, "genesis2".to_string())),);
+
+        assert_eq!(observed.complete.len(), 6);
+        assert_eq!(observed.next.len(), 0);
+
+        assert_eq!(observed.keys.len(), 6);
+        assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
+        assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
+        assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
+        assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+        assert_eq!(observed.keys.get(&genesis1_ref), Some(&genesis1_key));
+        assert_eq!(observed.keys.get(&genesis2_ref), Some(&genesis2_key));
+    }
+
+    #[tokio::test]
+    async fn test_incomplete_store() {
+        let mut csprng = rand::thread_rng();
+        let doc_id = DocumentId::generate(&mut csprng);
+        let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+            raw: blake3::hash(b"PcsOp"),
+            _phantom: PhantomData,
+        };
+
+        let genesis1_ref = [0u8; 32];
+        let genesis2_ref = [1u8; 32];
+
+        let left_ref = [2u8; 32];
+        let right_ref = [3u8; 32];
+
+        let head1_ref = [4u8; 32];
+        let head2_ref = [5u8; 32];
+        let head3_ref = [6u8; 32];
+
+        let (_genesis1, genesis1_key) = setup(
+            "genesis1".to_string(),
+            genesis1_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (_genesis2, genesis2_key) = setup(
+            "genesis2".to_string(),
+            genesis2_ref,
+            pcs_update_op_hash,
+            HashMap::new(),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (left, left_key) = setup(
+            "left".to_string(),
+            left_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis1_ref, genesis1_key)]),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (right, right_key) = setup(
+            "right".to_string(),
+            right_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (head1, _head1_key) = setup(
+            "head1".to_string(),
+            head1_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (head2, head2_key) = setup(
+            "head2".to_string(),
+            head2_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(left_ref, left_key)]),
+            doc_id,
+            &mut csprng,
+        );
+
+        let (head3, head3_key) = setup(
+            "head3".to_string(),
+            head3_ref,
+            pcs_update_op_hash,
+            HashMap::from_iter([(right_ref, right_key)]),
+            doc_id,
+            &mut csprng,
+        );
+
+        let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+            // NOTE: skipping: (genesis1_ref, genesis1.clone()),
+            // NOTE: skipping (genesis2_ref, genesis2.clone()),
+            (left_ref, left.clone()),
+            (right_ref, right.clone()),
+            (head1_ref, head1.clone()),
+            (head2_ref, head2.clone()),
+            (head3_ref, head3.clone()),
+        ]);
+
+        let observed = store
+            .try_causal_decrypt(&mut vec![
+                (head2.clone(), head2_key),
+                (head3.clone(), head3_key),
+            ])
+            .await
+            .unwrap();
+
+        // Doesn't have the unused head
+        assert!(!observed
+            .complete
+            .contains(&(head1_ref, "head1".to_string())));
+
+        assert!(observed
+            .complete
+            .contains(&(head2_ref, "head2".to_string())));
+        assert!(observed
+            .complete
+            .contains(&(head3_ref, "head3".to_string())));
+
+        assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+        assert!(observed
+            .complete
+            .contains(&(right_ref, "right".to_string())));
+
+        assert!(!observed
+            .complete
+            .contains(&(genesis1_ref, "genesis1".to_string())),);
+        assert!(!observed
+            .complete
+            .contains(&(genesis2_ref, "genesis2".to_string())),);
+
+        assert_eq!(observed.complete.len(), 4);
+
+        assert_eq!(observed.keys.len(), 4);
+        assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
+        assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
+        assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
+        assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+
+        assert_eq!(observed.next.len(), 2);
+        assert_eq!(observed.next.get(&genesis1_ref), Some(&genesis1_key));
+        assert_eq!(observed.next.get(&genesis2_ref), Some(&genesis2_key));
     }
 }

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -7,10 +7,11 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use thiserror::Error;
 
-#[allow(async_fn_in_trait)]
 pub trait CiphertextStore<T, Cr: ContentRef> {
+    #[allow(async_fn_in_trait)]
     async fn get(&self, id: &Cr) -> Option<EncryptedContent<T, Cr>>;
 
+    #[allow(async_fn_in_trait)]
     async fn try_causal_decrypt(
         &self,
         to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
@@ -65,7 +66,9 @@ pub trait CiphertextStore<T, Cr: ContentRef> {
     }
 }
 
-pub trait SendableCiphertextStore<T: Send, Cr: ContentRef + Send>: CiphertextStore<T, Cr> {
+pub trait SendableCiphertextStore<T: Send, Cr: ContentRef + Send>:
+    CiphertextStore<T, Cr> + Sync
+{
     fn get_sendable(&self, id: &Cr)
         -> impl Future<Output = Option<EncryptedContent<T, Cr>>> + Send;
 

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -1,64 +1,123 @@
 use crate::{
     content::reference::ContentRef,
     crypto::{
-        digest::Digest,
-        encrypted::{CausalDecryptionError, CausalDecryptionState, EncryptedContent, Reason},
-        envelope::Envelope,
+        digest::Digest, encrypted::EncryptedContent, envelope::Envelope,
         symmetric_key::SymmetricKey,
     },
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::{HashMap, HashSet};
+use thiserror::Error;
 
-// FIXME feature flag
 #[trait_variant::make(SendableCiphertextStore: Send)]
-pub trait CiphertextStore<T: Send, Cr: ContentRef + Send> {
+pub trait CiphertextStore<T, Cr: ContentRef> {
     async fn get(&self, id: &Digest<Cr>) -> Option<EncryptedContent<T, Cr>>;
+}
 
-    async fn try_causal_decrypt(
-        &self,
-        to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
-    ) -> Result<CausalDecryptionState<T, Cr>, CausalDecryptionError<T, Cr>>
-    where
-        T: Serialize + DeserializeOwned + Clone,
-        Cr: DeserializeOwned,
-    {
-        let mut acc = CausalDecryptionState::new();
-        let mut seen = HashSet::new();
+pub async fn try_sendable_causal_decrypt<
+    T: Send,
+    Cr: ContentRef + Send,
+    S: SendableCiphertextStore<T, Cr>,
+>(
+    store: &S,
+    to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
+) -> Result<CausalDecryptionState<T, Cr>, CausalDecryptionError<T, Cr>>
+where
+    T: Serialize + DeserializeOwned + Clone,
+    Cr: DeserializeOwned,
+{
+    try_causal_decrypt(store, to_decrypt).await
+}
 
-        while let Some((ciphertext, key)) = to_decrypt.pop() {
-            if !seen.insert(ciphertext.content_ref) {
-                continue;
-            }
+pub async fn try_causal_decrypt<T, Cr: ContentRef, S: CiphertextStore<T, Cr>>(
+    store: &S,
+    to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
+) -> Result<CausalDecryptionState<T, Cr>, CausalDecryptionError<T, Cr>>
+where
+    T: Serialize + DeserializeOwned + Clone,
+    Cr: DeserializeOwned,
+{
+    let mut acc = CausalDecryptionState::new();
+    let mut seen = HashSet::new();
 
-            if let Ok(decrypted) = ciphertext.try_decrypt(key) {
-                let envelope: Envelope<Cr, T> = bincode::deserialize(decrypted.as_slice())
-                    .map_err(|e| CausalDecryptionError {
-                        progress: acc.clone(),
-                        cannot: HashMap::from_iter([(
-                            ciphertext.content_ref,
-                            Reason::DeserializationFailed(e.into()),
-                        )]),
-                    })?;
+    while let Some((ciphertext, key)) = to_decrypt.pop() {
+        if !seen.insert(ciphertext.content_ref) {
+            continue;
+        }
 
-                for (ancestor_hash, ancestor_key) in envelope.ancestors.iter() {
-                    let ancestor = self.get(&Digest::hash(ancestor_hash)).await.expect("FIXME");
-                    to_decrypt.push((ancestor, *ancestor_key));
-                }
-
-                acc.complete
-                    .push((ciphertext.content_ref, envelope.plaintext));
-            } else {
-                Err(CausalDecryptionError {
+        if let Ok(decrypted) = ciphertext.try_decrypt(key) {
+            let envelope: Envelope<Cr, T> =
+                bincode::deserialize(decrypted.as_slice()).map_err(|e| CausalDecryptionError {
                     progress: acc.clone(),
                     cannot: HashMap::from_iter([(
                         ciphertext.content_ref,
-                        Reason::DecryptionFailed(key),
+                        ErrorReason::DeserializationFailed(e.into()),
                     )]),
                 })?;
-            }
-        }
 
-        Ok(acc)
+            for (ancestor_hash, ancestor_key) in envelope.ancestors.iter() {
+                let ancestor =
+                    store
+                        .get(&Digest::hash(ancestor_hash))
+                        .await
+                        .ok_or(CausalDecryptionError {
+                            progress: acc.clone(),
+                            cannot: HashMap::from_iter([(
+                                ciphertext.content_ref,
+                                ErrorReason::CannotFindCiphertext(ancestor_hash.clone()),
+                            )]),
+                        })?;
+                to_decrypt.push((ancestor, *ancestor_key));
+            }
+
+            acc.complete
+                .push((ciphertext.content_ref, envelope.plaintext));
+        } else {
+            Err(CausalDecryptionError {
+                progress: acc.clone(),
+                cannot: HashMap::from_iter([(
+                    ciphertext.content_ref,
+                    ErrorReason::DecryptionFailed(key),
+                )]),
+            })?;
+        }
     }
+
+    Ok(acc)
+}
+
+#[derive(Debug, Clone)]
+pub struct CausalDecryptionState<T, Cr: ContentRef> {
+    pub complete: Vec<(Digest<Cr>, T)>,
+    pub keys: HashMap<Digest<Cr>, SymmetricKey>,
+    pub next: HashMap<Digest<Cr>, SymmetricKey>,
+}
+
+impl<T, Cr: ContentRef> CausalDecryptionState<T, Cr> {
+    pub fn new() -> Self {
+        CausalDecryptionState {
+            complete: vec![],
+            keys: HashMap::new(),
+            next: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Causal decryption error: {cannot}")]
+pub struct CausalDecryptionError<T, Cr: ContentRef> {
+    pub cannot: HashMap<Digest<Cr>, ErrorReason<Cr>>,
+    pub progress: CausalDecryptionState<T, Cr>,
+}
+
+#[derive(Debug, Error)]
+pub enum ErrorReason<Cr: ContentRef> {
+    #[error("Decryption failed")]
+    DecryptionFailed(SymmetricKey),
+
+    #[error(transparent)]
+    DeserializationFailed(Box<bincode::Error>),
+
+    #[error("Cannot find ciphertext: {0}")]
+    CannotFindCiphertext(Cr),
 }

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -8,8 +8,12 @@ use std::future::Future;
 use thiserror::Error;
 
 pub trait CiphertextStore<T, Cr: ContentRef> {
-    #[allow(async_fn_in_trait)]
-    async fn get(&self, id: &Cr) -> Option<EncryptedContent<T, Cr>>;
+    type WorkFuture<'a>: Future<Output = Option<EncryptedContent<T, Cr>>>
+    where
+        Self: 'a,
+        Cr: 'a;
+
+    fn get<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'_>;
 
     #[allow(async_fn_in_trait)]
     async fn try_causal_decrypt(
@@ -66,67 +70,23 @@ pub trait CiphertextStore<T, Cr: ContentRef> {
     }
 }
 
-pub trait SendableCiphertextStore<T: Send, Cr: ContentRef + Send>:
-    CiphertextStore<T, Cr> + Sync
-{
-    fn get_sendable(&self, id: &Cr)
-        -> impl Future<Output = Option<EncryptedContent<T, Cr>>> + Send;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 
-    #[allow(async_fn_in_trait)]
-    async fn try_sendable_causal_decrypt(
-        &self,
-        to_decrypt: &mut Vec<(EncryptedContent<T, Cr>, SymmetricKey)>,
-    ) -> Result<CausalDecryptionState<T, Cr>, CausalDecryptionError<T, Cr>>
+#[derive(Debug, Clone)]
+pub struct Foo<T: Send, Cr: ContentRef + Send + Sync>(
+    Arc<tokio::sync::Mutex<HashMap<Cr, EncryptedContent<T, Cr>>>>,
+);
+
+impl<T: Send + Clone, Cr: ContentRef + Send + Sync> CiphertextStore<T, Cr> for Foo<T, Cr> {
+    type WorkFuture<'a>
+        = Pin<Box<dyn Future<Output = Option<EncryptedContent<T, Cr>>> + Send + 'a>>
     where
-        T: Serialize + DeserializeOwned + Clone,
-        Cr: DeserializeOwned,
-    {
-        let mut acc = CausalDecryptionState::new();
-        let mut seen = HashSet::new();
+        Self: 'a,
+        Cr: 'a;
 
-        while let Some((ciphertext, key)) = to_decrypt.pop() {
-            if !seen.insert(ciphertext.content_ref.clone()) {
-                continue;
-            }
-
-            if let Ok(decrypted) = ciphertext.try_decrypt(key) {
-                let envelope: Envelope<Cr, T> = bincode::deserialize(decrypted.as_slice())
-                    .map_err(|e| CausalDecryptionError {
-                        progress: acc.clone(),
-                        cannot: HashMap::from_iter([(
-                            ciphertext.content_ref.clone(),
-                            ErrorReason::DeserializationFailed(e.into()),
-                        )]),
-                    })?;
-
-                for (ancestor_ref, ancestor_key) in envelope.ancestors.iter() {
-                    let ancestor =
-                        self.get_sendable(&ancestor_ref)
-                            .await
-                            .ok_or(CausalDecryptionError {
-                                progress: acc.clone(),
-                                cannot: HashMap::from_iter([(
-                                    ciphertext.content_ref.clone(),
-                                    ErrorReason::CannotFindCiphertext(ancestor_ref.clone()),
-                                )]),
-                            })?;
-                    to_decrypt.push((ancestor, *ancestor_key));
-                }
-
-                acc.complete
-                    .push((ciphertext.content_ref, envelope.plaintext));
-            } else {
-                Err(CausalDecryptionError {
-                    progress: acc.clone(),
-                    cannot: HashMap::from_iter([(
-                        ciphertext.content_ref,
-                        ErrorReason::DecryptionFailed(key),
-                    )]),
-                })?;
-            }
-        }
-
-        Ok(acc)
+    fn get<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'_> {
+        Box::pin(async move { self.0.lock().await.get(&id).cloned() })
     }
 }
 

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -3,8 +3,11 @@ use crate::{
     crypto::{encrypted::EncryptedContent, envelope::Envelope, symmetric_key::SymmetricKey},
 };
 use serde::{de::DeserializeOwned, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::future::Future;
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+};
 use thiserror::Error;
 
 pub trait CiphertextStore<T, Cr: ContentRef> {
@@ -13,7 +16,7 @@ pub trait CiphertextStore<T, Cr: ContentRef> {
         Self: 'a,
         Cr: 'a;
 
-    fn get<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a>;
+    fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a>;
 
     #[allow(async_fn_in_trait)]
     async fn try_causal_decrypt(
@@ -32,38 +35,38 @@ pub trait CiphertextStore<T, Cr: ContentRef> {
                 continue;
             }
 
-            if let Ok(decrypted) = ciphertext.try_decrypt(key) {
-                let envelope: Envelope<Cr, T> = bincode::deserialize(decrypted.as_slice())
-                    .map_err(|e| CausalDecryptionError {
-                        progress: acc.clone(),
-                        cannot: HashMap::from_iter([(
-                            ciphertext.content_ref.clone(),
-                            ErrorReason::DeserializationFailed(e.into()),
-                        )]),
-                    })?;
+            acc.keys.insert(ciphertext.content_ref.clone(), key);
+            let content_ref = ciphertext.content_ref.clone();
 
-                for (ancestor_ref, ancestor_key) in envelope.ancestors.iter() {
-                    let ancestor = self.get(&ancestor_ref).await.ok_or(CausalDecryptionError {
-                        progress: acc.clone(),
-                        cannot: HashMap::from_iter([(
-                            ciphertext.content_ref.clone(),
-                            ErrorReason::CannotFindCiphertext(ancestor_ref.clone()),
-                        )]),
-                    })?;
-                    to_decrypt.push((ancestor, *ancestor_key));
-                }
-
-                acc.complete
-                    .push((ciphertext.content_ref, envelope.plaintext));
-            } else {
-                Err(CausalDecryptionError {
+            let decrypted = ciphertext
+                .try_decrypt(key)
+                .map_err(|_| CausalDecryptionError {
                     progress: acc.clone(),
                     cannot: HashMap::from_iter([(
-                        ciphertext.content_ref,
+                        content_ref.clone(),
                         ErrorReason::DecryptionFailed(key),
                     )]),
                 })?;
+
+            let envelope: Envelope<Cr, T> =
+                bincode::deserialize(decrypted.as_slice()).map_err(|e| CausalDecryptionError {
+                    progress: acc.clone(),
+                    cannot: HashMap::from_iter([(
+                        content_ref,
+                        ErrorReason::DeserializationFailed(e.into()),
+                    )]),
+                })?;
+
+            for (ancestor_ref, ancestor_key) in envelope.ancestors.iter() {
+                if let Some(ancestor) = self.get_ciphertext(&ancestor_ref).await {
+                    to_decrypt.push((ancestor, *ancestor_key));
+                } else {
+                    acc.next.insert(ancestor_ref.clone(), *ancestor_key);
+                }
             }
+
+            acc.complete
+                .push((ciphertext.content_ref, envelope.plaintext));
         }
 
         Ok(acc)
@@ -84,6 +87,18 @@ impl<T, Cr: ContentRef> CausalDecryptionState<T, Cr> {
             keys: HashMap::new(),
             next: HashMap::new(),
         }
+    }
+}
+
+impl<T: Clone, Cr: ContentRef> CiphertextStore<T, Cr> for HashMap<Cr, EncryptedContent<T, Cr>> {
+    type WorkFuture<'a>
+        = Pin<Box<dyn Future<Output = Option<EncryptedContent<T, Cr>>> + 'a>>
+    where
+        Self: 'a,
+        Cr: 'a;
+
+    fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
+        Box::pin(async move { HashMap::get(self, id).cloned() })
     }
 }
 
@@ -109,11 +124,444 @@ pub enum ErrorReason<Cr: ContentRef> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        cgka::operation::CgkaOperation,
+        crypto::{
+            application_secret::PcsKey, digest::Digest, envelope::Envelope,
+            share_key::ShareSecretKey, signed::Signed, siv::Siv,
+        },
+        principal::document::id::DocumentId,
+    };
+    use rand::rngs::ThreadRng;
+    use std::marker::PhantomData;
+
+    fn setup(
+        plaintext: String,
+        cref: [u8; 32],
+        pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
+        ancestors: HashMap<[u8; 32], SymmetricKey>,
+        doc_id: DocumentId,
+        csprng: &mut ThreadRng,
+    ) -> (EncryptedContent<String, [u8; 32]>, SymmetricKey) {
+        let pcs_key: PcsKey = ShareSecretKey::generate(csprng).into();
+        let pcs_key_hash = Digest::hash(&pcs_key);
+
+        let key = SymmetricKey::generate(csprng);
+        let envelope = Envelope {
+            plaintext,
+            ancestors,
+        };
+        let mut bytes = bincode::serialize(&envelope).unwrap();
+        let nonce = Siv::new(&key, bytes.as_slice(), doc_id).unwrap();
+        key.try_encrypt(nonce, &mut bytes).unwrap();
+
+        (
+            EncryptedContent::<String, [u8; 32]>::new(
+                nonce,
+                bytes,
+                //
+                pcs_key_hash,
+                pcs_update_op_hash,
+                //
+                cref,
+                Digest::hash(&vec![]),
+            ),
+            key,
+        )
+    }
+
+    mod single_threaded {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_hash_map_get_ciphertext() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let one_ref = [0u8; 32];
+            let two_ref = [1u8; 32];
+
+            let (one, one_key) = setup(
+                "one".to_string(),
+                one_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (two, _two_key) = setup(
+                "two".to_string(),
+                two_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(one_ref, one_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+                (one_ref, one.clone()),
+                (two_ref, two.clone()),
+            ]);
+
+            assert_eq!(store.get_ciphertext(&one_ref).await, Some(one));
+            assert_eq!(store.get_ciphertext(&two_ref).await, Some(two));
+        }
+
+        #[tokio::test]
+        async fn test_try_causal_decrypt() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let genesis_ref = [0u8; 32];
+            let left_ref = [1u8; 32];
+            let right_ref = [2u8; 32];
+            let head_ref = [3u8; 32];
+
+            let (genesis, genesis_key) = setup(
+                "genesis".to_string(),
+                genesis_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (left, left_key) = setup(
+                "left".to_string(),
+                left_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis_ref, genesis_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (right, right_key) = setup(
+                "right".to_string(),
+                right_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis_ref, genesis_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head, head_key) = setup(
+                "head".to_string(),
+                head_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+                (genesis_ref, genesis.clone()),
+                (left_ref, left.clone()),
+                (right_ref, right.clone()),
+                (head_ref, head.clone()),
+            ]);
+
+            let observed = store
+                .try_causal_decrypt(&mut vec![(head.clone(), head_key)])
+                .await
+                .unwrap();
+
+            assert_eq!(observed.complete.len(), 4);
+            assert!(observed
+                .complete
+                .contains(&(genesis_ref, "genesis".to_string())),);
+            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+            assert!(observed
+                .complete
+                .contains(&(right_ref, "right".to_string())),);
+            assert!(observed.complete.contains(&(head_ref, "head".to_string())),);
+        }
+
+        #[tokio::test]
+        async fn test_try_causal_decrypt_multiple_heads() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let genesis1_ref = [0u8; 32];
+            let genesis2_ref = [1u8; 32];
+
+            let left_ref = [2u8; 32];
+            let right_ref = [3u8; 32];
+
+            let head1_ref = [4u8; 32];
+            let head2_ref = [5u8; 32];
+            let head3_ref = [6u8; 32];
+
+            let (genesis1, genesis1_key) = setup(
+                "genesis1".to_string(),
+                genesis1_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (genesis2, genesis2_key) = setup(
+                "genesis2".to_string(),
+                genesis2_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (left, left_key) = setup(
+                "left".to_string(),
+                left_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (right, right_key) = setup(
+                "right".to_string(),
+                right_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head1, _head1_key) = setup(
+                "head1".to_string(),
+                head1_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head2, head2_key) = setup(
+                "head2".to_string(),
+                head2_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head3, head3_key) = setup(
+                "head3".to_string(),
+                head3_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+                (genesis1_ref, genesis1.clone()),
+                (genesis2_ref, genesis2.clone()),
+                (left_ref, left.clone()),
+                (right_ref, right.clone()),
+                (head1_ref, head1.clone()),
+                (head2_ref, head2.clone()),
+                (head3_ref, head3.clone()),
+            ]);
+
+            let observed = store
+                .try_causal_decrypt(&mut vec![
+                    (head2.clone(), head2_key),
+                    (head3.clone(), head3_key),
+                ])
+                .await
+                .unwrap();
+
+            // Doesn't have the unused head
+            assert!(!observed
+                .complete
+                .contains(&(head1_ref, "head1".to_string())));
+
+            assert!(observed
+                .complete
+                .contains(&(head2_ref, "head2".to_string())));
+            assert!(observed
+                .complete
+                .contains(&(head3_ref, "head3".to_string())));
+
+            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+            assert!(observed
+                .complete
+                .contains(&(right_ref, "right".to_string())));
+
+            assert!(observed
+                .complete
+                .contains(&(genesis1_ref, "genesis1".to_string())),);
+            assert!(observed
+                .complete
+                .contains(&(genesis2_ref, "genesis2".to_string())),);
+
+            assert_eq!(observed.complete.len(), 6);
+            assert_eq!(observed.next.len(), 0);
+
+            assert_eq!(observed.keys.len(), 6);
+            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
+            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
+            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
+            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+            assert_eq!(observed.keys.get(&genesis1_ref), Some(&genesis1_key));
+            assert_eq!(observed.keys.get(&genesis2_ref), Some(&genesis2_key));
+        }
+
+        #[tokio::test]
+        async fn test_incomplete_store() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let genesis1_ref = [0u8; 32];
+            let genesis2_ref = [1u8; 32];
+
+            let left_ref = [2u8; 32];
+            let right_ref = [3u8; 32];
+
+            let head1_ref = [4u8; 32];
+            let head2_ref = [5u8; 32];
+            let head3_ref = [6u8; 32];
+
+            let (_genesis1, genesis1_key) = setup(
+                "genesis1".to_string(),
+                genesis1_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (_genesis2, genesis2_key) = setup(
+                "genesis2".to_string(),
+                genesis2_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (left, left_key) = setup(
+                "left".to_string(),
+                left_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (right, right_key) = setup(
+                "right".to_string(),
+                right_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head1, _head1_key) = setup(
+                "head1".to_string(),
+                head1_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head2, head2_key) = setup(
+                "head2".to_string(),
+                head2_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head3, head3_key) = setup(
+                "head3".to_string(),
+                head3_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = HashMap::<[u8; 32], EncryptedContent<String, [u8; 32]>>::from_iter([
+                // NOTE: skipping: (genesis1_ref, genesis1.clone()),
+                // NOTE: skipping (genesis2_ref, genesis2.clone()),
+                (left_ref, left.clone()),
+                (right_ref, right.clone()),
+                (head1_ref, head1.clone()),
+                (head2_ref, head2.clone()),
+                (head3_ref, head3.clone()),
+            ]);
+
+            let observed = store
+                .try_causal_decrypt(&mut vec![
+                    (head2.clone(), head2_key),
+                    (head3.clone(), head3_key),
+                ])
+                .await
+                .unwrap();
+
+            // Doesn't have the unused head
+            assert!(!observed
+                .complete
+                .contains(&(head1_ref, "head1".to_string())));
+
+            assert!(observed
+                .complete
+                .contains(&(head2_ref, "head2".to_string())));
+            assert!(observed
+                .complete
+                .contains(&(head3_ref, "head3".to_string())));
+
+            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+            assert!(observed
+                .complete
+                .contains(&(right_ref, "right".to_string())));
+
+            assert!(!observed
+                .complete
+                .contains(&(genesis1_ref, "genesis1".to_string())),);
+            assert!(!observed
+                .complete
+                .contains(&(genesis2_ref, "genesis2".to_string())),);
+
+            assert_eq!(observed.complete.len(), 4);
+
+            assert_eq!(observed.keys.len(), 4);
+            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
+            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
+            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
+            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+
+            assert_eq!(observed.next.len(), 2);
+            assert_eq!(observed.next.get(&genesis1_ref), Some(&genesis1_key));
+            assert_eq!(observed.next.get(&genesis2_ref), Some(&genesis2_key));
+        }
+    }
 
     mod sendable {
         use super::*;
-        use std::pin::Pin;
-        use std::sync::{Arc, Mutex};
+        use std::{pin::Pin, sync::Arc};
 
         #[derive(Debug, Clone)]
         struct Foo<T: Send, Cr: ContentRef + Send + Sync>(
@@ -127,9 +575,195 @@ mod tests {
                 Self: 'a,
                 Cr: 'a;
 
-            fn get<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
+            fn get_ciphertext<'a>(&'a self, id: &'a Cr) -> Self::WorkFuture<'a> {
                 Box::pin(async move { self.0.lock().await.get(&id).cloned() })
             }
+        }
+
+        #[tokio::test]
+        async fn test_get() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let one_ref = [0u8; 32];
+            let two_ref = [1u8; 32];
+
+            let (one, one_key) = setup(
+                "one".to_string(),
+                one_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (two, _two_key) = setup(
+                "two".to_string(),
+                two_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(one_ref, one_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = Foo(Arc::new(tokio::sync::Mutex::new(HashMap::<
+                [u8; 32],
+                EncryptedContent<String, [u8; 32]>,
+            >::from_iter(
+                [
+                (one_ref, one.clone()),
+                (two_ref, two.clone()),
+            ]
+            ))));
+
+            assert_eq!(store.get_ciphertext(&one_ref).await, Some(one));
+            assert_eq!(store.get_ciphertext(&two_ref).await, Some(two));
+        }
+
+        #[tokio::test]
+        async fn test_incomplete_store() {
+            let mut csprng = rand::thread_rng();
+            let doc_id = DocumentId::generate(&mut csprng);
+            let pcs_update_op_hash: Digest<Signed<CgkaOperation>> = Digest {
+                raw: blake3::hash(b"PcsOp"),
+                _phantom: PhantomData,
+            };
+
+            let genesis1_ref = [0u8; 32];
+            let genesis2_ref = [1u8; 32];
+
+            let left_ref = [2u8; 32];
+            let right_ref = [3u8; 32];
+
+            let head1_ref = [4u8; 32];
+            let head2_ref = [5u8; 32];
+            let head3_ref = [6u8; 32];
+
+            let (_genesis1, genesis1_key) = setup(
+                "genesis1".to_string(),
+                genesis1_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (_genesis2, genesis2_key) = setup(
+                "genesis2".to_string(),
+                genesis2_ref,
+                pcs_update_op_hash,
+                HashMap::new(),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (left, left_key) = setup(
+                "left".to_string(),
+                left_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (right, right_key) = setup(
+                "right".to_string(),
+                right_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(genesis2_ref, genesis2_key), (genesis1_ref, genesis1_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head1, _head1_key) = setup(
+                "head1".to_string(),
+                head1_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key), (right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head2, head2_key) = setup(
+                "head2".to_string(),
+                head2_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(left_ref, left_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let (head3, head3_key) = setup(
+                "head3".to_string(),
+                head3_ref,
+                pcs_update_op_hash,
+                HashMap::from_iter([(right_ref, right_key)]),
+                doc_id,
+                &mut csprng,
+            );
+
+            let store = Foo(Arc::new(tokio::sync::Mutex::new(HashMap::<
+                [u8; 32],
+                EncryptedContent<String, [u8; 32]>,
+            >::from_iter(
+                [
+                // NOTE: skipping: (genesis1_ref, genesis1.clone()),
+                // NOTE: skipping (genesis2_ref, genesis2.clone()),
+                (left_ref, left.clone()),
+                (right_ref, right.clone()),
+                (head1_ref, head1.clone()),
+                (head2_ref, head2.clone()),
+                (head3_ref, head3.clone()),
+            ]
+            ))));
+
+            let observed = store
+                .try_causal_decrypt(&mut vec![
+                    (head2.clone(), head2_key),
+                    (head3.clone(), head3_key),
+                ])
+                .await
+                .unwrap();
+
+            // Doesn't have the unused head
+            assert!(!observed
+                .complete
+                .contains(&(head1_ref, "head1".to_string())));
+
+            assert!(observed
+                .complete
+                .contains(&(head2_ref, "head2".to_string())));
+            assert!(observed
+                .complete
+                .contains(&(head3_ref, "head3".to_string())));
+
+            assert!(observed.complete.contains(&(left_ref, "left".to_string())),);
+            assert!(observed
+                .complete
+                .contains(&(right_ref, "right".to_string())));
+
+            assert!(!observed
+                .complete
+                .contains(&(genesis1_ref, "genesis1".to_string())),);
+            assert!(!observed
+                .complete
+                .contains(&(genesis2_ref, "genesis2".to_string())),);
+
+            assert_eq!(observed.complete.len(), 4);
+
+            assert_eq!(observed.keys.len(), 4);
+            assert_eq!(observed.keys.get(&head2_ref), Some(&head2_key));
+            assert_eq!(observed.keys.get(&head3_ref), Some(&head3_key));
+            assert_eq!(observed.keys.get(&left_ref), Some(&left_key));
+            assert_eq!(observed.keys.get(&right_ref), Some(&right_key));
+
+            assert_eq!(observed.next.len(), 2);
+            assert_eq!(observed.next.get(&genesis1_ref), Some(&genesis1_key));
+            assert_eq!(observed.next.get(&genesis2_ref), Some(&genesis2_key));
         }
     }
 }

--- a/keyhive_wasm/src/js/encrypted.rs
+++ b/keyhive_wasm/src/js/encrypted.rs
@@ -31,7 +31,7 @@ impl JsEncrypted {
 
     #[wasm_bindgen(getter)]
     pub fn content_ref(&self) -> Vec<u8> {
-        self.0.content_ref.raw.as_bytes().to_vec()
+        self.0.content_ref.bytes().to_vec()
     }
 
     #[wasm_bindgen(getter)]


### PR DESCRIPTION
* [x] Remove superfluous `Digest` from `ContentRef`s
    * [x] i.e. no more need to run `Digest::hash` on `ChangeHash`, so updated relevant Beelay code
* [x] Async ciphertext store trait, plus `Send`able variant
* [x] Causal decryption
* [x] Tests
* [x] Docs

I also bumped the version of Rust to 1.85.0 (latest) in order to get some async trait stuff that's been stabilised.