### PR TITLE
Remove derivative dependency

### DIFF
--- a/keyhive_core/Cargo.toml
+++ b/keyhive_core/Cargo.toml
@@ -35,7 +35,6 @@ x25519-dalek = { workspace = true }
 thiserror = { workspace = true }
 
 # Utilities
-derivative = "2.2"
 derive_more = { workspace = true }
 derive-where = "1.2"
 dupe = { workspace = true }

--- a/keyhive_core/src/crypto/envelope.rs
+++ b/keyhive_core/src/crypto/envelope.rs
@@ -1,6 +1,5 @@
 //! The (plaintext) container for causal encryption.
 
-use derivative::Derivative;
 use keyhive_crypto::{
     content::reference::ContentRef, read_capability::ReadCap, symmetric_key::SymmetricKey,
 };
@@ -78,7 +77,7 @@ use std::{
 /// ```
 ///
 /// [causal encryption]: https://github.com/inkandswitch/keyhive/blob/main/design/causal_encryption.md
-#[derive(Debug, Clone, PartialEq, Eq, Derivative, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Envelope<C: ContentRef + DeserializeOwned, T: Serialize> {
     /// The plaintext payload.
     pub plaintext: T,
@@ -87,10 +86,6 @@ pub struct Envelope<C: ContentRef + DeserializeOwned, T: Serialize> {
     #[serde(
         serialize_with = "ordered_map_serializer",
         deserialize_with = "ordered_map_deserializer"
-    )]
-    #[derivative(
-        PartialOrd(compare_with = "crate::util::partial_eq::hash_map_keys"),
-        Hash(hash_with = "crate::util::hasher::hash_map_keys")
     )]
     pub ancestors: HashMap<C, SymmetricKey>,
 }

--- a/keyhive_core/src/principal/active.rs
+++ b/keyhive_core/src/principal/active.rs
@@ -28,7 +28,6 @@ use crate::{
         merge::{Merge, MergeAsync},
     },
 };
-use derivative::Derivative;
 use dupe::Dupe;
 use future_form::FutureForm;
 use futures::{lock::Mutex, prelude::*};
@@ -40,12 +39,15 @@ use keyhive_crypto::{
     verifiable::Verifiable,
 };
 use serde::Serialize;
-use std::{collections::BTreeMap, fmt::Debug, marker::PhantomData, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    sync::Arc,
+};
 use thiserror::Error;
 
 /// The current user agent (which can sign and encrypt).
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Active<
     F: FutureForm,
     S: AsyncSigner<F>,
@@ -53,7 +55,6 @@ pub struct Active<
     L: PrekeyListener<F> = NoListener,
 > {
     /// The signing key of the active agent.
-    #[derivative(Debug = "ignore")]
     pub(crate) signer: S,
 
     // TODO generalize to use e.g. KMS for X25519 secret keys
@@ -65,10 +66,21 @@ pub struct Active<
     pub(crate) individual: Arc<Mutex<Individual>>,
 
     ///The listener for prekey events.
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
     pub(crate) listener: L,
 
     pub(crate) _phantom: PhantomData<(F, T)>,
+}
+
+impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: PrekeyListener<F>> Debug
+    for Active<F, S, T, L>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Active")
+            .field("prekey_pairs", &self.prekey_pairs)
+            .field("id", &self.id)
+            .field("individual", &self.individual)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: PrekeyListener<F>> Active<F, S, T, L> {

--- a/keyhive_core/src/principal/agent.rs
+++ b/keyhive_core/src/principal/agent.rs
@@ -12,7 +12,6 @@ use crate::{
     listener::{membership::MembershipListener, no_listener::NoListener},
     util::content_addressed_map::CaMap,
 };
-use derivative::Derivative;
 use derive_more::{From, TryInto};
 use derive_where::derive_where;
 use dupe::Dupe;
@@ -33,7 +32,7 @@ use std::{
 ///
 /// This type is very lightweight to clone, since it only contains immutable references to the actual agents.
 #[derive_where(Clone, Debug; T)]
-#[derive(From, TryInto, Derivative)]
+#[derive(From, TryInto)]
 pub enum Agent<
     F: FutureForm,
     S: AsyncSigner<F>,

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -34,7 +34,6 @@ use beekem::{
     keys::ShareKeyMap,
     operation::{CgkaEpoch, CgkaOperation},
 };
-use derivative::Derivative;
 use derive_where::derive_where;
 use dupe::Dupe;
 use ed25519_dalek::VerifyingKey;
@@ -60,7 +59,7 @@ use std::{
 use thiserror::Error;
 use tracing::instrument;
 
-#[derive(Clone, Derivative)]
+#[derive(Clone)]
 #[derive_where(Debug; T)]
 pub struct Document<
     F: FutureForm,

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -27,7 +27,6 @@ use crate::{
     store::{delegation::DelegationStore, revocation::RevocationStore},
 };
 use beekem::error::CgkaError;
-use derivative::Derivative;
 use derive_more::Debug;
 use derive_where::derive_where;
 use dupe::{Dupe, IterDupedExt};
@@ -60,7 +59,7 @@ use thiserror::Error;
 /// Groups are stateful agents. It is possible the delegate control over them,
 /// and they can be delegated to. This produces transitives lines of authority
 /// through the network of [`Agent`]s.
-#[derive(Clone, Derivative)]
+#[derive(Clone)]
 #[derive_where(Debug; T)]
 pub struct Group<
     F: FutureForm,

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -11,7 +11,6 @@ use crate::{
     transact::{fork::Fork, merge::Merge},
     util::content_addressed_map::CaMap,
 };
-use derivative::Derivative;
 use derive_more::Debug;
 use ed25519_dalek::VerifyingKey;
 use id::IndividualId;
@@ -35,8 +34,7 @@ use std::num::NonZeroUsize;
 /// `Individual`s can be thought of as the terminal agents. They represent
 /// keys that may sign ops, be delegated capabilties to
 /// [`Document`][super::document::Document]s and [`Group`][super::group::Group]s.
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
-#[derivative(PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Individual {
     /// The public key identifier.
     pub(crate) id: IndividualId,


### PR DESCRIPTION
## Summary

- Remove the `derivative` dependency from `keyhive_core`.
- Replace the remaining `Derivative` derives/field attrs with ordinary derives or a small manual `Debug` implementation for `Active`.

## Why

The crate already uses ordinary derives, `derive_where`, and `derive_more` for the relevant cases. Removing `derivative` reduces the dependency surface without changing public behavior.

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `cargo check -p keyhive_core`
