### PR TITLE
Updates to JS WASM API to support end-to-end example

### DIFF
--- a/beelay/beelay-core/src/documents/commit_hash.rs
+++ b/beelay/beelay-core/src/documents/commit_hash.rs
@@ -1,10 +1,9 @@
-use dupe::Dupe;
 pub use error::InvalidCommitHash;
 
 use crate::serialization::{hex, parse, Encode, Parse};
 
 #[derive(
-    Clone, Copy, Dupe, Eq, Hash, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+    Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
 )]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct CommitHash([u8; 32]);

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1185,10 +1185,10 @@ impl<
     #[instrument(skip(self), fields(khid = %self.id()))]
     pub fn into_archive(&self) -> Archive<T> {
         Archive {
-            active: self.active.clone().borrow().into_archive(),
+            active: self.active.borrow().into_archive(),
             topsorted_ops: MembershipOperation::<S, T, L>::topsort(
-                &self.delegations.clone().borrow(),
-                &self.revocations.clone().borrow(),
+                &self.delegations.borrow(),
+                &self.revocations.borrow(),
             )
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
@@ -1196,17 +1196,17 @@ impl<
             individuals: self
                 .individuals
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().clone()))
+                .map(|(k, rc_v)| (*k, rc_v.borrow().clone()))
                 .collect(),
             groups: self
                 .groups
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().into_archive()))
+                .map(|(k, rc_v)| (*k, rc_v.borrow().into_archive()))
                 .collect(),
             docs: self
                 .docs
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().into_archive()))
+                .map(|(k, rc_v)| (*k, rc_v.borrow().into_archive()))
                 .collect(),
         }
     }

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1185,10 +1185,10 @@ impl<
     #[instrument(skip(self), fields(khid = %self.id()))]
     pub fn into_archive(&self) -> Archive<T> {
         Archive {
-            active: self.active.borrow().into_archive(),
+            active: self.active.clone().borrow().into_archive(),
             topsorted_ops: MembershipOperation::<S, T, L>::topsort(
-                &self.delegations.borrow(),
-                &self.revocations.borrow(),
+                &self.delegations.clone().borrow(),
+                &self.revocations.clone().borrow(),
             )
             .into_iter()
             .map(|(k, v)| (k.into(), v.into()))
@@ -1196,17 +1196,17 @@ impl<
             individuals: self
                 .individuals
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.borrow().clone()))
+                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().clone()))
                 .collect(),
             groups: self
                 .groups
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.borrow().into_archive()))
+                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().into_archive()))
                 .collect(),
             docs: self
                 .docs
                 .iter()
-                .map(|(k, rc_v)| (*k, rc_v.borrow().into_archive()))
+                .map(|(k, rc_v)| (*k, rc_v.clone().borrow().into_archive()))
                 .collect(),
         }
     }

