### PR TITLE
beelay_core: Use custom executor, not futures::executor::LocalExecutor

### DIFF
--- a/beelay/beelay-core/src/driver.rs
+++ b/beelay/beelay-core/src/driver.rs
@@ -10,6 +10,8 @@ use futures::{
 };
 use keyhive_core::crypto::verifiable::Verifiable;
 
+mod executor;
+
 use crate::{
     commands,
     conn_info::ConnectionInfo,
@@ -38,7 +40,7 @@ pub(crate) struct Driver {
     rx_driver_events: mpsc::UnboundedReceiver<DriverEvent>,
     tx_commands: mpsc::UnboundedSender<(CommandId, Command)>,
     tx_tick: mpsc::Sender<()>,
-    executor: futures::executor::LocalPool,
+    executor: executor::LocalExecutor,
 }
 
 impl Driver {
@@ -60,8 +62,7 @@ impl Driver {
             rx_tick,
         };
         let fut = f(spawn_args);
-        let executor = futures::executor::LocalPool::new();
-        executor.spawner().spawn_local(fut).unwrap();
+        let executor = executor::LocalExecutor::spawn(fut);
         let driver = Self {
             now,
             io_tasks: HashMap::new(),

--- a/beelay/beelay-core/src/driver/executor.rs
+++ b/beelay/beelay-core/src/driver/executor.rs
@@ -1,0 +1,73 @@
+use std::{
+    future::Future,
+    sync::{atomic::AtomicBool, Arc},
+    task::{Context, Poll},
+};
+
+use futures::{
+    task::{waker, ArcWake, LocalFutureObj},
+    FutureExt,
+};
+
+/// A very simple "executor" which just drives a single future.
+pub(crate) struct LocalExecutor {
+    running: Option<LocalFutureObj<'static, ()>>,
+}
+
+struct WakeThis {
+    woken: AtomicBool,
+}
+
+impl ArcWake for WakeThis {
+    fn wake_by_ref(arc_self: &std::sync::Arc<Self>) {
+        arc_self
+            .woken
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl LocalExecutor {
+    /// Create a new `LocalExecutor` which will  drive the given Future until completion
+    pub(crate) fn spawn<Fut: Future<Output = ()> + 'static>(fut: Fut) -> Self {
+        let fut_obj = LocalFutureObj::new(Box::new(fut));
+        Self {
+            running: Some(fut_obj),
+        }
+    }
+
+    /// Run the spawned future until it can't make progress
+    pub(super) fn run_until_stalled(&mut self) {
+        let wake_this = Arc::new(WakeThis {
+            woken: AtomicBool::new(false),
+        });
+        let waker = waker(wake_this.clone());
+        loop {
+            let Some(running) = &mut self.running else {
+                return;
+            };
+            let mut cx = Context::from_waker(&waker);
+
+            let pool_ret = running.poll_unpin(&mut cx);
+            match pool_ret {
+                Poll::Ready(()) => {
+                    // Make sure we don't poll the future once it's completed
+                    self.running = None;
+                    return;
+                }
+                Poll::Pending => {
+                    // Handle futures which call wake while we're polling them (as FuturesUnordered does)
+                    let woken = wake_this.woken.load(std::sync::atomic::Ordering::SeqCst);
+                    if woken {
+                        wake_this
+                            .woken
+                            .store(false, std::sync::atomic::Ordering::SeqCst);
+                        continue;
+                    } else {
+                        // We're stalled for now.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Problem: the beelay state machine is written using async/await syntax. To drive the resulting future we use futures::executor::LocalExecutor. This works but it throws an error if you try and use it inside the dynamic scope of another executor. For example, if you were to try and call `beelay_core::Beelay::handle_event` in a task running inside Tokio, you would get a panic. Additionally, `LocalExecutor` does a whole bunch of stuff parking and unparking the current thread which we just don't need to do.

Solution: replace `futures::executor::LocalExecutor` with a custom executor that just polls a single spawned future to completion. We don't need to be able to spawn new futures and it is very much not an error to drive the beelay state machine inside the dynamic scope of another executor.