### PR TITLE
Strip `Js` prefixes in `wasm_refgen`

### DIFF
--- a/keyhive_wasm/Cargo.toml
+++ b/keyhive_wasm/Cargo.toml
@@ -13,9 +13,9 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-from_js_ref = "0.1.0"
-keyhive_core = "0.2.0-alpha.1"
-wasm_refgen = "0.1.0"
+from_js_ref = { path = "../from_js_ref" }
+keyhive_core = { path = "../keyhive_core" }
+wasm_refgen = { path = "../wasm_refgen" }
 
 base64-simd = "0.8.0"
 bincode = { workspace = true }

--- a/wasm_refgen/src/lib.rs
+++ b/wasm_refgen/src/lib.rs
@@ -35,7 +35,11 @@ pub fn wasm_refgen(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    let core_name = ty_ident.to_string();
+    let struct_name = ty_ident.to_string();
+    let core_name = struct_name
+        .strip_prefix("Js")
+        .unwrap_or(&struct_name)
+        .to_string();
     let core_snake = core_name.to_snake_case();
 
     let upcast_tag = format!("__wasm_refgen_to{}", core_name);


### PR DESCRIPTION
Without stripping `Js` prefixes in the `wasm_refgen` macro, building the wasm package for the web target failed.