### PR TITLE
keyhive_core: Add an 'ingest_static' feature

### DIFF
--- a/beelay/beelay-core/Cargo.toml
+++ b/beelay/beelay-core/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 keyhive_core = { path = "../../keyhive_core", features = [
-    "test_utils",
+    "ingest_static",
 ] } # TODO: get rid of test_utils
 bincode = "1.3"
 

--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -53,7 +53,12 @@ test-utils = { path = "../test-utils" }
 
 arbitrary = { version = "1.4.1", features = ["derive"] }
 lazy_static = "1.5"
-tokio = { version = "1.43", features = ["macros", "rt", "sync", "rt-multi-thread"] }
+tokio = { version = "1.43", features = [
+    "macros",
+    "rt",
+    "sync",
+    "rt-multi-thread",
+] }
 tokio-test = "0.4.4"
 
 # Benchmarks
@@ -70,7 +75,8 @@ default = []
 debug_events = ["prettytable-rs"]
 mermaid_docs = ["aquamarine"]
 sendable = []
-test_utils = ["proptest", "proptest-derive"]
+test_utils = ["proptest", "proptest-derive", "ingest_static"]
+ingest_static = []
 
 [[bench]]
 name = "bench_cgka"

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1418,7 +1418,7 @@ impl<
         })
     }
 
-    #[cfg(any(test, feature = "test_utils"))]
+    #[cfg(any(test, feature = "ingest_static"))]
     #[instrument(level = "trace", skip_all, fields(khid = %self.id()))]
     pub async fn ingest_archive(
         &mut self,
@@ -1456,7 +1456,7 @@ impl<
         &self.event_listener
     }
 
-    #[cfg(any(test, feature = "test_utils"))]
+    #[cfg(any(test, feature = "ingest_static"))]
     #[instrument(level = "trace", skip_all, fields(khid = %self.id()))]
     pub async fn ingest_unsorted_static_events(
         &mut self,


### PR DESCRIPTION
Problem: we are currently using the
`Keyhive::ingest_unsorted_static_event` function in `beelay`. To do this `beelay` depends on the `test_utils` feature of `keyhive_core`, which also pulls in `proptest`. `proptest` doesn't build for `wasm32-unknown-unknown`.

Solution: add a new feature called `ingest_static` which is enabled by default for the `test_utils` feature and only enable `ingest_static` in `beelay`. The ideal solution would obviously be to implement something like `ingest_static` properly in `beelay`, but this is a pragmatic solution for now.