### PR TITLE
BeeKEM: Replace key ratcheting with independently sampled secrets

### DIFF
--- a/.github/workflows/dictionary.txt
+++ b/.github/workflows/dictionary.txt
@@ -17,6 +17,7 @@ ChaCha's
 Cohn-Gordon
 Crypto
 Cryptree
+CSPRNG
 Diffie-Hellman
 DCGKA
 DCGKA's

--- a/beekem/README.md
+++ b/beekem/README.md
@@ -6,7 +6,7 @@ A dynamic group of peers needs to maintain shared encryption keys over time, sup
 
 ## Tree Structure
 
-BeeKEM uses a binary ratchet tree:
+BeeKEM uses a binary tree:
 * Each leaf hold a member's identity and DH public key
 * The root holds the group's shared encryption key (encrypted)
 * Each inner node holds a DH public key and encrypted secrets (which effectively function as the shared key for its subtree/subgroup)
@@ -73,7 +73,7 @@ When a member rotates their leaf key, they encrypt a new secret at every ancesto
 
 2. **Walk up the path from the leaf toward the root.** At each parent node:
 
-   a. **Derive a new parent secret** by applying a one-way ratchet (BLAKE3-based KDF) to the child secret. The child secret at the first step is the leaf's secret key; at subsequent steps, it is the secret just derived for the previous parent. This means each ancestor's secret is deterministically derived from the leaf secret by ratcheting forward once per level.
+   a. **Sample a new parent secret** from the CSPRNG. Every ancestor's secret is sampled independently, so learning one secret on the path reveals nothing about the secrets above it. The encrypter keeps each sampled secret in its own key map so that it can derive the root secret later without decrypting its own path.
 
    b. **Compute the new parent public key** from the new parent secret.
 
@@ -97,11 +97,7 @@ When a member rotates their leaf key, they encrypt a new secret at every ancesto
 
 Any group member can derive the current root secret by traversing from their leaf up to the root, decrypting at each step.
 
-1. **Shortcut for the encrypter.** If the member performing decryption is the same member who last encrypted the path, they already know their leaf secret. They simply ratchet it forward by the length of the path (one ratchet per ancestor) to directly derive the root secret. No DH or decryption is needed.
-
-2. **Find the lowest common ancestor (LCA)** of your leaf and the encrypter's leaf. This is the point where your path intersects the encrypter's path. You only need to decrypt up to the LCA. From there, you can ratchet forward to derive the root.
-
-3. **Walk up your path from your leaf.** Keep track of every index you visit (a "seen indices" list). At each parent:
+1. **Walk up your path from your leaf.** Keep track of every index you visit (a "seen indices" list). At each parent:
 
    a. **Skip blank and conflict parents.** If a parent is blank or has conflict keys, skip it and move up to the next ancestor. You must hold onto the last secret you decrypted.
 
