### PR TITLE
Add more WASM API methods

### DIFF
--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -283,6 +283,17 @@ impl<
     }
 
     #[instrument(skip_all)]
+    pub async fn get_existing_contact_card(&self) -> ContactCard {
+        self.active
+            .lock()
+            .await
+            .individual()
+            .lock()
+            .await
+            .contact_card()
+    }
+
+    #[instrument(skip_all)]
     pub async fn receive_contact_card(
         &self,
         contact_card: &ContactCard,

--- a/keyhive_wasm/src/js/identifier.rs
+++ b/keyhive_wasm/src/js/identifier.rs
@@ -1,4 +1,4 @@
-use keyhive_core::principal::identifier::Identifier;
+use keyhive_core::principal::{identifier::Identifier, public::Public};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
@@ -18,6 +18,11 @@ impl JsIdentifier {
             ed25519_dalek::VerifyingKey::from_bytes(&vec).map_err(|_| CannotParseIdentifier)?;
 
         Ok(JsIdentifier(Identifier::from(vk)))
+    }
+
+    #[wasm_bindgen(js_name = publicId)]
+    pub fn public_id() -> Self {
+        JsIdentifier(Public.id())
     }
 
     #[wasm_bindgen(js_name = toBytes)]

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -318,6 +318,12 @@ impl JsKeyhive {
             .map_err(Into::into)
     }
 
+    #[wasm_bindgen(js_name = getExistingContactCard)]
+    pub async fn get_existing_contact_card(&self) -> JsContactCard {
+        init_span!("JsKeyhive::get_existing_contact_card");
+        self.0.get_existing_contact_card().await.into()
+    }
+
     #[wasm_bindgen(js_name = receiveContactCard)]
     pub async fn receive_contact_card(
         &self,


### PR DESCRIPTION
Adds

* JsKeyhive.getExistingContactCard() - For retrieving the last contact card without triggering a key rotation.
* JsIdentifier.publicId() - For retrieving the id for `Public`