--- a/keyhive_core/src/principal/individual/op.rs
+++ b/keyhive_core/src/principal/individual/op.rs
@@ -20,7 +20,7 @@ use std::{
 /// Operations for updating prekeys.
 ///
 /// Note that the number of keys only ever increases.
-/// This prevents the case where all keys are remved and the user is unable to be
+/// This prevents the case where all keys are removed and the user is unable to be
 /// added to a [`Cgka`][crate::cgka::Cgka].
 #[derive(Debug, Clone, Dupe, PartialEq, Eq, Hash, Serialize, Deserialize, From, TryInto)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]

--- a/keyhive_core/src/store/ciphertext.rs
+++ b/keyhive_core/src/store/ciphertext.rs
@@ -90,7 +90,7 @@ pub trait CiphertextStore<Cr: ContentRef, T>: Sized {
     ) -> impl Future<Output = Result<(), Self::MarkDecryptedError>>;
 
     #[cfg_attr(all(doc, feature = "mermaid_docs"), aquamarine::aquamarine)]
-    /// Recursively decryptsa set of causally-related ciphertexts.
+    /// Recursively decrypts a set of causally-related ciphertexts.
     ///
     /// Consider the following causally encrypted graph:
     ///
@@ -159,7 +159,7 @@ pub trait CiphertextStore<Cr: ContentRef, T>: Sized {
     /// By passing in the entrypoint, futher keys are discovered, and can be pulled out
     /// the store, which contain more keys and references, and so on.
     ///
-    /// It is normal for this to stop decryption if it enounters an already-decrypted
+    /// It is normal for this to stop decryption if it encounters an already-decrypted
     /// ciphertext. There is no reason to decrypt it again if you already have the plaintext.
     #[allow(async_fn_in_trait)]
     #[instrument(skip(self, to_decrypt), fields(ciphertext_heads_count = %to_decrypt.len()))]

--- a/keyhive_wasm/Cargo.toml
+++ b/keyhive_wasm/Cargo.toml
@@ -70,3 +70,4 @@ lto = true
 default = ["console_error_panic_hook", "web-sys", "json"]
 browser_test = []
 json = ["dep:serde_json"]
+ingest_static = ["keyhive_core/ingest_static"]

--- a/keyhive_wasm/README.md
+++ b/keyhive_wasm/README.md
@@ -28,7 +28,7 @@ Run tests:
 npx playwright test
 ```
 
-To view Playwright report:
+View Playwright report:
 ```
 npx playwright show-report
 ```

--- a/keyhive_wasm/README.md
+++ b/keyhive_wasm/README.md
@@ -1,0 +1,29 @@
+# Keyhive WASM bindings
+
+## Build package
+
+```
+wasm-pack build --target web --out-dir pkg -- --features web-sys
+```
+
+## Run tests
+
+Install dependencies:
+```
+pnpm install
+```
+
+Install Playwright's browser binaries:
+```
+npx playwright install
+```
+
+Run tests:
+```
+npx playwright test
+```
+
+To view Playwright report:
+```
+npx playwright show-report
+```

--- a/keyhive_wasm/README.md
+++ b/keyhive_wasm/README.md
@@ -6,6 +6,11 @@
 wasm-pack build --target web --out-dir pkg -- --features web-sys
 ```
 
+To build with the `ingest_static` feature:
+```
+wasm-pack build --target web --out-dir pkg -- --features web-sys,ingest_static
+```
+
 ## Run tests
 
 Install dependencies:

--- a/keyhive_wasm/e2e/document.spec.ts
+++ b/keyhive_wasm/e2e/document.spec.ts
@@ -12,16 +12,16 @@ test.describe("Document", async () => {
       const { Keyhive, Signer, ChangeRef, CiphertextStore } = window.keyhive;
 
       const store = CiphertextStore.newInMemory();
-      const bh = await Keyhive.init(
+      const kh = await Keyhive.init(
         await Signer.generate(),
         store,
-        console.log,
+        console.log
       );
       const changeRef = new ChangeRef(new Uint8Array([1, 2, 3]));
 
-      const g = await bh.generateGroup([]);
-      const doc = await bh.generateDocument([g.toPeer()], changeRef, []);
-      const docId = doc.id;
+      const g = await kh.generateGroup([])
+      const doc = await kh.generateDocument([g.toPeer()], changeRef, [])
+      const docId = doc.id
 
       return { doc, docId };
     });

--- a/keyhive_wasm/e2e/keyhive.spec.ts
+++ b/keyhive_wasm/e2e/keyhive.spec.ts
@@ -98,8 +98,12 @@ test.describe("Keyhive", async () => {
 
   test.describe("archive", async () => {
     const scenario = async () => {
-      const { Keyhive, Signer, Archive, ChangeRef, CiphertextStore } =
+      const { Keyhive, Signer, Access, Archive, ChangeRef, CiphertextStore, ContactCard, Individual } =
         window.keyhive;
+
+      function testContactCard(): ContactCard {
+        return ContactCard.fromJson(`{"Rotate":{"payload":{"old":[162,145,165,196,36,224,73,112,145,188,239,44,86,166,20,30,132,108,154,237,83,69,195,21,41,18,247,146,217,79,21,65],"new":[65,22,115,210,58,181,17,14,148,30,90,73,154,200,20,81,107,120,237,144,159,70,19,25,122,11,238,169,191,239,222,18]},"issuer":[89,148,210,47,52,105,242,130,40,253,172,205,17,39,98,47,171,251,25,33,19,205,115,101,160,144,209,139,13,6,168,3],"signature":[26,42,5,188,200,86,129,50,162,87,200,64,152,180,93,59,70,150,87,12,222,93,165,249,110,150,52,123,169,222,138,253,72,64,83,74,88,60,147,178,135,64,14,77,40,61,89,164,119,235,73,71,34,184,248,172,125,3,144,248,177,72,65,13]}}`)
+      }
 
       const signer = await Signer.generate();
       const secondSigner = signer.clone();
@@ -113,22 +117,26 @@ test.describe("Keyhive", async () => {
       await kh.generateGroup([d1.toPeer()]);
       await kh.generateGroup([g2.toPeer(), d1.toPeer()]);
 
+      const individual = kh.receiveContactCard(testContactCard());
+      const access = Access.tryFromString("write");
+      kh.addMember(individual.toAgent(), g2.toMembered(), access, []);
+
       const archive = kh.intoArchive();
       const archiveBytes = archive.toBytes();
       const archiveBytesIsUint8Array = archiveBytes instanceof Uint8Array;
       const newStore = CiphertextStore.newInMemory();
       const roundTrip = new Archive(archiveBytes).tryToKeyhive(
         newStore,
-        secondSigner,
+        secondSigner
       );
       return {
         archive,
         archiveBytes,
         keyhive: kh,
         roundTrip,
-        archiveBytesIsUint8Array,
+        archiveBytesIsUint8Array
       };
-    };
+    }
 
     test("makes a new group", async ({ page }) => {
       const out = await page.evaluate(scenario);

--- a/keyhive_wasm/e2e/keyhive.spec.ts
+++ b/keyhive_wasm/e2e/keyhive.spec.ts
@@ -99,11 +99,8 @@ test.describe("Keyhive", async () => {
   test.describe("archive", async () => {
     const scenario = async () => {
       const { Keyhive, Signer, Access, Archive, ChangeRef, CiphertextStore, ContactCard, Individual } =
-        window.keyhive;
-
-      function testContactCard(): ContactCard {
-        return ContactCard.fromJson(`{"Rotate":{"payload":{"old":[162,145,165,196,36,224,73,112,145,188,239,44,86,166,20,30,132,108,154,237,83,69,195,21,41,18,247,146,217,79,21,65],"new":[65,22,115,210,58,181,17,14,148,30,90,73,154,200,20,81,107,120,237,144,159,70,19,25,122,11,238,169,191,239,222,18]},"issuer":[89,148,210,47,52,105,242,130,40,253,172,205,17,39,98,47,171,251,25,33,19,205,115,101,160,144,209,139,13,6,168,3],"signature":[26,42,5,188,200,86,129,50,162,87,200,64,152,180,93,59,70,150,87,12,222,93,165,249,110,150,52,123,169,222,138,253,72,64,83,74,88,60,147,178,135,64,14,77,40,61,89,164,119,235,73,71,34,184,248,172,125,3,144,248,177,72,65,13]}}`)
-      }
+        window.keyhive
+      const testContactCard = ContactCard.fromJson(`{"Rotate":{"payload":{"old":[162,145,165,196,36,224,73,112,145,188,239,44,86,166,20,30,132,108,154,237,83,69,195,21,41,18,247,146,217,79,21,65],"new":[65,22,115,210,58,181,17,14,148,30,90,73,154,200,20,81,107,120,237,144,159,70,19,25,122,11,238,169,191,239,222,18]},"issuer":[89,148,210,47,52,105,242,130,40,253,172,205,17,39,98,47,171,251,25,33,19,205,115,101,160,144,209,139,13,6,168,3],"signature":[26,42,5,188,200,86,129,50,162,87,200,64,152,180,93,59,70,150,87,12,222,93,165,249,110,150,52,123,169,222,138,253,72,64,83,74,88,60,147,178,135,64,14,77,40,61,89,164,119,235,73,71,34,184,248,172,125,3,144,248,177,72,65,13]}}`)
 
       const signer = await Signer.generate();
       const secondSigner = signer.clone();
@@ -117,7 +114,7 @@ test.describe("Keyhive", async () => {
       await kh.generateGroup([d1.toPeer()]);
       await kh.generateGroup([g2.toPeer(), d1.toPeer()]);
 
-      const individual = kh.receiveContactCard(testContactCard());
+      const individual = kh.receiveContactCard(testContactCard)
       const access = Access.tryFromString("write");
       kh.addMember(individual.toAgent(), g2.toMembered(), access, []);
 

--- a/keyhive_wasm/src/js/agent.rs
+++ b/keyhive_wasm/src/js/agent.rs
@@ -1,4 +1,7 @@
-use super::{change_ref::JsChangeRef, event_handler::JsEventHandler, signer::JsSigner};
+use super::{
+    change_ref::JsChangeRef, event_handler::JsEventHandler, identifier::JsIdentifier,
+    signer::JsSigner,
+};
 use derive_more::{Deref, Display, From, Into};
 use keyhive_core::principal::agent::Agent;
 use wasm_bindgen::prelude::*;
@@ -34,5 +37,10 @@ impl JsAgent {
     #[wasm_bindgen(js_name = isDocument)]
     pub fn is_document(&self) -> bool {
         matches!(self.0, Agent::Document(_))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> JsIdentifier {
+        JsIdentifier(self.0.id())
     }
 }

--- a/keyhive_wasm/src/js/archive.rs
+++ b/keyhive_wasm/src/js/archive.rs
@@ -32,12 +32,12 @@ impl JsArchive {
     pub fn try_to_keyhive(
         &self,
         ciphertext_store: JsCiphertextStore,
-        signer: JsSigner,
+        signer: &JsSigner,
         event_handler: &js_sys::Function,
     ) -> Result<JsKeyhive, JsTryFromArchiveError> {
         Ok(Keyhive::try_from_archive(
             &self.0,
-            signer,
+            signer.clone(),
             ciphertext_store,
             event_handler.clone().into(),
             rand::thread_rng(),

--- a/keyhive_wasm/src/js/capability.rs
+++ b/keyhive_wasm/src/js/capability.rs
@@ -3,6 +3,7 @@ use super::{
     signed_delegation::JsSignedDelegation, signer::JsSigner,
 };
 use dupe::Dupe;
+use keyhive_core::access::Access;
 use keyhive_core::{
     crypto::signed::Signed,
     principal::{agent::Agent, group::delegation::Delegation},
@@ -32,5 +33,25 @@ impl Capability {
     #[wasm_bindgen(getter)]
     pub fn proof(&self) -> JsSignedDelegation {
         self.proof.dupe().into()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Dupe)]
+pub struct SimpleCapability {
+    pub(crate) who: Agent<JsSigner, JsChangeRef, JsEventHandler>,
+    pub(crate) can: Access,
+}
+
+#[wasm_bindgen]
+impl SimpleCapability {
+    #[wasm_bindgen(getter)]
+    pub fn who(&self) -> JsAgent {
+        JsAgent(self.who.dupe())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn can(&self) -> JsAccess {
+        JsAccess(self.can.dupe())
     }
 }

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -1,3 +1,5 @@
+use crate::js::document_id::JsDocumentId;
+
 use super::{
     agent::JsAgent, change_ref::JsChangeRef, event_handler::JsEventHandler,
     identifier::JsIdentifier, peer::JsPeer, signer::JsSigner,
@@ -17,6 +19,11 @@ impl JsDocument {
     #[wasm_bindgen(getter)]
     pub fn id(&self) -> JsIdentifier {
         JsIdentifier(self.0.borrow().id())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn doc_id(&self) -> JsDocumentId {
+        JsDocumentId(self.0.borrow().doc_id())
     }
 
     #[wasm_bindgen(js_name = toPeer)]

--- a/keyhive_wasm/src/js/document_id.rs
+++ b/keyhive_wasm/src/js/document_id.rs
@@ -1,5 +1,8 @@
 use derive_more::{Display, From, Into};
+use keyhive_core::principal::{document::id::DocumentId, identifier::Identifier};
 use wasm_bindgen::prelude::*;
+
+use crate::js::identifier::CannotParseIdentifier;
 
 #[wasm_bindgen(js_name = DocumentId)]
 #[derive(Debug, Clone, Copy, Display, From, Into)]
@@ -7,6 +10,17 @@ pub struct JsDocumentId(pub(crate) keyhive_core::principal::document::id::Docume
 
 #[wasm_bindgen(js_class = DocumentId)]
 impl JsDocumentId {
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: Vec<u8>) -> Result<Self, CannotParseIdentifier> {
+        let vec: [u8; 32] = bytes.try_into().map_err(|_| CannotParseIdentifier)?;
+
+        // NOTE signature::Error is opaque, so we can just ignore the inbuilt error
+        let vk =
+            ed25519_dalek::VerifyingKey::from_bytes(&vec).map_err(|_| CannotParseIdentifier)?;
+
+        Ok(JsDocumentId(DocumentId::from(Identifier::from(vk))))
+    }
+
     #[wasm_bindgen(js_name = fromString)]
     pub fn to_js_string(&self) -> String {
         self.to_string()
@@ -15,5 +29,10 @@ impl JsDocumentId {
     #[wasm_bindgen(js_name = toJsValue)]
     pub fn to_js_value(&self) -> JsValue {
         JsValue::from(self.to_js_string())
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
     }
 }

--- a/keyhive_wasm/src/js/identifier.rs
+++ b/keyhive_wasm/src/js/identifier.rs
@@ -1,9 +1,10 @@
 use keyhive_core::principal::identifier::Identifier;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = Identifier)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct JsIdentifier(pub(crate) Identifier);
 
 #[wasm_bindgen(js_class = Identifier)]

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -321,6 +321,16 @@ impl JsKeyhive {
     pub fn to_archive(&self) -> JsArchive {
         self.0.into_archive().into()
     }
+
+    #[cfg(any(test, feature = "ingest_static"))]
+    #[wasm_bindgen(js_name = ingestArchive)]
+    pub async fn ingest_archive(
+        &mut self,
+        archive: &JsArchive,
+    ) -> Result<(), JsReceiveStaticEventError> {
+        self.0.ingest_archive(archive.clone().0).await?;
+        Ok(())
+    }
 }
 
 #[wasm_bindgen]

--- a/keyhive_wasm/src/js/signed.rs
+++ b/keyhive_wasm/src/js/signed.rs
@@ -1,12 +1,23 @@
 use keyhive_core::crypto::{signed::Signed, verifiable::Verifiable};
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = Signed)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct JsSigned(pub(crate) Signed<Vec<u8>>);
 
 #[wasm_bindgen(js_class = Signed)]
 impl JsSigned {
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        bincode::deserialize(bytes).expect("FIXME")
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bincode::serialize(self).expect("FIXME")
+    }
+
     pub fn verify(&self) -> bool {
         self.0.try_verify().is_ok()
     }


### PR DESCRIPTION
These changes include:
* exposed some existing underlying methods
* added methods for getting all members with access to a doc and checking the access for an identifier to a doc
* defensive cloning so that developers don't need to understand when to call `.clone()` in JS code