### PR TITLE
Fixes for CGKA access

### DIFF
--- a/beekem/src/cgka.rs
+++ b/beekem/src/cgka.rs
@@ -364,6 +364,11 @@ impl Cgka {
         self.tree.member_count()
     }
 
+    /// The members currently in the tree.
+    pub fn member_ids(&self) -> impl Iterator<Item = &MemberId> {
+        self.tree.member_ids()
+    }
+
     /// Merges concurrent [`CgkaOperation`]. Returns `Ok(true)` if merge is successful.
     ///
     /// If we receive a concurrent membership change (i.e., add or remove), then

--- a/beekem/src/cgka.rs
+++ b/beekem/src/cgka.rs
@@ -365,7 +365,7 @@ impl Cgka {
     }
 
     /// The members currently in the tree.
-    pub fn member_ids(&self) -> impl Iterator<Item = &MemberId> {
+    pub fn member_ids(&self) -> impl Iterator<Item = MemberId> + '_ {
         self.tree.member_ids()
     }
 

--- a/beekem/src/tree.rs
+++ b/beekem/src/tree.rs
@@ -94,6 +94,11 @@ impl BeeKem {
         self.id_to_leaf_idx.contains_key(id)
     }
 
+    /// The members currently in the tree.
+    pub fn member_ids(&self) -> impl Iterator<Item = &MemberId> {
+        self.id_to_leaf_idx.keys()
+    }
+
     pub fn node_key_for_id(&self, id: MemberId) -> Result<NodeKey, CgkaError> {
         let idx = self.leaf_index_for_id(id)?;
         self.node_key_for_index((*idx).into())

--- a/beekem/src/tree.rs
+++ b/beekem/src/tree.rs
@@ -95,8 +95,8 @@ impl BeeKem {
     }
 
     /// The members currently in the tree.
-    pub fn member_ids(&self) -> impl Iterator<Item = &MemberId> {
-        self.id_to_leaf_idx.keys()
+    pub fn member_ids(&self) -> impl Iterator<Item = MemberId> + '_ {
+        self.id_to_leaf_idx.keys().copied()
     }
 
     pub fn node_key_for_id(&self, id: MemberId) -> Result<NodeKey, CgkaError> {

--- a/keyhive_core/src/cgka.rs
+++ b/keyhive_core/src/cgka.rs
@@ -200,9 +200,7 @@ impl Cgka {
 
     /// The individuals currently in this document's CGKA tree.
     pub fn member_ids(&self) -> impl Iterator<Item = IndividualId> + '_ {
-        self.0
-            .member_ids()
-            .map(|member_id| IndividualId(Identifier(member_id.0)))
+        self.0.member_ids().map(IndividualId::from)
     }
 
     pub fn merge_concurrent_operation(

--- a/keyhive_core/src/cgka.rs
+++ b/keyhive_core/src/cgka.rs
@@ -198,6 +198,13 @@ impl Cgka {
         self.0.group_size()
     }
 
+    /// The individuals currently in this document's CGKA tree.
+    pub fn member_ids(&self) -> impl Iterator<Item = IndividualId> + '_ {
+        self.0
+            .member_ids()
+            .map(|member_id| IndividualId(Identifier(member_id.0)))
+    }
+
     pub fn merge_concurrent_operation(
         &mut self,
         op: Arc<Signed<CgkaOperation>>,

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -4802,7 +4802,7 @@ mod tests {
             .await?;
 
         assert!(
-            { doc.lock().await.cgka_members()?.contains(&bob_id) },
+            { doc.lock().await.cgka_members()?.any(|m| m == bob_id) },
             "Bob should hold a key while he reads the document through G"
         );
 
@@ -4811,7 +4811,7 @@ mod tests {
             .await?;
 
         assert!(
-            !{ doc.lock().await.cgka_members()?.contains(&bob_id) },
+            !{ doc.lock().await.cgka_members()?.any(|m| m == bob_id) },
             "Bob kept his key on a document he may now only relay"
         );
 
@@ -5575,7 +5575,7 @@ mod tests {
             )
             .await?;
             assert!(
-                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                !{ doc.lock().await.cgka_members()?.any(|m| m == id) },
                 "a relay member of the document has cgka access to it"
             );
         }
@@ -5603,7 +5603,7 @@ mod tests {
             )
             .await?;
             assert!(
-                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                !{ doc.lock().await.cgka_members()?.any(|m| m == id) },
                 "someone who may only relay the group has cgka access to a document it edits"
             );
         }
@@ -5631,7 +5631,7 @@ mod tests {
             )
             .await?;
             assert!(
-                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                !{ doc.lock().await.cgka_members()?.any(|m| m == id) },
                 "a relay member added to a group that already holds the document has cgka access"
             );
 
@@ -5645,7 +5645,7 @@ mod tests {
             )
             .await?;
             assert!(
-                !{ doc.lock().await.cgka_members()?.contains(&id2) },
+                !{ doc.lock().await.cgka_members()?.any(|m| m == id2) },
                 "a relay member has cgka access before being promoted"
             );
             hive.add_member(
@@ -5656,7 +5656,7 @@ mod tests {
             )
             .await?;
             assert!(
-                { doc.lock().await.cgka_members()?.contains(&id2) },
+                { doc.lock().await.cgka_members()?.any(|m| m == id2) },
                 "promoting to read within the group did not grant cgka access"
             );
         }
@@ -5685,7 +5685,7 @@ mod tests {
             )
             .await?;
             assert!(
-                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                !{ doc.lock().await.cgka_members()?.any(|m| m == id) },
                 "a reader in a group that may only relay the document has cgka access"
             );
         }
@@ -5738,9 +5738,8 @@ mod tests {
             "carol relays the group, so she relays the document"
         );
 
-        let cgka_members = { doc.lock().await.cgka_members()? };
         assert!(
-            !cgka_members.contains(&carol_id),
+            !{ doc.lock().await.cgka_members()?.any(|m| m == carol_id) },
             "carol cannot read the document, yet has cgka access to it"
         );
 

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -5457,6 +5457,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_relay_does_not_get_into_cgka_tree() -> TestResult {
+        test_utils::init_logging();
+
+        let mk_hive = || async {
+            let sk = MemorySigner::generate(&mut rand::rngs::OsRng);
+            Keyhive::<Sendable, MemorySigner, [u8; 32], String, _, NoListener, _>::generate(
+                sk,
+                Arc::new(Mutex::new(MemoryCiphertextStore::new())),
+                NoListener,
+                rand::rngs::OsRng,
+            )
+            .await
+        };
+
+        async fn mk_person(
+            hive: &Keyhive<
+                Sendable,
+                MemorySigner,
+                [u8; 32],
+                String,
+                Arc<Mutex<MemoryCiphertextStore<[u8; 32], String>>>,
+                NoListener,
+                rand::rngs::OsRng,
+            >,
+        ) -> (
+            IndividualId,
+            Agent<Sendable, MemorySigner, [u8; 32], NoListener>,
+        ) {
+            let sk = MemorySigner::generate(&mut rand::rngs::OsRng);
+            let indie = Arc::new(Mutex::new(
+                Individual::generate::<Sendable, _, _>(&sk, &mut rand::rngs::OsRng)
+                    .await
+                    .unwrap(),
+            ));
+            hive.register_individual(indie.dupe()).await;
+            let id = { indie.lock().await.id() };
+            (id, Agent::Individual(id, indie))
+        }
+
+        // a) relay directly on the document
+        {
+            let hive = mk_hive().await?;
+            let (id, agent) = mk_person(&hive).await;
+            let doc = hive.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+            let doc_id = DocumentId(doc.lock().await.id());
+            hive.add_member(
+                agent,
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+            assert!(
+                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                "a relay member of the document holds a key to it"
+            );
+        }
+
+        // b) relay in a group, then the group is given edit on the document
+        {
+            let hive = mk_hive().await?;
+            let (id, agent) = mk_person(&hive).await;
+            let group = hive.generate_group(vec![]).await?;
+            let group_id = { group.lock().await.group_id() };
+            hive.add_member(
+                agent,
+                &Membered::Group(group_id, group.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+            let doc = hive.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+            let doc_id = DocumentId(doc.lock().await.id());
+            hive.add_member(
+                Agent::Group(group_id, group.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Edit,
+                &[],
+            )
+            .await?;
+            assert!(
+                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                "someone who may only relay the group holds a key to a document it edits"
+            );
+        }
+
+        // c) the same, in the other order
+        {
+            let hive = mk_hive().await?;
+            let (id, agent) = mk_person(&hive).await;
+            let group = hive.generate_group(vec![]).await?;
+            let group_id = { group.lock().await.group_id() };
+            let doc = hive.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+            let doc_id = DocumentId(doc.lock().await.id());
+            hive.add_member(
+                Agent::Group(group_id, group.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Edit,
+                &[],
+            )
+            .await?;
+            hive.add_member(
+                agent,
+                &Membered::Group(group_id, group.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+            assert!(
+                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                "a relay member added to a group that already holds the document holds a key"
+            );
+
+            // d) then promote that member to read within the group
+            let (id2, agent2) = mk_person(&hive).await;
+            hive.add_member(
+                agent2.dupe(),
+                &Membered::Group(group_id, group.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+            assert!(
+                !{ doc.lock().await.cgka_members()?.contains(&id2) },
+                "a relay member holds a key before being promoted"
+            );
+            hive.add_member(
+                agent2,
+                &Membered::Group(group_id, group.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+            assert!(
+                { doc.lock().await.cgka_members()?.contains(&id2) },
+                "promoting to read within the group did not hand over a key"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_group_member_below_read_gets_no_key() -> TestResult {
         test_utils::init_logging();
 

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -4759,6 +4759,65 @@ mod tests {
         Ok(())
     }
 
+    /// Bob reads Doc D through Group G and separately has relay access to D directly.
+    /// Revoke G from D. Bob should lose his cgka access.
+    #[tokio::test]
+    async fn test_revoke_leaves_no_key_with_a_direct_relay_member() -> TestResult {
+        test_utils::init_logging();
+
+        let alice = make_keyhive().await;
+        let bob_kh = make_keyhive().await;
+        let (bob_id, bob_indie) = register_peer(&alice, &bob_kh).await;
+
+        // G with Bob as a reader
+        let g = alice.generate_group(vec![]).await?;
+        let g_id = g.lock().await.group_id();
+        alice
+            .add_member(
+                Agent::Individual(bob_id, bob_indie.dupe()),
+                &Membered::Group(g_id, g.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+
+        // Doc D, which G reads and Bob may also relay in his own right
+        let doc = alice.generate_doc(vec![], nonempty![[0u8; 32]]).await?;
+        let doc_id = doc.lock().await.doc_id();
+        alice
+            .add_member(
+                Agent::Group(g_id, g.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+        alice
+            .add_member(
+                Agent::Individual(bob_id, bob_indie.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+
+        assert!(
+            { doc.lock().await.cgka_members()?.contains(&bob_id) },
+            "Bob should hold a key while he reads the document through G"
+        );
+
+        alice
+            .revoke_member(g_id.into(), true, &Membered::Document(doc_id, doc.dupe()))
+            .await?;
+
+        assert!(
+            !{ doc.lock().await.cgka_members()?.contains(&bob_id) },
+            "Bob kept his key on a document he may now only relay"
+        );
+
+        Ok(())
+    }
+
     /// G in G1 in D1, and G in G2 in D2. Bob in G.
     /// Revoke G from G1 → Bob loses D1, keeps D2.
     #[tokio::test]

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -502,17 +502,23 @@ impl<
                     let group_identifier: Identifier = (*group_id).into();
                     let docs = { self.docs.lock().await.values().cloned().collect::<Vec<_>>() };
                     for doc in &docs {
-                        let (contains_group, doc_id) = {
+                        let (group_access, doc_id) = {
                             let locked = doc.lock().await;
                             (
                                 locked
                                     .transitive_members()
                                     .await
-                                    .contains_key(&group_identifier),
+                                    .get(&group_identifier)
+                                    .map(|(_, access)| *access),
                                 locked.doc_id(),
                             )
                         };
-                        if !contains_group {
+                        let Some(group_access) = group_access else {
+                            continue;
+                        };
+                        // The new member cannot read this document through a
+                        // group that may not read it either.
+                        if !can.min(group_access).is_reader() {
                             continue;
                         }
                         // Document lock is intentionally dropped before `pick_individual_prekeys`,
@@ -5511,7 +5517,7 @@ mod tests {
             .await?;
             assert!(
                 !{ doc.lock().await.cgka_members()?.contains(&id) },
-                "a relay member of the document holds a key to it"
+                "a relay member of the document has cgka access to it"
             );
         }
 
@@ -5539,7 +5545,7 @@ mod tests {
             .await?;
             assert!(
                 !{ doc.lock().await.cgka_members()?.contains(&id) },
-                "someone who may only relay the group holds a key to a document it edits"
+                "someone who may only relay the group has cgka access to a document it edits"
             );
         }
 
@@ -5567,7 +5573,7 @@ mod tests {
             .await?;
             assert!(
                 !{ doc.lock().await.cgka_members()?.contains(&id) },
-                "a relay member added to a group that already holds the document holds a key"
+                "a relay member added to a group that already holds the document has cgka access"
             );
 
             // d) then promote that member to read within the group
@@ -5581,7 +5587,7 @@ mod tests {
             .await?;
             assert!(
                 !{ doc.lock().await.cgka_members()?.contains(&id2) },
-                "a relay member holds a key before being promoted"
+                "a relay member has cgka access before being promoted"
             );
             hive.add_member(
                 agent2,
@@ -5592,7 +5598,36 @@ mod tests {
             .await?;
             assert!(
                 { doc.lock().await.cgka_members()?.contains(&id2) },
-                "promoting to read within the group did not hand over a key"
+                "promoting to read within the group did not grant cgka access"
+            );
+        }
+
+        // e) the opposite of b): the group only has relay for the document and a reader
+        //    is added to the group
+        {
+            let hive = mk_hive().await?;
+            let (id, agent) = mk_person(&hive).await;
+            let group = hive.generate_group(vec![]).await?;
+            let group_id = { group.lock().await.group_id() };
+            let doc = hive.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+            let doc_id = DocumentId(doc.lock().await.id());
+            hive.add_member(
+                Agent::Group(group_id, group.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Relay,
+                &[],
+            )
+            .await?;
+            hive.add_member(
+                agent,
+                &Membered::Group(group_id, group.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+            assert!(
+                !{ doc.lock().await.cgka_members()?.contains(&id) },
+                "a reader in a group that may only relay the document has cgka access"
             );
         }
 
@@ -5647,7 +5682,7 @@ mod tests {
         let cgka_members = { doc.lock().await.cgka_members()? };
         assert!(
             !cgka_members.contains(&carol_id),
-            "carol cannot read the document, yet holds a key to it"
+            "carol cannot read the document, yet has cgka access to it"
         );
 
         Ok(())

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -5457,6 +5457,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_group_member_below_read_gets_no_key() -> TestResult {
+        test_utils::init_logging();
+
+        let mut csprng = rand::rngs::OsRng;
+        let sk = MemorySigner::generate(&mut csprng);
+        let hive: Keyhive<Sendable, MemorySigner, [u8; 32], String, _, NoListener, _> =
+            Keyhive::generate(
+                sk,
+                Arc::new(Mutex::new(MemoryCiphertextStore::new())),
+                NoListener,
+                rand::rngs::OsRng,
+            )
+            .await?;
+
+        // Carol may only relay the group, which is below read.
+        let carol_sk = MemorySigner::generate(&mut csprng);
+        let carol = Arc::new(Mutex::new(
+            Individual::generate::<Sendable, _, _>(&carol_sk, &mut csprng).await?,
+        ));
+        hive.register_individual(carol.dupe()).await;
+        let carol_id = { carol.lock().await.id() };
+        let carol_agent = Agent::Individual(carol_id, carol.dupe());
+
+        let group = hive.generate_group(vec![]).await?;
+        let group_id = { group.lock().await.group_id() };
+        let membered_group = Membered::Group(group_id, group.dupe());
+        hive.add_member(carol_agent, &membered_group, Access::Relay, &[])
+            .await?;
+
+        // The group edits the document.
+        let doc = hive.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+        let doc_id = DocumentId(doc.lock().await.id());
+        let membered_doc = Membered::Document(doc_id, doc.dupe());
+        let group_agent = Agent::Group(group_id, group.dupe());
+        hive.add_member(group_agent, &membered_doc, Access::Edit, &[])
+            .await?;
+
+        let transitive = { doc.lock().await.transitive_members().await };
+        assert_eq!(
+            transitive.get(&carol_id.into()).map(|(_, access)| *access),
+            Some(Access::Relay),
+            "carol relays the group, so she relays the document"
+        );
+
+        let cgka_members = { doc.lock().await.cgka_members()? };
+        assert!(
+            !cgka_members.contains(&carol_id),
+            "carol cannot read the document, yet holds a key to it"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_async_transaction() -> TestResult {
         test_utils::init_logging();
 

--- a/keyhive_core/src/principal/agent.rs
+++ b/keyhive_core/src/principal/agent.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     listener::{membership::MembershipListener, no_listener::NoListener},
+    principal::group::delegation::Delegation,
     util::content_addressed_map::CaMap,
 };
 use derivative::Derivative;
@@ -20,9 +21,10 @@ use ed25519_dalek::VerifyingKey;
 use future_form::FutureForm;
 use futures::lock::Mutex;
 use keyhive_crypto::{
-    content::reference::ContentRef, share_key::ShareKey, signer::async_signer::AsyncSigner,
-    verifiable::Verifiable,
+    content::reference::ContentRef, share_key::ShareKey, signed::Signed,
+    signer::async_signer::AsyncSigner, verifiable::Verifiable,
 };
+use nonempty::NonEmpty;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
@@ -81,6 +83,24 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
         }
     }
 
+    /// Queue everyone a group or document delegates to at
+    /// [`Access::Read`](crate::access::Access::Read) or better, once each.
+    #[allow(clippy::type_complexity)]
+    fn push_readers(
+        stack: &mut Vec<Self>,
+        members: &HashMap<Identifier, NonEmpty<Arc<Signed<Delegation<F, S, T, L>>>>>,
+    ) {
+        for dlgs in members.values() {
+            if dlgs.iter().any(|d| d.payload.can.is_reader()) {
+                stack.push(dlgs[0].payload.delegate.dupe());
+            }
+        }
+    }
+
+    /// The individuals reachable from this agent by delegations of
+    /// [`Access::Read`](crate::access::Access::Read) or better.
+    ///
+    /// Someone reachable only by relay is not entitled to decrypt anything.
     pub async fn individual_ids(&self) -> HashSet<IndividualId> {
         let mut ids = HashSet::new();
         let mut seen = HashSet::new();
@@ -97,26 +117,11 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                 Agent::Individual(i_id, _) => {
                     ids.insert(i_id);
                 }
-                // Only members who are at least read are followed.
                 Agent::Group(_, g) => {
-                    let locked_group = g.lock().await;
-                    for ms in locked_group.members().values() {
-                        for m in ms {
-                            if m.payload.can.is_reader() {
-                                stack.push(m.payload.delegate.dupe());
-                            }
-                        }
-                    }
+                    Self::push_readers(&mut stack, g.lock().await.members());
                 }
                 Agent::Document(_, d) => {
-                    let locked_doc = d.lock().await;
-                    for ms in locked_doc.members().values() {
-                        for m in ms {
-                            if m.payload.can.is_reader() {
-                                stack.push(m.payload.delegate.dupe());
-                            }
-                        }
-                    }
+                    Self::push_readers(&mut stack, d.lock().await.members());
                 }
             }
         }
@@ -124,6 +129,8 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
         ids
     }
 
+    /// A prekey for each individual reachable from this agent by delegations
+    /// of [`Access::Read`](crate::access::Access::Read) or better.
     pub async fn pick_individual_prekeys(
         &self,
         doc_id: DocumentId,
@@ -153,26 +160,11 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     };
                     result.insert(id, prekey);
                 }
-                // Only members who are at least read are followed.
                 Agent::Group(_, g) => {
-                    let locked_group = g.lock().await;
-                    for ms in locked_group.members().values() {
-                        for m in ms {
-                            if m.payload.can.is_reader() {
-                                stack.push(m.payload.delegate.dupe());
-                            }
-                        }
-                    }
+                    Self::push_readers(&mut stack, g.lock().await.members());
                 }
                 Agent::Document(_, d) => {
-                    let locked_doc = d.lock().await;
-                    for ms in locked_doc.members().values() {
-                        for m in ms {
-                            if m.payload.can.is_reader() {
-                                stack.push(m.payload.delegate.dupe());
-                            }
-                        }
-                    }
+                    Self::push_readers(&mut stack, d.lock().await.members());
                 }
             }
         }

--- a/keyhive_core/src/principal/agent.rs
+++ b/keyhive_core/src/principal/agent.rs
@@ -62,6 +62,20 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     }
 }
 
+/// Queue everyone a group or document delegates to at
+/// [`Access::Read`](crate::access::Access::Read) or better, once each.
+#[allow(clippy::type_complexity)]
+fn push_readers<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S, T>>(
+    readers: &mut Vec<Agent<F, S, T, L>>,
+    members: &HashMap<Identifier, NonEmpty<Arc<Signed<Delegation<F, S, T, L>>>>>,
+) {
+    for dlgs in members.values() {
+        if dlgs.iter().any(|d| d.payload.can.is_reader()) {
+            readers.push(dlgs[0].payload.delegate.dupe());
+        }
+    }
+}
+
 impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S, T>>
     Agent<F, S, T, L>
 {
@@ -83,20 +97,6 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
         }
     }
 
-    /// Queue everyone a group or document delegates to at
-    /// [`Access::Read`](crate::access::Access::Read) or better, once each.
-    #[allow(clippy::type_complexity)]
-    fn push_readers(
-        stack: &mut Vec<Self>,
-        members: &HashMap<Identifier, NonEmpty<Arc<Signed<Delegation<F, S, T, L>>>>>,
-    ) {
-        for dlgs in members.values() {
-            if dlgs.iter().any(|d| d.payload.can.is_reader()) {
-                stack.push(dlgs[0].payload.delegate.dupe());
-            }
-        }
-    }
-
     /// The individuals reachable from this agent by delegations of
     /// [`Access::Read`](crate::access::Access::Read) or better.
     ///
@@ -104,9 +104,9 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     pub async fn individual_ids(&self) -> HashSet<IndividualId> {
         let mut ids = HashSet::new();
         let mut seen = HashSet::new();
-        let mut stack: Vec<Self> = vec![self.dupe()];
+        let mut readers: Vec<Self> = vec![self.dupe()];
 
-        while let Some(node) = stack.pop() {
+        while let Some(node) = readers.pop() {
             if !seen.insert(node.id()) {
                 continue;
             }
@@ -118,10 +118,10 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     ids.insert(i_id);
                 }
                 Agent::Group(_, g) => {
-                    Self::push_readers(&mut stack, g.lock().await.members());
+                    push_readers(&mut readers, g.lock().await.members());
                 }
                 Agent::Document(_, d) => {
-                    Self::push_readers(&mut stack, d.lock().await.members());
+                    push_readers(&mut readers, d.lock().await.members());
                 }
             }
         }
@@ -137,9 +137,9 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     ) -> HashMap<IndividualId, ShareKey> {
         let mut result = HashMap::new();
         let mut seen = HashSet::new();
-        let mut stack: Vec<Self> = vec![self.dupe()];
+        let mut readers: Vec<Self> = vec![self.dupe()];
 
-        while let Some(agent) = stack.pop() {
+        while let Some(agent) = readers.pop() {
             if !seen.insert(agent.id()) {
                 continue;
             }
@@ -161,10 +161,10 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     result.insert(id, prekey);
                 }
                 Agent::Group(_, g) => {
-                    Self::push_readers(&mut stack, g.lock().await.members());
+                    push_readers(&mut readers, g.lock().await.members());
                 }
                 Agent::Document(_, d) => {
-                    Self::push_readers(&mut stack, d.lock().await.members());
+                    push_readers(&mut readers, d.lock().await.members());
                 }
             }
         }

--- a/keyhive_core/src/principal/agent.rs
+++ b/keyhive_core/src/principal/agent.rs
@@ -97,11 +97,14 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                 Agent::Individual(i_id, _) => {
                     ids.insert(i_id);
                 }
+                // Only members who are at least read are followed.
                 Agent::Group(_, g) => {
                     let locked_group = g.lock().await;
                     for ms in locked_group.members().values() {
                         for m in ms {
-                            stack.push(m.payload.delegate.dupe());
+                            if m.payload.can.is_reader() {
+                                stack.push(m.payload.delegate.dupe());
+                            }
                         }
                     }
                 }
@@ -109,7 +112,9 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     let locked_doc = d.lock().await;
                     for ms in locked_doc.members().values() {
                         for m in ms {
-                            stack.push(m.payload.delegate.dupe());
+                            if m.payload.can.is_reader() {
+                                stack.push(m.payload.delegate.dupe());
+                            }
                         }
                     }
                 }
@@ -148,11 +153,14 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     };
                     result.insert(id, prekey);
                 }
+                // Only members who are at least read are followed.
                 Agent::Group(_, g) => {
                     let locked_group = g.lock().await;
                     for ms in locked_group.members().values() {
                         for m in ms {
-                            stack.push(m.payload.delegate.dupe());
+                            if m.payload.can.is_reader() {
+                                stack.push(m.payload.delegate.dupe());
+                            }
                         }
                     }
                 }
@@ -160,7 +168,9 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                     let locked_doc = d.lock().await;
                     for ms in locked_doc.members().values() {
                         for m in ms {
-                            stack.push(m.payload.delegate.dupe());
+                            if m.payload.can.is_reader() {
+                                stack.push(m.payload.delegate.dupe());
+                            }
                         }
                     }
                 }

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -130,8 +130,10 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     }
 
     /// The individuals in this document's CGKA tree.
-    pub fn cgka_members(&self) -> Result<Vec<IndividualId>, CgkaError> {
-        Ok(self.cgka()?.member_ids().collect())
+    ///
+    /// Returns [`CgkaError::NotInitialized`] if this document has no CGKA yet.
+    pub fn cgka_members(&self) -> Result<impl Iterator<Item = IndividualId> + '_, CgkaError> {
+        Ok(self.cgka()?.member_ids())
     }
 
     pub async fn transitive_members(&self) -> HashMap<Identifier, (Agent<F, S, T, L>, Access)> {

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -129,6 +129,11 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
         self.group.members()
     }
 
+    /// The individuals in this document's CGKA tree.
+    pub fn cgka_members(&self) -> Result<Vec<IndividualId>, CgkaError> {
+        Ok(self.cgka()?.member_ids().collect())
+    }
+
     pub async fn transitive_members(&self) -> HashMap<Identifier, (Agent<F, S, T, L>, Access)> {
         self.group.transitive_members().await
     }

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1375,6 +1375,107 @@ mod tests {
         );
     }
 
+    /// A group's member's access level is capped by their own delegation and
+    /// by the group's access here, whichever is weaker, no matter how strong anyone else in
+    /// the chain is.
+    #[tokio::test]
+    async fn test_transitive_caps_a_member_by_their_own_delegations() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let bob = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let bob_id = { bob.lock().await.id() };
+        let bob_agent: Agent<Sendable, MemorySigner, String> = Agent::Active(bob_id, bob.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let carol_id = { carol.lock().await.id() };
+        let carol_agent: Agent<Sendable, MemorySigner, String> = Agent::Active(carol_id, carol.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let inner = Arc::new(Mutex::new(
+            Group::generate(
+                nonempty![alice_agent.dupe()],
+                dlg_store.dupe(),
+                rev_store.dupe(),
+                NoListener,
+                arc_csprng.dupe(),
+            )
+            .await
+            .unwrap(),
+        ));
+
+        let outer = Arc::new(Mutex::new(
+            Group::generate(
+                nonempty![alice_agent.dupe()],
+                dlg_store.dupe(),
+                rev_store.dupe(),
+                NoListener,
+                arc_csprng.dupe(),
+            )
+            .await
+            .unwrap(),
+        ));
+
+        // The inner group reads the outer one. Alice, who administers both,
+        // has the highest access level.
+        let inner_gid = { inner.lock().await.group_id() };
+        outer
+            .lock()
+            .await
+            .add_member(
+                Agent::Group(inner_gid, inner.dupe()),
+                Access::Edit,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        // Bob is admin for the inner group, which only has edit for the outer one.
+        inner
+            .lock()
+            .await
+            .add_member(bob_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        // Carol has read for the inner group, which has edit for the outer one.
+        inner
+            .lock()
+            .await
+            .add_member(carol_agent, Access::Read, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        let members = outer.lock().await.transitive_members().await;
+        assert_eq!(
+            members.get(&alice_id.into()).map(|(_, access)| *access),
+            Some(Access::Admin),
+            "alice is admin the outer group directly"
+        );
+        assert_eq!(
+            members.get(&bob_id.into()).map(|(_, access)| *access),
+            Some(Access::Edit),
+            "bob administers the inner group, which can only edit this one"
+        );
+        assert_eq!(
+            members.get(&carol_id.into()).map(|(_, access)| *access),
+            Some(Access::Read),
+            "carol has only read for the inner group, so she only has read for this one"
+        );
+    }
+
     #[tokio::test]
     async fn test_transitive_one() {
         test_utils::init_logging();

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -280,6 +280,27 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             parent_access: Access,
         }
 
+        /// Record `access` for `id`, keeping the best seen so far.
+        fn raise_to_best<
+            G: FutureForm,
+            Z: AsyncSigner<G>,
+            U: ContentRef,
+            M: MembershipListener<G, Z, U>,
+        >(
+            caps: &mut HashMap<Identifier, (Agent<G, Z, U, M>, Access)>,
+            id: Identifier,
+            agent: &Agent<G, Z, U, M>,
+            access: Access,
+        ) {
+            caps.entry(id)
+                .and_modify(|(_, existing)| {
+                    if access > *existing {
+                        *existing = access;
+                    }
+                })
+                .or_insert_with(|| (agent.dupe(), access));
+        }
+
         let mut explore: Vec<GroupAccess<F, S, T, L>> = vec![];
         let mut seen: HashSet<([u8; 64], Access)> = HashSet::new();
 
@@ -316,7 +337,11 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                 .unwrap_or(&access);
 
             let current_path_access = access.min(parent_access);
-            caps.insert(member.id(), (member.dupe(), current_path_access));
+            // Reaching someone again by a weaker route does not take away what
+            // a stronger one already gave them. An admin who also sits in a
+            // group with read access is still an admin, and which route the
+            // traversal happens to walk last is not their access level.
+            raise_to_best(&mut caps, member.id(), &member, current_path_access);
 
             if let Some(membered) = match member {
                 Agent::Group(id, inner_group) => Some(Membered::Group(id, inner_group.dupe())),
@@ -329,8 +354,10 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                         .await
                         .expect("members have capabilities by defintion");
 
-                    caps.insert(*mem_id, (dlg.payload.delegate.dupe(), best_access));
-
+                    // Nothing is recorded for this member here: what they can
+                    // do depends on their own delegation as much as on this
+                    // group's, and that is settled when they are popped, capped
+                    // by the route that reached them.
                     'inner: for sub_dlg in dlgs.iter() {
                         if !seen.insert((sub_dlg.signature.to_bytes(), dlg.payload.can)) {
                             continue 'inner;
@@ -1277,6 +1304,75 @@ mod tests {
         )]);
 
         assert_eq!(g0_mems, expected);
+    }
+
+    /// Reaching someone twice, once as an admin and once through a group that
+    /// only has read access, must not demote them to a reader. Which order the
+    /// traversal happens to walk the two routes in is not their access level.
+    #[tokio::test]
+    async fn test_transitive_keeps_the_strongest_route() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        // Alice is an admin of both groups, because generating one delegates
+        // admin to its parents.
+        let inner = Arc::new(Mutex::new(
+            Group::generate(
+                nonempty![alice_agent.dupe()],
+                dlg_store.dupe(),
+                rev_store.dupe(),
+                NoListener,
+                arc_csprng.dupe(),
+            )
+            .await
+            .unwrap(),
+        ));
+
+        let outer = Arc::new(Mutex::new(
+            Group::generate(
+                nonempty![alice_agent.dupe()],
+                dlg_store.dupe(),
+                rev_store.dupe(),
+                NoListener,
+                arc_csprng.dupe(),
+            )
+            .await
+            .unwrap(),
+        ));
+
+        // Now Alice also reaches the outer group the long way round, as a
+        // reader, through a group she administers.
+        let inner_gid = { inner.lock().await.group_id() };
+        outer
+            .lock()
+            .await
+            .add_member(
+                Agent::Group(inner_gid, inner.dupe()),
+                Access::Read,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let members = outer.lock().await.transitive_members().await;
+        assert_eq!(
+            members.get(&alice_id.into()).map(|(_, access)| *access),
+            Some(Access::Admin),
+            "an admin who is also in a reader group is still an admin"
+        );
     }
 
     #[tokio::test]

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -248,7 +248,12 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     ) -> HashMap<IndividualId, ShareKey> {
         let mut prekeys = HashMap::new();
         let public_id = crate::principal::public::Public.id();
-        for (id, (agent, _access)) in self.transitive_members().await.iter() {
+        for (id, (agent, access)) in self.transitive_members().await.iter() {
+            // Anyone whose access here is below `Read` is not entitled to decrypt.
+            if !access.is_reader() {
+                continue;
+            }
+
             // Public must always be added with its single well-known key.
             if *id == public_id {
                 prekeys.insert(

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -233,9 +233,14 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
         self.group_id().into()
     }
 
+    /// The individuals reachable from this group by delegations of
+    /// [`Access::Read`] or better.
     pub async fn individual_ids(&self) -> HashSet<IndividualId> {
         let mut ids = HashSet::new();
         for delegations in self.members.values() {
+            if !delegations.iter().any(|d| d.payload().can.is_reader()) {
+                continue;
+            }
             let more_ids = delegations[0].payload().delegate.individual_ids().await;
             ids.extend(more_ids.iter());
         }

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -280,7 +280,7 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             parent_access: Access,
         }
 
-        /// Record `access` for `id`, keeping the best seen so far.
+        /// Record `access` for `id`, keeping the best seen so far
         fn raise_to_best<
             G: FutureForm,
             Z: AsyncSigner<G>,
@@ -291,14 +291,12 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             id: Identifier,
             agent: &Agent<G, Z, U, M>,
             access: Access,
-        ) {
-            caps.entry(id)
-                .and_modify(|(_, existing)| {
-                    if access > *existing {
-                        *existing = access;
-                    }
-                })
-                .or_insert_with(|| (agent.dupe(), access));
+        ) -> Access {
+            let entry = caps.entry(id).or_insert_with(|| (agent.dupe(), access));
+            if access > entry.1 {
+                entry.1 = access;
+            }
+            entry.1
         }
 
         let mut explore: Vec<GroupAccess<F, S, T, L>> = vec![];
@@ -331,17 +329,13 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                 continue;
             }
 
-            let best_access = *caps
-                .get(&id)
-                .map(|(_, existing_access)| existing_access.max(&access))
-                .unwrap_or(&access);
-
-            let current_path_access = access.min(parent_access);
             // Reaching someone again by a weaker route does not take away what
             // a stronger one already gave them. An admin who also sits in a
             // group with read access is still an admin, and which route the
             // traversal happens to walk last is not their access level.
-            raise_to_best(&mut caps, member.id(), &member, current_path_access);
+            let current_path_access = access.min(parent_access);
+            let effective_access =
+                raise_to_best(&mut caps, member.id(), &member, current_path_access);
 
             if let Some(membered) = match member {
                 Agent::Group(id, inner_group) => Some(Membered::Group(id, inner_group.dupe())),
@@ -354,10 +348,6 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                         .await
                         .expect("members have capabilities by defintion");
 
-                    // Nothing is recorded for this member here: what they can
-                    // do depends on their own delegation as much as on this
-                    // group's, and that is settled when they are popped, capped
-                    // by the route that reached them.
                     'inner: for sub_dlg in dlgs.iter() {
                         if !seen.insert((sub_dlg.signature.to_bytes(), dlg.payload.can)) {
                             continue 'inner;
@@ -366,7 +356,7 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                         explore.push(GroupAccess {
                             agent: sub_dlg.payload.delegate.dupe(),
                             agent_access: sub_dlg.payload.can,
-                            parent_access: best_access,
+                            parent_access: effective_access,
                         });
                     }
                 }
@@ -1307,10 +1297,10 @@ mod tests {
     }
 
     /// Reaching someone twice, once as an admin and once through a group that
-    /// only has read access, must not demote them to a reader. Which order the
-    /// traversal happens to walk the two routes in is not their access level.
+    /// only has read access, must not demote them to a reader. The order of
+    /// traversal shouldn't matter.
     #[tokio::test]
-    async fn test_transitive_keeps_the_strongest_route() {
+    async fn test_transitive_keeps_the_best_route() {
         test_utils::init_logging();
         let mut csprng = OsRng;
 
@@ -1397,7 +1387,8 @@ mod tests {
 
         let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let carol_id = { carol.lock().await.id() };
-        let carol_agent: Agent<Sendable, MemorySigner, String> = Agent::Active(carol_id, carol.dupe());
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(carol_id, carol.dupe());
 
         let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
         let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
@@ -1473,6 +1464,90 @@ mod tests {
             members.get(&carol_id.into()).map(|(_, access)| *access),
             Some(Access::Read),
             "carol has only read for the inner group, so she only has read for this one"
+        );
+    }
+
+    /// A three-link chain whose weakest link is the first one. Carol
+    /// administers a group that administers a group that can only *read* the
+    /// outer group, so Carol reads it and no more.
+    #[tokio::test]
+    async fn test_transitive_weakest_link_is_the_first_one() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let carol_id = { carol.lock().await.id() };
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(carol_id, carol.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let make = |parents: NonEmpty<Agent<Sendable, MemorySigner, String>>| {
+            let dlg = dlg_store.dupe();
+            let rev = rev_store.dupe();
+            let rng = arc_csprng.dupe();
+            async move {
+                Arc::new(Mutex::new(
+                    Group::generate(parents, dlg, rev, NoListener, rng)
+                        .await
+                        .unwrap(),
+                ))
+            }
+        };
+
+        let outer = make(nonempty![alice_agent.dupe()]).await;
+        let middle = make(nonempty![alice_agent.dupe()]).await;
+        let inner = make(nonempty![alice_agent.dupe()]).await;
+
+        // outer --Read--> middle --Admin--> inner --Admin--> carol
+        let middle_gid = { middle.lock().await.group_id() };
+        outer
+            .lock()
+            .await
+            .add_member(
+                Agent::Group(middle_gid, middle.dupe()),
+                Access::Read,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let inner_gid = { inner.lock().await.group_id() };
+        middle
+            .lock()
+            .await
+            .add_member(
+                Agent::Group(inner_gid, inner.dupe()),
+                Access::Admin,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+
+        inner
+            .lock()
+            .await
+            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        let members = outer.lock().await.transitive_members().await;
+        assert_eq!(
+            members.get(&carol_id.into()).map(|(_, access)| *access),
+            Some(Access::Read),
+            "the chain is only as strong as the read delegation at its head"
         );
     }
 

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1574,13 +1574,13 @@ mod tests {
 
         let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let dan_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active({ dan.lock().await.id() }, dan.dupe());
+            Agent::Active(dan.lock().await.id(), dan.dupe());
 
         let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
         let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
         let arc_csprng = Arc::new(Mutex::new(csprng));
 
-        let mut make = || {
+        let make = || {
             let parents = nonempty![alice_agent.dupe()];
             let dlg = dlg_store.dupe();
             let rev = rev_store.dupe();
@@ -1672,7 +1672,7 @@ mod tests {
         let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let carol_signer = { carol.lock().await.signer.clone() };
         let carol_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active({ carol.lock().await.id() }, carol.dupe());
+            Agent::Active(carol.lock().await.id(), carol.dupe());
 
         let erin = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let erin_id = { erin.lock().await.id() };
@@ -1682,7 +1682,7 @@ mod tests {
         let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
         let arc_csprng = Arc::new(Mutex::new(csprng));
 
-        let mut make = || {
+        let make = || {
             let parents = nonempty![alice_agent.dupe()];
             let dlg = dlg_store.dupe();
             let rev = rev_store.dupe();
@@ -1789,13 +1789,13 @@ mod tests {
 
         let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let dan_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active({ dan.lock().await.id() }, dan.dupe());
+            Agent::Active(dan.lock().await.id(), dan.dupe());
 
         let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
         let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
         let arc_csprng = Arc::new(Mutex::new(csprng));
 
-        let mut make = || {
+        let make = || {
             let parents = nonempty![alice_agent.dupe()];
             let dlg = dlg_store.dupe();
             let rev = rev_store.dupe();

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1656,6 +1656,112 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_revocation_beyond_the_weakest_link_is_refused() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let carol_signer = { carol.lock().await.signer.clone() };
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active({ carol.lock().await.id() }, carol.dupe());
+
+        let erin = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let erin_id = { erin.lock().await.id() };
+        let erin_agent: Agent<Sendable, MemorySigner, String> = Agent::Active(erin_id, erin.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let mut make = || {
+            let parents = nonempty![alice_agent.dupe()];
+            let dlg = dlg_store.dupe();
+            let rev = rev_store.dupe();
+            let rng = arc_csprng.dupe();
+            async move {
+                Arc::new(Mutex::new(
+                    Group::generate(parents, dlg, rev, NoListener, rng)
+                        .await
+                        .unwrap(),
+                ))
+            }
+        };
+
+        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol,
+        // and erin is an admin of the outer group in her own right.
+        let outer = make().await;
+        let middle = make().await;
+        let a = make().await;
+        let b = make().await;
+
+        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
+            let g = g.dupe();
+            async move {
+                let gid = { g.lock().await.group_id() };
+                Agent::Group(gid, g)
+            }
+        };
+
+        outer
+            .lock()
+            .await
+            .add_member(
+                group_agent(&middle).await,
+                Access::Admin,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+        outer
+            .lock()
+            .await
+            .add_member(erin_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+        middle
+            .lock()
+            .await
+            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
+            .await
+            .unwrap();
+        a.lock()
+            .await
+            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+        b.lock()
+            .await
+            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        let result = outer
+            .lock()
+            .await
+            .revoke_member(erin_id.into(), true, &carol_signer, &BTreeMap::new())
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a reader revoked an admin: {:?}",
+            result.map(|update| update.revocations.len())
+        );
+        assert!(
+            outer.lock().await.members().contains_key(&erin_id.into()),
+            "erin is still an admin of the group"
+        );
+    }
+
     /// Accepting a delegation asks whether its signer really holds the access
     /// they are passing on, and asks it of `transitive_members`. A chain that
     /// was not limited to its weakest link would let someone sign delegations at a

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1415,7 +1415,9 @@ mod tests {
             let outer = make().await;
 
             let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>,
-                               gid: GroupId| Agent::Group(gid, g.dupe());
+                               gid: GroupId| {
+                Agent::Group(gid, g.dupe())
+            };
 
             let inner_gid = { inner.lock().await.group_id() };
             let admin_gid = { admin_route.lock().await.group_id() };

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -292,25 +292,6 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             parent_access: Access,
         }
 
-        /// Record `access` for `id`, keeping the best seen so far
-        fn raise_to_best<
-            G: FutureForm,
-            Z: AsyncSigner<G>,
-            U: ContentRef,
-            M: MembershipListener<G, Z, U>,
-        >(
-            caps: &mut HashMap<Identifier, (Agent<G, Z, U, M>, Access)>,
-            id: Identifier,
-            agent: &Agent<G, Z, U, M>,
-            access: Access,
-        ) -> Access {
-            let entry = caps.entry(id).or_insert_with(|| (agent.dupe(), access));
-            if access > entry.1 {
-                entry.1 = access;
-            }
-            entry.1
-        }
-
         let mut explore: Vec<GroupAccess<F, S, T, L>> = vec![];
         let mut seen: HashSet<([u8; 64], Access)> = HashSet::new();
 
@@ -346,8 +327,15 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             // group with read access is still an admin, and which route the
             // traversal happens to walk last is not their access level.
             let current_path_access = access.min(parent_access);
-            let effective_access =
-                raise_to_best(&mut caps, member.id(), &member, current_path_access);
+            let effective_access = caps
+                .entry(id)
+                .and_modify(|(_, existing)| {
+                    if current_path_access > *existing {
+                        *existing = current_path_access;
+                    }
+                })
+                .or_insert_with(|| (member.dupe(), current_path_access))
+                .1;
 
             if let Some(membered) = match member {
                 Agent::Group(id, inner_group) => Some(Membered::Group(id, inner_group.dupe())),

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -347,14 +347,9 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
                 Agent::Document(id, doc) => Some(Membered::Document(id, doc.dupe())),
                 _ => None,
             } {
-                for (mem_id, dlgs) in membered.members().await.iter() {
-                    let dlg = membered
-                        .get_capability(mem_id)
-                        .await
-                        .expect("members have capabilities by defintion");
-
+                for dlgs in membered.members().await.into_values() {
                     'inner: for sub_dlg in dlgs.iter() {
-                        if !seen.insert((sub_dlg.signature.to_bytes(), dlg.payload.can)) {
+                        if !seen.insert((sub_dlg.signature.to_bytes(), effective_access)) {
                             continue 'inner;
                         }
 
@@ -1368,6 +1363,111 @@ mod tests {
             Some(Access::Admin),
             "an admin who is also in a reader group is still an admin"
         );
+    }
+
+    #[tokio::test]
+    async fn test_transitive_keeps_the_best_route_through_a_nested_group() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        for _ in 0..10 {
+            let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+            let (alice_id, alice_signer) = {
+                let locked = alice.lock().await;
+                (locked.id(), locked.signer.clone())
+            };
+            let alice_agent: Agent<Sendable, MemorySigner, String> =
+                Agent::Active(alice_id, alice.dupe());
+
+            let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+            let carol_id = { carol.lock().await.id() };
+            let carol_agent: Agent<Sendable, MemorySigner, String> =
+                Agent::Active(carol_id, carol.dupe());
+
+            let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+            let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+            let arc_csprng = Arc::new(Mutex::new(csprng));
+
+            let make = || async {
+                Arc::new(Mutex::new(
+                    Group::generate(
+                        nonempty![alice_agent.dupe()],
+                        dlg_store.dupe(),
+                        rev_store.dupe(),
+                        NoListener,
+                        arc_csprng.dupe(),
+                    )
+                    .await
+                    .unwrap(),
+                ))
+            };
+
+            let inner = make().await;
+            let admin_route = make().await;
+            let read_route = make().await;
+            let outer = make().await;
+
+            let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>,
+                               gid: GroupId| Agent::Group(gid, g.dupe());
+
+            let inner_gid = { inner.lock().await.group_id() };
+            let admin_gid = { admin_route.lock().await.group_id() };
+            let read_gid = { read_route.lock().await.group_id() };
+
+            // Both middle groups administer the inner one.
+            for middle in [&admin_route, &read_route] {
+                middle
+                    .lock()
+                    .await
+                    .add_member(
+                        group_agent(&inner, inner_gid),
+                        Access::Admin,
+                        &alice_signer,
+                        &[],
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            // The outer group reaches one of them as an admin and the other as
+            // a reader, so the inner group is reachable both ways.
+            outer
+                .lock()
+                .await
+                .add_member(
+                    group_agent(&admin_route, admin_gid),
+                    Access::Admin,
+                    &alice_signer,
+                    &[],
+                )
+                .await
+                .unwrap();
+            outer
+                .lock()
+                .await
+                .add_member(
+                    group_agent(&read_route, read_gid),
+                    Access::Read,
+                    &alice_signer,
+                    &[],
+                )
+                .await
+                .unwrap();
+
+            inner
+                .lock()
+                .await
+                .add_member(carol_agent.dupe(), Access::Admin, &alice_signer, &[])
+                .await
+                .unwrap();
+
+            let members = outer.lock().await.transitive_members().await;
+            assert_eq!(
+                members.get(&carol_id.into()).map(|(_, access)| *access),
+                Some(Access::Admin),
+                "the admin route to the inner group is the one that counts"
+            );
+        }
     }
 
     /// A group's member's access level is capped by their own delegation and

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1551,6 +1551,111 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_add_member_beyond_the_weakest_link_is_refused() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (carol_id, carol_signer) = {
+            let locked = carol.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(carol_id, carol.dupe());
+
+        let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let dan_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active({ dan.lock().await.id() }, dan.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let mut make = || {
+            let parents = nonempty![alice_agent.dupe()];
+            let dlg = dlg_store.dupe();
+            let rev = rev_store.dupe();
+            let rng = arc_csprng.dupe();
+            async move {
+                Arc::new(Mutex::new(
+                    Group::generate(parents, dlg, rev, NoListener, rng)
+                        .await
+                        .unwrap(),
+                ))
+            }
+        };
+
+        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol
+        let outer = make().await;
+        let middle = make().await;
+        let a = make().await;
+        let b = make().await;
+
+        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
+            let g = g.dupe();
+            async move {
+                let gid = { g.lock().await.group_id() };
+                Agent::Group(gid, g)
+            }
+        };
+
+        outer
+            .lock()
+            .await
+            .add_member(
+                group_agent(&middle).await,
+                Access::Admin,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+        middle
+            .lock()
+            .await
+            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
+            .await
+            .unwrap();
+        a.lock()
+            .await
+            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+        b.lock()
+            .await
+            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        // Carol reads the outer group, so she has nothing to pass on here.
+        let result = outer
+            .lock()
+            .await
+            .add_member(dan_agent, Access::Admin, &carol_signer, &[])
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(AddGroupMemberError::AccessEscalation {
+                    wanted: Access::Admin,
+                    have: Access::Read
+                })
+            ),
+            "a reader made someone else an admin: {:?}",
+            result.map(|_| "delegation created")
+        );
+    }
+
     /// Accepting a delegation asks whether its signer really holds the access
     /// they are passing on, and asks it of `transitive_members`. A chain that
     /// was not limited to its weakest link would let someone sign delegations at a

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -253,20 +253,22 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     ) -> HashMap<IndividualId, ShareKey> {
         let mut prekeys = HashMap::new();
         let public_id = crate::principal::public::Public.id();
-        for (id, (agent, access)) in self.transitive_members().await.iter() {
+        for (id, (agent, access)) in self.transitive_members().await {
             // Anyone whose access here is below `Read` is not entitled to decrypt.
             if !access.is_reader() {
                 continue;
             }
 
             // Public must always be added with its single well-known key.
-            if *id == public_id {
+            if id == public_id {
                 prekeys.insert(
                     IndividualId(public_id),
                     crate::principal::public::Public.share_key(),
                 );
-            } else {
-                prekeys.extend(agent.pick_individual_prekeys(doc_id).await.iter());
+            } else if matches!(agent, Agent::Individual(_, _) | Agent::Active(_, _)) {
+                // Nested groups and documents are already flattened into
+                // `transitive_members` so we only look up individuals.
+                prekeys.extend(agent.pick_individual_prekeys(doc_id).await);
             }
         }
         prekeys

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -323,9 +323,7 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
             }
 
             // Reaching someone again by a weaker route does not take away what
-            // a stronger one already gave them. An admin who also sits in a
-            // group with read access is still an admin, and which route the
-            // traversal happens to walk last is not their access level.
+            // a stronger one already gave them.
             let current_path_access = access.min(parent_access);
             let effective_access = caps
                 .entry(id)
@@ -1016,7 +1014,7 @@ mod tests {
     ///
     /// Carol may only read the outer group, but has admin to every link below
     /// the read delegation into `a`. Alice generated all four groups, so
-    /// she administers each of them directly.
+    /// she is admin of each of them directly.
     struct WeakestLinkChain {
         outer: TestGroup,
         middle: TestGroup,
@@ -1435,7 +1433,7 @@ mod tests {
         ));
 
         // Now Alice also reaches the outer group the long way round, as a
-        // reader, through a group she administers.
+        // reader, through a group where she is admin.
         let inner_gid = { inner.lock().await.group_id() };
         outer
             .lock()
@@ -1617,7 +1615,7 @@ mod tests {
             .unwrap(),
         ));
 
-        // The inner group edits the outer one. Alice, who administers both,
+        // The inner group edits the outer one. Alice, who is admin of both,
         // has the highest access level.
         let inner_gid = { inner.lock().await.group_id() };
         outer
@@ -1632,7 +1630,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Bob is admin for the inner group, which only has edit for the outer one.
+        // Bob is admin of the inner group, which only has edit for the outer one.
         inner
             .lock()
             .await
@@ -1657,7 +1655,7 @@ mod tests {
         assert_eq!(
             members.get(&bob_id.into()).map(|(_, access)| *access),
             Some(Access::Edit),
-            "bob administers the inner group, which can only edit this one"
+            "bob is admin of the inner group, which can only edit this one"
         );
         assert_eq!(
             members.get(&carol_id.into()).map(|(_, access)| *access),
@@ -1667,7 +1665,7 @@ mod tests {
     }
 
     /// A three-link chain whose weakest link is the first one. Carol
-    /// administers a group that administers a group that can only read the
+    /// is admin of a group that is admin of a group that can only read the
     /// outer group, so Carol reads it and no more.
     #[tokio::test]
     async fn test_transitive_weakest_link_is_the_first_one() {

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1010,6 +1010,103 @@ mod tests {
         Active::generate(sk, NoListener, csprng).await.unwrap()
     }
 
+    type TestGroup = Arc<Mutex<Group<Sendable, MemorySigner, String>>>;
+
+    /// `outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol`.
+    ///
+    /// Carol may only read the outer group, but has admin to every link below
+    /// the read delegation into `a`. Alice generated all four groups, so
+    /// she administers each of them directly.
+    struct WeakestLinkChain {
+        outer: TestGroup,
+        middle: TestGroup,
+        alice_signer: MemorySigner,
+        carol_signer: MemorySigner,
+    }
+
+    async fn weakest_link_chain() -> WeakestLinkChain {
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (carol_id, carol_signer) = {
+            let locked = carol.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(carol_id, carol.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let make = || {
+            let parents = nonempty![alice_agent.dupe()];
+            let dlg = dlg_store.dupe();
+            let rev = rev_store.dupe();
+            let rng = arc_csprng.dupe();
+            async move {
+                Arc::new(Mutex::new(
+                    Group::generate(parents, dlg, rev, NoListener, rng)
+                        .await
+                        .unwrap(),
+                ))
+            }
+        };
+
+        let outer = make().await;
+        let middle = make().await;
+        let a = make().await;
+        let b = make().await;
+
+        let group_agent = |g: &TestGroup| {
+            let g = g.dupe();
+            async move {
+                let gid = { g.lock().await.group_id() };
+                Agent::Group(gid, g)
+            }
+        };
+
+        for (parent, child, can) in [
+            (&outer, &middle, Access::Admin),
+            (&middle, &a, Access::Read),
+            (&a, &b, Access::Admin),
+        ] {
+            parent
+                .lock()
+                .await
+                .add_member(group_agent(child).await, can, &alice_signer, &[])
+                .await
+                .unwrap();
+        }
+        b.lock()
+            .await
+            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        let members = outer.lock().await.transitive_members().await;
+        assert_eq!(
+            members.get(&carol_id.into()).map(|(_, access)| *access),
+            Some(Access::Read),
+            "carol reads the outer group and no more"
+        );
+
+        WeakestLinkChain {
+            outer,
+            middle,
+            alice_signer,
+            carol_signer,
+        }
+    }
+
     async fn setup_groups<T: ContentRef, R: rand::CryptoRng + rand::RngCore>(
         alice: Arc<Mutex<Active<Sendable, MemorySigner, T>>>,
         bob: Arc<Mutex<Active<Sendable, MemorySigner, T>>>,
@@ -1520,7 +1617,7 @@ mod tests {
             .unwrap(),
         ));
 
-        // The inner group reads the outer one. Alice, who administers both,
+        // The inner group edits the outer one. Alice, who administers both,
         // has the highest access level.
         let inner_gid = { inner.lock().await.group_id() };
         outer
@@ -1555,7 +1652,7 @@ mod tests {
         assert_eq!(
             members.get(&alice_id.into()).map(|(_, access)| *access),
             Some(Access::Admin),
-            "alice is admin the outer group directly"
+            "alice is admin of the outer group directly"
         );
         assert_eq!(
             members.get(&bob_id.into()).map(|(_, access)| *access),
@@ -1570,7 +1667,7 @@ mod tests {
     }
 
     /// A three-link chain whose weakest link is the first one. Carol
-    /// administers a group that administers a group that can only *read* the
+    /// administers a group that administers a group that can only read the
     /// outer group, so Carol reads it and no more.
     #[tokio::test]
     async fn test_transitive_weakest_link_is_the_first_one() {
@@ -1658,91 +1755,18 @@ mod tests {
         test_utils::init_logging();
         let mut csprng = OsRng;
 
-        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let (alice_id, alice_signer) = {
-            let locked = alice.lock().await;
-            (locked.id(), locked.signer.clone())
-        };
-        let alice_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(alice_id, alice.dupe());
-
-        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let (carol_id, carol_signer) = {
-            let locked = carol.lock().await;
-            (locked.id(), locked.signer.clone())
-        };
-        let carol_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(carol_id, carol.dupe());
-
         let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let dan_agent: Agent<Sendable, MemorySigner, String> =
             Agent::Active(dan.lock().await.id(), dan.dupe());
 
-        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
-        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
-        let arc_csprng = Arc::new(Mutex::new(csprng));
+        let chain = weakest_link_chain().await;
 
-        let make = || {
-            let parents = nonempty![alice_agent.dupe()];
-            let dlg = dlg_store.dupe();
-            let rev = rev_store.dupe();
-            let rng = arc_csprng.dupe();
-            async move {
-                Arc::new(Mutex::new(
-                    Group::generate(parents, dlg, rev, NoListener, rng)
-                        .await
-                        .unwrap(),
-                ))
-            }
-        };
-
-        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol
-        let outer = make().await;
-        let middle = make().await;
-        let a = make().await;
-        let b = make().await;
-
-        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
-            let g = g.dupe();
-            async move {
-                let gid = { g.lock().await.group_id() };
-                Agent::Group(gid, g)
-            }
-        };
-
-        outer
+        // Carol only reads the outer group, so admin is not hers to pass on.
+        let result = chain
+            .outer
             .lock()
             .await
-            .add_member(
-                group_agent(&middle).await,
-                Access::Admin,
-                &alice_signer,
-                &[],
-            )
-            .await
-            .unwrap();
-        middle
-            .lock()
-            .await
-            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
-            .await
-            .unwrap();
-        a.lock()
-            .await
-            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
-        b.lock()
-            .await
-            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
-
-        // Carol reads the outer group, so she has nothing to pass on here.
-        let result = outer
-            .lock()
-            .await
-            .add_member(dan_agent, Access::Admin, &carol_signer, &[])
+            .add_member(dan_agent, Access::Admin, &chain.carol_signer, &[])
             .await;
 
         assert!(
@@ -1763,94 +1787,26 @@ mod tests {
         test_utils::init_logging();
         let mut csprng = OsRng;
 
-        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let (alice_id, alice_signer) = {
-            let locked = alice.lock().await;
-            (locked.id(), locked.signer.clone())
-        };
-        let alice_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(alice_id, alice.dupe());
-
-        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let carol_signer = { carol.lock().await.signer.clone() };
-        let carol_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(carol.lock().await.id(), carol.dupe());
-
         let erin = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let erin_id = { erin.lock().await.id() };
         let erin_agent: Agent<Sendable, MemorySigner, String> = Agent::Active(erin_id, erin.dupe());
 
-        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
-        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
-        let arc_csprng = Arc::new(Mutex::new(csprng));
+        let chain = weakest_link_chain().await;
 
-        let make = || {
-            let parents = nonempty![alice_agent.dupe()];
-            let dlg = dlg_store.dupe();
-            let rev = rev_store.dupe();
-            let rng = arc_csprng.dupe();
-            async move {
-                Arc::new(Mutex::new(
-                    Group::generate(parents, dlg, rev, NoListener, rng)
-                        .await
-                        .unwrap(),
-                ))
-            }
-        };
-
-        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol,
-        // and erin is an admin of the outer group in her own right.
-        let outer = make().await;
-        let middle = make().await;
-        let a = make().await;
-        let b = make().await;
-
-        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
-            let g = g.dupe();
-            async move {
-                let gid = { g.lock().await.group_id() };
-                Agent::Group(gid, g)
-            }
-        };
-
-        outer
+        // Erin is an admin of the outer group in her own right.
+        chain
+            .outer
             .lock()
             .await
-            .add_member(
-                group_agent(&middle).await,
-                Access::Admin,
-                &alice_signer,
-                &[],
-            )
-            .await
-            .unwrap();
-        outer
-            .lock()
-            .await
-            .add_member(erin_agent, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
-        middle
-            .lock()
-            .await
-            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
-            .await
-            .unwrap();
-        a.lock()
-            .await
-            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
-        b.lock()
-            .await
-            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .add_member(erin_agent, Access::Admin, &chain.alice_signer, &[])
             .await
             .unwrap();
 
-        let result = outer
+        let result = chain
+            .outer
             .lock()
             .await
-            .revoke_member(erin_id.into(), true, &carol_signer, &BTreeMap::new())
+            .revoke_member(erin_id.into(), true, &chain.carol_signer, &BTreeMap::new())
             .await;
 
         assert!(
@@ -1859,7 +1815,12 @@ mod tests {
             result.map(|update| update.revocations.len())
         );
         assert!(
-            outer.lock().await.members().contains_key(&erin_id.into()),
+            chain
+                .outer
+                .lock()
+                .await
+                .members()
+                .contains_key(&erin_id.into()),
             "erin is still an admin of the group"
         );
     }
@@ -1873,101 +1834,24 @@ mod tests {
         test_utils::init_logging();
         let mut csprng = OsRng;
 
-        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let (alice_id, alice_signer) = {
-            let locked = alice.lock().await;
-            (locked.id(), locked.signer.clone())
-        };
-        let alice_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(alice_id, alice.dupe());
-
-        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
-        let (carol_id, carol_signer) = {
-            let locked = carol.lock().await;
-            (locked.id(), locked.signer.clone())
-        };
-        let carol_agent: Agent<Sendable, MemorySigner, String> =
-            Agent::Active(carol_id, carol.dupe());
-
         let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
         let dan_agent: Agent<Sendable, MemorySigner, String> =
             Agent::Active(dan.lock().await.id(), dan.dupe());
 
-        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
-        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
-        let arc_csprng = Arc::new(Mutex::new(csprng));
-
-        let make = || {
-            let parents = nonempty![alice_agent.dupe()];
-            let dlg = dlg_store.dupe();
-            let rev = rev_store.dupe();
-            let rng = arc_csprng.dupe();
-            async move {
-                Arc::new(Mutex::new(
-                    Group::generate(parents, dlg, rev, NoListener, rng)
-                        .await
-                        .unwrap(),
-                ))
-            }
-        };
-
-        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol
-        //
-        // Carol may only read the outer group: the read delegation into `a`
-        // caps everything below it.
-        let outer = make().await;
-        let middle = make().await;
-        let a = make().await;
-        let b = make().await;
-
-        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
-            let g = g.dupe();
-            async move {
-                let gid = { g.lock().await.group_id() };
-                Agent::Group(gid, g)
-            }
-        };
-
-        outer
-            .lock()
-            .await
-            .add_member(
-                group_agent(&middle).await,
-                Access::Admin,
-                &alice_signer,
-                &[],
-            )
-            .await
-            .unwrap();
-        middle
-            .lock()
-            .await
-            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
-            .await
-            .unwrap();
-        a.lock()
-            .await
-            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
-        b.lock()
-            .await
-            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
-            .await
-            .unwrap();
+        let chain = weakest_link_chain().await;
 
         // Carol signs an admin delegation on the outer group, proving it with
         // the outer group's own admin delegation to `middle`. The claim does
         // not exceed that proof, so all that stands in the way is whether
         // carol is really an admin-level member of `middle`.
-        let middle_id: Identifier = { middle.lock().await.group_id().into() };
+        let middle_id: Identifier = { chain.middle.lock().await.group_id().into() };
         let proof = {
-            let locked = outer.lock().await;
+            let locked = chain.outer.lock().await;
             locked.get_capability(&middle_id).unwrap().dupe()
         };
         let forged = Arc::new(
             keyhive_crypto::signer::async_signer::try_sign_async::<Sendable, _, _>(
-                &carol_signer,
+                &chain.carol_signer,
                 Delegation {
                     delegate: dan_agent,
                     can: Access::Admin,
@@ -1980,7 +1864,7 @@ mod tests {
             .unwrap(),
         );
 
-        let result = outer.lock().await.receive_delegation(forged).await;
+        let result = chain.outer.lock().await.receive_delegation(forged).await;
         assert!(
             result.is_err(),
             "the outer group accepted an admin delegation from someone who can only read it"

--- a/keyhive_core/src/principal/group.rs
+++ b/keyhive_core/src/principal/group.rs
@@ -1551,6 +1551,129 @@ mod tests {
         );
     }
 
+    /// Accepting a delegation asks whether its signer really holds the access
+    /// they are passing on, and asks it of `transitive_members`. A chain that
+    /// was not limited to its weakest link would let someone sign delegations at a
+    /// level no path actually granted them.
+    #[tokio::test]
+    async fn test_forged_delegation_beyond_the_weakest_link_is_refused() {
+        test_utils::init_logging();
+        let mut csprng = OsRng;
+
+        let alice = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (alice_id, alice_signer) = {
+            let locked = alice.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let alice_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(alice_id, alice.dupe());
+
+        let carol = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let (carol_id, carol_signer) = {
+            let locked = carol.lock().await;
+            (locked.id(), locked.signer.clone())
+        };
+        let carol_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active(carol_id, carol.dupe());
+
+        let dan = Arc::new(Mutex::new(setup_user(&mut csprng).await));
+        let dan_agent: Agent<Sendable, MemorySigner, String> =
+            Agent::Active({ dan.lock().await.id() }, dan.dupe());
+
+        let dlg_store = Arc::new(Mutex::new(DelegationStore::new()));
+        let rev_store = Arc::new(Mutex::new(RevocationStore::new()));
+        let arc_csprng = Arc::new(Mutex::new(csprng));
+
+        let mut make = || {
+            let parents = nonempty![alice_agent.dupe()];
+            let dlg = dlg_store.dupe();
+            let rev = rev_store.dupe();
+            let rng = arc_csprng.dupe();
+            async move {
+                Arc::new(Mutex::new(
+                    Group::generate(parents, dlg, rev, NoListener, rng)
+                        .await
+                        .unwrap(),
+                ))
+            }
+        };
+
+        // outer --Admin--> middle --Read--> a --Admin--> b --Admin--> carol
+        //
+        // Carol may only read the outer group: the read delegation into `a`
+        // caps everything below it.
+        let outer = make().await;
+        let middle = make().await;
+        let a = make().await;
+        let b = make().await;
+
+        let group_agent = |g: &Arc<Mutex<Group<Sendable, MemorySigner, String>>>| {
+            let g = g.dupe();
+            async move {
+                let gid = { g.lock().await.group_id() };
+                Agent::Group(gid, g)
+            }
+        };
+
+        outer
+            .lock()
+            .await
+            .add_member(
+                group_agent(&middle).await,
+                Access::Admin,
+                &alice_signer,
+                &[],
+            )
+            .await
+            .unwrap();
+        middle
+            .lock()
+            .await
+            .add_member(group_agent(&a).await, Access::Read, &alice_signer, &[])
+            .await
+            .unwrap();
+        a.lock()
+            .await
+            .add_member(group_agent(&b).await, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+        b.lock()
+            .await
+            .add_member(carol_agent, Access::Admin, &alice_signer, &[])
+            .await
+            .unwrap();
+
+        // Carol signs an admin delegation on the outer group, proving it with
+        // the outer group's own admin delegation to `middle`. The claim does
+        // not exceed that proof, so all that stands in the way is whether
+        // carol is really an admin-level member of `middle`.
+        let middle_id: Identifier = { middle.lock().await.group_id().into() };
+        let proof = {
+            let locked = outer.lock().await;
+            locked.get_capability(&middle_id).unwrap().dupe()
+        };
+        let forged = Arc::new(
+            keyhive_crypto::signer::async_signer::try_sign_async::<Sendable, _, _>(
+                &carol_signer,
+                Delegation {
+                    delegate: dan_agent,
+                    can: Access::Admin,
+                    proof: Some(proof),
+                    after_revocations: vec![],
+                    after_content: BTreeMap::new(),
+                },
+            )
+            .await
+            .unwrap(),
+        );
+
+        let result = outer.lock().await.receive_delegation(forged).await;
+        assert!(
+            result.is_err(),
+            "the outer group accepted an admin delegation from someone who can only read it"
+        );
+    }
+
     #[tokio::test]
     async fn test_transitive_one() {
         test_utils::init_logging();

--- a/keyhive_wasm/package.json
+++ b/keyhive_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyhive/keyhive",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "",
   "main": "pkg/keyhive_wasm.js",
   "scripts": {

--- a/keyhive_wasm/package.json
+++ b/keyhive_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyhive/keyhive",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "",
   "main": "pkg/keyhive_wasm.js",
   "scripts": {

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -54,12 +54,11 @@ impl JsDocument {
         JsMembered(Membered::Document(self.doc_id, self.inner.dupe()))
     }
 
-    /// The individuals in this document's CGKA tree, i.e., those that
-    /// can derive its current secret.
+    /// The individuals in this document's CGKA tree.
     ///
     /// This is the set to watch when deciding whether a new reader needs a key
     /// rotation. `members()` reports the document's own delegations, which do
-    /// not change when a group that already holds access gains a member.
+    /// not change when a group that already has access gains a member.
     ///
     /// Empty if the document has no initialized CGKA.
     #[wasm_bindgen(js_name = cgkaMembers)]

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -4,6 +4,7 @@ use super::{
     agent::JsAgent, capability::Capability, change_id::JsChangeId, event_handler::JsEventHandler,
     identifier::JsIdentifier, peer::JsPeer, signer::JsSigner,
 };
+use beekem::error::CgkaError;
 use dupe::Dupe;
 use future_form::Local;
 use futures::lock::Mutex;
@@ -63,14 +64,14 @@ impl JsDocument {
     /// Empty if the document has no initialized CGKA.
     #[wasm_bindgen(js_name = cgkaMembers)]
     pub async fn cgka_members(&self) -> Vec<JsIdentifier> {
-        self.inner
-            .lock()
-            .await
-            .cgka_members()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|id| JsIdentifier(id.into()))
-            .collect()
+        match self.inner.lock().await.cgka_members() {
+            Ok(ids) => ids.map(|id| JsIdentifier(id.into())).collect(),
+            Err(CgkaError::NotInitialized) => vec![],
+            Err(e) => {
+                tracing::warn!("JsDocument::cgka_members: {e}");
+                vec![]
+            }
+        }
     }
 
     #[wasm_bindgen]

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -53,6 +53,26 @@ impl JsDocument {
         JsMembered(Membered::Document(self.doc_id, self.inner.dupe()))
     }
 
+    /// The individuals in this document's CGKA tree, i.e., those that
+    /// can derive its current secret.
+    ///
+    /// This is the set to watch when deciding whether a new reader needs a key
+    /// rotation. `members()` reports the document's own delegations, which do
+    /// not change when a group that already holds access gains a member.
+    ///
+    /// Empty if the document has no initialized CGKA.
+    #[wasm_bindgen(js_name = cgkaMembers)]
+    pub async fn cgka_members(&self) -> Vec<JsIdentifier> {
+        self.inner
+            .lock()
+            .await
+            .cgka_members()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|id| JsIdentifier(id.into()))
+            .collect()
+    }
+
     #[wasm_bindgen]
     pub async fn members(&self) -> Vec<Capability> {
         self.inner

--- a/keyhive_wasm/src/js/group.rs
+++ b/keyhive_wasm/src/js/group.rs
@@ -1,8 +1,14 @@
 use crate::js::membered::JsMembered;
 
 use super::{
-    agent::JsAgent, capability::Capability, change_id::JsChangeId, event_handler::JsEventHandler,
-    group_id::JsGroupId, identifier::JsIdentifier, membership::Membership, peer::JsPeer,
+    agent::JsAgent,
+    capability::Capability,
+    change_id::JsChangeId,
+    event_handler::JsEventHandler,
+    group_id::JsGroupId,
+    identifier::JsIdentifier,
+    membership::{individual_memberships, Membership},
+    peer::JsPeer,
     signer::JsSigner,
 };
 use derive_more::{From, Into};
@@ -40,29 +46,11 @@ impl JsGroup {
     }
 
     /// Everyone who reaches this group, following nested groups all the way
-    /// down, with the access each one ends up holding.
-    ///
-    /// [`JsGroup::members`] is the group's own delegations, which is the wrong
-    /// question to ask when working out whether a particular person can act
-    /// here: someone in a group that is a member of this one holds real access
-    /// and appears in no delegation of ours. Documents have
-    /// [`JsKeyhive::doc_member_capabilities`] for this; groups had nothing.
+    /// down, with the access for each one.
     #[wasm_bindgen(js_name = transitiveMembers)]
     pub async fn transitive_members(&self) -> Vec<Membership> {
         let transitive = { self.inner.lock().await.transitive_members().await };
-        transitive
-            .into_iter()
-            // Skip the group itself.
-            .filter(|(id, _)| *id != self.group_id.into())
-            .filter_map(|(_, (agent, access))| {
-                // Individuals and the local identity, matching
-                // `doc_member_capabilities`.
-                matches!(agent, Agent::Individual(_, _) | Agent::Active(_, _)).then(|| Membership {
-                    who: agent,
-                    can: access,
-                })
-            })
-            .collect()
+        individual_memberships(transitive, self.group_id.into())
     }
 
     #[wasm_bindgen]

--- a/keyhive_wasm/src/js/group.rs
+++ b/keyhive_wasm/src/js/group.rs
@@ -2,7 +2,8 @@ use crate::js::membered::JsMembered;
 
 use super::{
     agent::JsAgent, capability::Capability, change_id::JsChangeId, event_handler::JsEventHandler,
-    group_id::JsGroupId, identifier::JsIdentifier, peer::JsPeer, signer::JsSigner,
+    group_id::JsGroupId, identifier::JsIdentifier, membership::Membership, peer::JsPeer,
+    signer::JsSigner,
 };
 use derive_more::{From, Into};
 use dupe::Dupe;
@@ -36,6 +37,32 @@ impl JsGroup {
     #[wasm_bindgen(getter, js_name = groupId)]
     pub fn group_id(&self) -> JsGroupId {
         JsGroupId(self.group_id)
+    }
+
+    /// Everyone who reaches this group, following nested groups all the way
+    /// down, with the access each one ends up holding.
+    ///
+    /// [`JsGroup::members`] is the group's own delegations, which is the wrong
+    /// question to ask when working out whether a particular person can act
+    /// here: someone in a group that is a member of this one holds real access
+    /// and appears in no delegation of ours. Documents have
+    /// [`JsKeyhive::doc_member_capabilities`] for this; groups had nothing.
+    #[wasm_bindgen(js_name = transitiveMembers)]
+    pub async fn transitive_members(&self) -> Vec<Membership> {
+        let transitive = { self.inner.lock().await.transitive_members().await };
+        transitive
+            .into_iter()
+            // Skip the group itself.
+            .filter(|(id, _)| *id != self.group_id.into())
+            .filter_map(|(_, (agent, access))| {
+                // Individuals and the local identity, matching
+                // `doc_member_capabilities`.
+                matches!(agent, Agent::Individual(_, _) | Agent::Active(_, _)).then(|| Membership {
+                    who: agent,
+                    can: access,
+                })
+            })
+            .collect()
     }
 
     #[wasm_bindgen]

--- a/keyhive_wasm/src/js/group_id.rs
+++ b/keyhive_wasm/src/js/group_id.rs
@@ -1,4 +1,6 @@
+use keyhive_core::principal::{group::id::GroupId, identifier::Identifier};
 use std::fmt::{Display, Formatter};
+use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = GroupId)]
@@ -7,6 +9,19 @@ pub struct JsGroupId(pub(crate) keyhive_core::principal::group::id::GroupId);
 
 #[wasm_bindgen(js_class = GroupId)]
 impl JsGroupId {
+    /// Build a group id from its 32 raw bytes.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: Vec<u8>) -> Result<Self, JsParseGroupIdError> {
+        let vec: [u8; 32] = bytes.try_into().map_err(|_| JsParseGroupIdError)?;
+        let vk = ed25519_dalek::VerifyingKey::from_bytes(&vec).map_err(|_| JsParseGroupIdError)?;
+        Ok(JsGroupId(GroupId::from(Identifier::from(vk))))
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
+    }
+
     #[wasm_bindgen(js_name = toString)]
     pub fn to_js_string(&self) -> String {
         self.0.to_string()
@@ -16,5 +31,17 @@ impl JsGroupId {
 impl Display for JsGroupId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+#[error("Failed to parse GroupId from bytes")]
+pub struct JsParseGroupIdError;
+
+impl From<JsParseGroupIdError> for JsValue {
+    fn from(err: JsParseGroupIdError) -> Self {
+        let err = js_sys::Error::new(&err.to_string());
+        err.set_name("ParseGroupIdError");
+        err.into()
     }
 }

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -787,6 +787,7 @@ impl JsKeyhive {
         self.0.into_archive().await.into()
     }
 
+    #[allow(clippy::result_large_err)]
     #[wasm_bindgen(js_name = ingestArchive)]
     pub async fn ingest_archive(
         &self,

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -4,8 +4,13 @@ use keyhive_core::principal::identifier::Identifier;
 
 use crate::{
     js::{
-        archive::JsSerializationError, document_id::JsDocumentId, event::JsEvent,
-        group_id::JsGroupId, individual::JsIndividual, membership::Membership, stats::JsStats,
+        archive::JsSerializationError,
+        document_id::JsDocumentId,
+        event::JsEvent,
+        group_id::JsGroupId,
+        individual::JsIndividual,
+        membership::{individual_memberships, Membership},
+        stats::JsStats,
     },
     macros::init_span,
 };
@@ -688,20 +693,7 @@ impl JsKeyhive {
         init_span!("JsKeyhive::doc_member_capabilities");
         if let Some(doc) = self.0.get_document(doc_id.0).await {
             let transitive_members = { doc.lock().await.transitive_members().await };
-            transitive_members
-                .into_iter()
-                // Skip the document itself
-                .filter(|(id, _)| *id != doc_id.0.into())
-                .filter_map(|(_, (agent, access))| {
-                    // Currently we only return Individuals and the Agent
-                    matches!(agent, Agent::Individual(_, _) | Agent::Active(_, _)).then(|| {
-                        Membership {
-                            who: agent,
-                            can: access,
-                        }
-                    })
-                })
-                .collect()
+            individual_memberships(transitive_members, doc_id.0.into())
         } else {
             Vec::new()
         }

--- a/keyhive_wasm/src/js/membership.rs
+++ b/keyhive_wasm/src/js/membership.rs
@@ -4,8 +4,31 @@ use super::{
 };
 use dupe::Dupe;
 use future_form::Local;
-use keyhive_core::{access::Access, principal::agent::Agent};
+use keyhive_core::{
+    access::Access,
+    principal::{agent::Agent, identifier::Identifier},
+};
+use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
+
+/// The individuals in a transitive membership, other than `skip`, which is the
+/// group or document the membership was taken from.
+#[allow(clippy::type_complexity)]
+pub(crate) fn individual_memberships(
+    transitive: HashMap<Identifier, (Agent<Local, JsSigner, JsChangeId, JsEventHandler>, Access)>,
+    skip: Identifier,
+) -> Vec<Membership> {
+    transitive
+        .into_iter()
+        .filter(|(id, _)| *id != skip)
+        .filter_map(|(_, (agent, access))| {
+            matches!(agent, Agent::Individual(_, _) | Agent::Active(_, _)).then(|| Membership {
+                who: agent,
+                can: access,
+            })
+        })
+        .collect()
+}
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, Dupe)]


### PR DESCRIPTION
* Exposes CGKA members via the WASM API.
* Ensures transitive authority is limited by the weakest link on the best path
* Ensures Relay access to a group doesn't transitively grant you membership into a document's CGKA tree
* Adds a suite of tests that fail on `main` and pass with these fixes