@@ -111,7 +107,7 @@ Any group member can derive the current root secret by traversing from their lea
 
    d. **Store the decrypted secret** in your key map (mapping the parent's public key to the decrypted secret). This is reusable for future decryptions.
 
-4. **Once you reach the LCA**, ratchet the decrypted secret forward by the number of remaining ancestors between the LCA and the root. Return this as the root secret.
+2. **Once you reach the root**, the last secret you decrypted is the root secret. Return it.
 
 ## Adding a Member
 
@@ -191,4 +187,4 @@ A secret store "has a conflict" when it has more than one version.
 
 **An adversary needs all historical leaf secrets from at least one leaf to exploit conflict merges.** Because conflict keys are retained (rather than picking a winner), an adversary who compromises one branch of a fork cannot read the other branch without also knowing its leaf secrets.
 
-**A root secret always corresponds to a specific update at a specific leaf.** It is never a "merged" root secret. Instead, it is always the product of one member's path encryption. Other members decrypt it by traversing up to their lowest common ancestor with the encrypter and ratcheting from there.
+**A root secret always corresponds to a specific update at a specific leaf.** It is never a "merged" root secret. Instead, it is always the product of one member's path encryption. Other members decrypt it by traversing all the way from their leaf to the root.

--- a/beekem/src/tree.rs
+++ b/beekem/src/tree.rs
@@ -69,10 +69,6 @@ pub struct BeeKem {
     inner_nodes: Vec<Option<InnerNode>>,
     tree_size: TreeSize,
     id_to_leaf_idx: BTreeMap<MemberId, LeafNodeIndex>,
-    /// The leaf node that was the source of the last path encryption, or [`None`]
-    /// if there is currently no root key. This is used to determine when a
-    /// decrypter has intersected with the encrypter's path.
-    current_secret_encrypter_leaf_idx: Option<LeafNodeIndex>,
 }
 
 impl BeeKem {
@@ -88,7 +84,6 @@ impl BeeKem {
             inner_nodes: Vec::new(),
             tree_size: TreeSize::from_leaf_count(1),
             id_to_leaf_idx: BTreeMap::new(),
-            current_secret_encrypter_leaf_idx: None,
         };
         tree.grow_tree_to_size();
         tree.push_leaf(initial_member_id, initial_member_pk.into());
@@ -216,19 +211,6 @@ impl BeeKem {
             .leaf(leaf_idx)
             .as_ref()
             .expect("Leaf should not be blank");
-        if Some(leaf_idx) == self.current_secret_encrypter_leaf_idx {
-            let NodeKey::ShareKey(pk) = leaf.pk else {
-                return Err(CgkaError::ShareKeyNotFound);
-            };
-            let secret = owner_sks.get(&pk).ok_or(CgkaError::ShareKeyNotFound)?;
-            return Ok(secret
-                .ratchet_n_forward(treemath::direct_path(leaf_idx.into(), self.tree_size).len()));
-        }
-        let lca_with_encrypter = treemath::lowest_common_ancestor(
-            leaf_idx,
-            self.current_secret_encrypter_leaf_idx
-                .expect("A tree with a root key should have a current encrypter"),
-        );
         let mut child_idx: TreeNodeIndex = leaf_idx.into();
         let mut seen_idxs = vec![child_idx];
         // We will return this at the end once we've decrypted the root secret.
@@ -244,15 +226,8 @@ impl BeeKem {
             debug_assert!(!self.is_root(child_idx));
             maybe_last_secret_decrypted =
                 self.maybe_decrypt_parent_key(child_idx, &child_node_key, &seen_idxs, owner_sks)?;
-            let Some(ref secret) = maybe_last_secret_decrypted else {
+            if maybe_last_secret_decrypted.is_none() {
                 panic!("Non-blank, non-conflict parent should have a secret we can decrypt");
-            };
-            // If we have reached the intersection of our path with the encrypter's
-            // path, then we can ratchet this parent secret forward for each of the
-            // remaining nodes in the path and return early.
-            if parent_idx == TreeNodeIndex::Inner(lca_with_encrypter) {
-                return Ok(secret
-                    .ratchet_n_forward(treemath::direct_path(parent_idx, self.tree_size).len()));
             }
             seen_idxs.push(parent_idx);
             child_idx = parent_idx;
@@ -305,8 +280,11 @@ impl BeeKem {
             if let Some(store) = self.inner_node(parent_idx) {
                 new_path.removed_keys.append(&mut store.node_key().keys());
             }
-            let new_parent_sk = child_sk.ratchet_forward();
+            let new_parent_sk = ShareSecretKey::generate(csprng);
             let new_parent_pk = new_parent_sk.share_key();
+            // Hold on to the secret so we can derive the root key later without
+            // having to decrypt our own path.
+            sks.insert(new_parent_pk, new_parent_sk);
             self.encrypt_key_for_parent(
                 child_idx,
                 child_pk,
@@ -327,7 +305,6 @@ impl BeeKem {
             child_sk = new_parent_sk;
             parent_idx = treemath::parent(child_idx);
         }
-        self.current_secret_encrypter_leaf_idx = Some(leaf_idx);
         Ok(Some((child_sk.into(), new_path)))
     }
 
@@ -370,12 +347,6 @@ impl BeeKem {
             } else {
                 self.insert_inner_node_at(current_idx, node.clone());
             }
-        }
-
-        if self.has_root_key() {
-            self.current_secret_encrypter_leaf_idx = Some(leaf_idx);
-        } else {
-            self.current_secret_encrypter_leaf_idx = None;
         }
     }
 
@@ -587,7 +558,6 @@ impl BeeKem {
             idx = treemath::parent(idx.into());
         }
         self.blank_inner_node(idx);
-        self.current_secret_encrypter_leaf_idx = None;
     }
 
     fn blank_inner_node(&mut self, idx: InnerNodeIndex) {

--- a/beekem/src/treemath.rs
+++ b/beekem/src/treemath.rs
@@ -376,28 +376,6 @@ pub(crate) fn direct_path(node_index: TreeNodeIndex, size: TreeSize) -> Vec<Inne
     d
 }
 
-/// Common ancestor of two leaf nodes, aka the node where their direct paths
-/// intersect.
-pub(super) fn lowest_common_ancestor(x: LeafNodeIndex, y: LeafNodeIndex) -> InnerNodeIndex {
-    let x = x.to_tree_index();
-    let y = y.to_tree_index();
-    let (lx, ly) = (level(x) + 1, level(y) + 1);
-    if (lx <= ly) && (x >> ly == y >> ly) {
-        return InnerNodeIndex::from_tree_index(y);
-    } else if (ly <= lx) && (x >> lx == y >> lx) {
-        return InnerNodeIndex::from_tree_index(x);
-    }
-
-    let (mut xn, mut yn) = (x, y);
-    let mut k = 0;
-    while xn != yn {
-        xn >>= 1;
-        yn >>= 1;
-        k += 1;
-    }
-    InnerNodeIndex::from_tree_index((xn << k) + (1 << (k - 1)) - 1)
-}
-
 #[allow(dead_code)]
 #[cfg(any(feature = "test_utils", test))]
 pub(crate) fn is_node_in_tree(node_index: TreeNodeIndex, size: TreeSize) -> bool {


### PR DESCRIPTION
Before this change, the secrets placed along a beekem path were ratcheted. When decrypting a beekem path from your leaf, you could then ratchet from your least common ancestor node with the last root secret encrypter's leaf. But this meant compromising an inner node secret gave you access to ancestor nodes you had not compromised. 

This commit replaces ratcheting with randomly sampling every secret on the path.