### PR TITLE
Add `skip(self)` to instrumentation of `try_verify`

### DIFF
--- a/keyhive_core/src/crypto/signed.rs
+++ b/keyhive_core/src/crypto/signed.rs
@@ -81,7 +81,7 @@ impl<T: Serialize + Debug> Signed<T> {
     /// let signed = signer.try_sign_sync("Hello, world!").unwrap();
     /// assert!(signed.try_verify().is_ok());
     /// ```
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn try_verify(&self) -> Result<(), VerificationError> {
         let buf: Vec<u8> = bincode::serialize(&self.payload)?;
         Ok(self


### PR DESCRIPTION
This was causing continuous memory growth in our test keyhive sync server. In the `wasm_tracing` crate, span strings are passed to the Performance API via `.measure()`, but the performance timeline is never cleared. This is a separate issue to investigate, but `skip(self)` is a change we should make anyway.