### PR TITLE
Add a testing facade API to streamline our keyhive testing strategy for higher-level tests

### DIFF
--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -5490,7 +5490,7 @@ mod tests {
         let with_one_route = doc.lock().await.cgka()?.group_size();
         assert_eq!(
             with_one_route, 3,
-            "the document owner, alice and frank, so frank really is in the tree \
+            "the document's own key, alice and frank, so frank really is in the tree \
              by way of the group rather than absent from it"
         );
 
@@ -5549,14 +5549,11 @@ mod tests {
 
         // Bob receives the delegations that describe both documents and none of the CGKA
         // operations that would let him rekey one.
-        let for_bob = alice
+        let mut for_bob = alice
             .events_for_agent(&Agent::Individual(bob_id, bob_indie.dupe()))
             .await;
-        let without_key_agreement: HashMap<_, _> = for_bob
-            .into_iter()
-            .filter(|(_, event)| !matches!(event, Event::CgkaOperation(_)))
-            .collect();
-        bob.ingest_event_table(without_key_agreement).await?;
+        for_bob.retain(|_, event| !matches!(event, Event::CgkaOperation(_)));
+        bob.ingest_event_table(for_bob).await?;
 
         let project_on_bob = bob
             .get_document(project_id)
@@ -5578,7 +5575,7 @@ mod tests {
                 result,
                 Err(AddMemberError::CgkaError(CgkaError::NotInitialized))
             ),
-            "expected CGKA error for non-initialized CGKA"
+            "expected a non-initialized CGKA error, got {result:?}"
         );
 
         Ok(())

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -5456,6 +5456,134 @@ mod tests {
         Ok(())
     }
 
+    /// A redundant direct membership must not put someone in the CGKA tree twice.
+    #[tokio::test]
+    async fn test_a_second_route_does_not_add_a_member_to_the_tree_twice() -> TestResult {
+        test_utils::init_logging();
+
+        let alice = make_keyhive().await;
+        let frank_kh = make_keyhive().await;
+        let (frank_id, frank_indie) = register_peer(&alice, &frank_kh).await;
+
+        let group = alice.generate_group(vec![]).await?;
+        let group_id = group.lock().await.group_id();
+        alice
+            .add_member(
+                Agent::Individual(frank_id, frank_indie.dupe()),
+                &Membered::Group(group_id, group.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+
+        let doc = alice.generate_doc(vec![], nonempty![[0u8; 32]]).await?;
+        let doc_id = doc.lock().await.doc_id();
+        alice
+            .add_member(
+                Agent::Group(group_id, group.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+
+        let with_one_route = doc.lock().await.cgka()?.group_size();
+        assert_eq!(
+            with_one_route, 3,
+            "the document owner, alice and frank, so frank really is in the tree \
+             by way of the group rather than absent from it"
+        );
+
+        // Frank is already reachable through the group. Adding him directly is a second
+        // route to the same identity, not a second identity.
+        alice
+            .add_member(
+                Agent::Individual(frank_id, frank_indie.dupe()),
+                &Membered::Document(doc_id, doc.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await?;
+
+        assert_eq!(
+            doc.lock().await.cgka()?.group_size(),
+            with_one_route,
+            "a second route to frank should not put him in the tree a second time"
+        );
+
+        Ok(())
+    }
+
+    /// `add_member` must refuse when the document's CGKA state is missing rather
+    /// than proceed without it.
+    #[tokio::test]
+    async fn test_add_member_refuses_when_the_key_agreement_is_not_initialized() -> TestResult {
+        test_utils::init_logging();
+
+        let alice = make_keyhive().await;
+        let bob = make_keyhive().await;
+        let (bob_id, bob_indie) = register_peer(&alice, &bob).await;
+        register_peer(&bob, &alice).await;
+
+        let account = alice.generate_doc(vec![], nonempty![[0u8; 32]]).await?;
+        let account_id = account.lock().await.doc_id();
+        let project = alice.generate_doc(vec![], nonempty![[1u8; 32]]).await?;
+        let project_id = project.lock().await.doc_id();
+
+        alice
+            .add_member(
+                Agent::Document(account_id, account.dupe()),
+                &Membered::Document(project_id, project.dupe()),
+                Access::Admin,
+                &[],
+            )
+            .await?;
+        alice
+            .add_member(
+                Agent::Individual(bob_id, bob_indie.dupe()),
+                &Membered::Document(account_id, account.dupe()),
+                Access::Admin,
+                &[],
+            )
+            .await?;
+
+        // Bob receives the delegations that describe both documents and none of the CGKA
+        // operations that would let him rekey one.
+        let for_bob = alice
+            .events_for_agent(&Agent::Individual(bob_id, bob_indie.dupe()))
+            .await;
+        let without_key_agreement: HashMap<_, _> = for_bob
+            .into_iter()
+            .filter(|(_, event)| !matches!(event, Event::CgkaOperation(_)))
+            .collect();
+        bob.ingest_event_table(without_key_agreement).await?;
+
+        let project_on_bob = bob
+            .get_document(project_id)
+            .await
+            .expect("bob has the document, because its delegations reached him");
+
+        let public = Public.individual();
+        let result = bob
+            .add_member(
+                Agent::Individual(public.id(), Arc::new(Mutex::new(public))),
+                &Membered::Document(project_id, project_on_bob.dupe()),
+                Access::Read,
+                &[],
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(AddMemberError::CgkaError(CgkaError::NotInitialized))
+            ),
+            "expected CGKA error for non-initialized CGKA"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_async_transaction() -> TestResult {
         test_utils::init_logging();

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -130,6 +130,10 @@ impl Individual {
         self.prekey_state.ops()
     }
 
+    /// The live prekeys, after applying every op in the prekey state.
+    ///
+    /// A key that has been rotated away is absent, and the iteration order is not
+    /// meaningful. Use [`Individual::prekey_ops`] for the log that produced them.
     pub fn prekeys(&self) -> &HashSet<ShareKey> {
         &self.prekeys
     }

--- a/keyhive_core/src/principal/individual.rs
+++ b/keyhive_core/src/principal/individual.rs
@@ -130,6 +130,10 @@ impl Individual {
         self.prekey_state.ops()
     }
 
+    pub fn prekeys(&self) -> &HashSet<ShareKey> {
+        &self.prekeys
+    }
+
     #[instrument]
     pub fn rebuild(&mut self) {
         self.prekeys = self.prekey_state.build();

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -219,6 +219,11 @@ async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
         Some(Admin),
         "bob reaches project through account"
     );
+    assert_eq!(
+        ctx.effective_access(&bob, &account).await?,
+        Some(Admin),
+        "and account, which is where he holds it"
+    );
 
     ctx.delegate(&bob, &carol, &project, Edit).await?;
     assert_eq!(
@@ -232,6 +237,11 @@ async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
         ctx.effective_access(&carol, &project).await?,
         Some(Edit),
         "and alice, who owns the document, honors it"
+    );
+    assert_eq!(
+        ctx.effective_access(&carol, &account).await?,
+        None,
+        "carol was let into project, and that does not reach back up to account"
     );
     Ok(())
 }
@@ -249,6 +259,13 @@ async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
     ctx.delegate(&alice, &bob, &engineering, Admin).await?;
     ctx.sync_all().await?;
     assert_eq!(ctx.effective_access(&bob, &project).await?, Some(Admin));
+    let members_of_the_group = ctx.transitive_members_of(&engineering).await?;
+    assert_eq!(members_of_the_group.get("bob"), Some(&Admin));
+    assert_eq!(
+        members_of_the_group.get("carol"),
+        None,
+        "carol is not in the group to begin with"
+    );
 
     ctx.delegate(&bob, &carol, &project, Edit).await?;
     assert_eq!(
@@ -262,6 +279,11 @@ async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
         ctx.effective_access(&carol, &project).await?,
         Some(Edit),
         "bob delegated based on a route (through a group) he does not hold directly"
+    );
+    assert_eq!(
+        ctx.transitive_members_of(&engineering).await?.get("carol"),
+        None,
+        "and being let into project does not put her in the group that holds it"
     );
     Ok(())
 }

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -86,7 +86,7 @@ async fn relay_never_permits_decryption() -> Result<()> {
 
         let may_read = doc_to_group.min(group_to_bob) >= Read;
         let ct = ctx.encrypt(&alice, &design_doc, b"top secret").await?;
-        ctx.sync_all().await?;
+        ctx.sync_all_unsent().await?;
 
         assert_eq!(
             ctx.can_decrypt(&bob, &ct).await?,
@@ -140,7 +140,7 @@ async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let before = ctx.encrypt(&alice, &design_doc, b"first").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert!(
         ctx.can_decrypt(&bob, &before).await?,
         "bob could read before"
@@ -148,7 +148,7 @@ async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
 
     ctx.revoke(&alice, &bob, &design_doc).await?;
     let after = ctx.encrypt(&alice, &design_doc, b"second").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
     assert!(
@@ -171,7 +171,7 @@ async fn two_replicas_agree_on_effective_access() -> Result<()> {
         .await?;
     ctx.delegate(&alice, &bob, &engineering, Read).await?;
     ctx.delegate(&alice, &carol, &engineering, Admin).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     for observer in [&alice, &bob, &carol] {
         assert_eq!(
@@ -213,7 +213,7 @@ async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
 
     ctx.delegate(&alice, &account, &project, Admin).await?;
     ctx.delegate(&alice, &bob, &account, Admin).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert_eq!(
         ctx.effective_access(&bob, &project).await?,
         Some(Admin),
@@ -232,7 +232,7 @@ async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
         "bob delegated based on a route (through a doc) he does not hold directly"
     );
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert_eq!(
         ctx.effective_access(&carol, &project).await?,
         Some(Edit),
@@ -257,7 +257,7 @@ async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
 
     ctx.delegate(&alice, &engineering, &project, Admin).await?;
     ctx.delegate(&alice, &bob, &engineering, Admin).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert_eq!(ctx.effective_access(&bob, &project).await?, Some(Admin));
     let members_of_the_group = ctx.transitive_members_of(&engineering).await?;
     assert_eq!(members_of_the_group.get("bob"), Some(&Admin));
@@ -274,7 +274,7 @@ async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
         "bob delegated on the strength of a route he does not hold directly"
     );
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert_eq!(
         ctx.effective_access(&carol, &project).await?,
         Some(Edit),
@@ -371,7 +371,7 @@ async fn a_reader_cannot_delegate_above_read() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     for access in [Edit, Admin] {
         match ctx.delegate(&bob, &carol, &design_doc, access).await {
@@ -395,9 +395,9 @@ async fn a_revoked_member_cannot_delegate_or_revoke() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
     ctx.delegate(&alice, &mallory, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     ctx.revoke(&alice, &mallory, &design_doc).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         matches!(
@@ -441,7 +441,7 @@ async fn revoking_a_group_removes_only_those_who_needed_it() -> Result<()> {
     ctx.revoke(&alice, &engineering, &design_doc).await?;
 
     let after = ctx.encrypt(&alice, &design_doc, b"post-revocation").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
     assert!(

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -1,0 +1,265 @@
+//! Tests for three access-control rules, written against the facade in `facade/`.
+
+mod facade;
+
+use facade::{Result, TestContext, TestError};
+use keyhive_core::access::Access::{Admin, Edit, Read, Relay};
+
+#[tokio::test]
+async fn a_group_member_reaches_the_groups_documents() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Read));
+    Ok(())
+}
+
+#[tokio::test]
+async fn members_are_listed_with_their_effective_level() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+    ctx.delegate(&alice, &carol, &design_doc, Read).await?;
+
+    let members = ctx.transitive_members_of(&design_doc).await?;
+    assert_eq!(members.get("bob"), Some(&Edit));
+    assert_eq!(members.get("carol"), Some(&Read));
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
+async fn attenuation_is_the_minimum_along_the_route() -> Result<()> {
+    for a in [Relay, Read, Edit, Admin] {
+        for b in [Relay, Read, Edit, Admin] {
+            for c in [Relay, Read, Edit, Admin] {
+                let mut ctx = TestContext::new().await;
+                let alice = ctx.individual("alice").await?;
+                let bob = ctx.individual("bob").await?;
+                let design_doc = ctx.doc(&alice, "design_doc").await?;
+                let outer = ctx.group(&alice, "outer").await?;
+                let inner = ctx.group(&alice, "inner").await?;
+
+                ctx.delegate(&alice, &outer, &design_doc, a).await?;
+                ctx.delegate(&alice, &inner, &outer, b).await?;
+                ctx.delegate(&alice, &bob, &inner, c).await?;
+
+                assert_eq!(
+                    ctx.effective_access(&bob, &design_doc).await?,
+                    Some(a.min(b).min(c)),
+                    "design_doc -{a:?}-> outer -{b:?}-> inner -{c:?}-> bob"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
+async fn relay_never_permits_decryption() -> Result<()> {
+    for (doc_to_group, group_to_bob) in [
+        (Relay, Read),
+        (Relay, Edit),
+        (Relay, Admin),
+        (Read, Relay),
+        (Read, Read),
+    ] {
+        let mut ctx = TestContext::new().await;
+        let alice = ctx.individual("alice").await?;
+        let bob = ctx.individual("bob").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+        let relays = ctx.group(&alice, "relays").await?;
+
+        ctx.delegate(&alice, &relays, &design_doc, doc_to_group)
+            .await?;
+        ctx.delegate(&alice, &bob, &relays, group_to_bob).await?;
+
+        let may_read = doc_to_group.min(group_to_bob) >= Read;
+        let ct = ctx.encrypt(&alice, &design_doc, b"top secret").await?;
+        ctx.sync_all().await?;
+
+        assert_eq!(
+            ctx.can_decrypt(&bob, &ct).await?,
+            may_read,
+            "decryption at {doc_to_group:?}/{group_to_bob:?}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
+async fn multi_route_resolution_is_deterministic() -> Result<()> {
+    let mut seen = std::collections::BTreeSet::new();
+    for _ in 0..25 {
+        let mut ctx = TestContext::new().await;
+        let alice = ctx.individual("alice").await?;
+        let bob = ctx.individual("bob").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+        let engineering = ctx.group(&alice, "engineering").await?;
+
+        // Route 1: design_doc -Edit-> engineering -Admin-> bob, giving Edit.
+        ctx.delegate(&alice, &engineering, &design_doc, Edit)
+            .await?;
+        ctx.delegate(&alice, &bob, &engineering, Admin).await?;
+        // Route 2: design_doc -Read-> bob, giving Read.
+        ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+
+        seen.insert(ctx.effective_access(&bob, &design_doc).await?);
+    }
+    assert_eq!(seen.len(), 1, "answer varied across runs: {seen:?}");
+    assert_eq!(
+        seen.into_iter().next().unwrap(),
+        Some(Edit),
+        "the better of the two routes"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let before = ctx.encrypt(&alice, &design_doc, b"first").await?;
+    ctx.sync_all().await?;
+    assert!(
+        ctx.can_decrypt(&bob, &before).await?,
+        "bob could read before"
+    );
+
+    ctx.revoke(&alice, &bob, &design_doc).await?;
+    let after = ctx.encrypt(&alice, &design_doc, b"second").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
+    assert!(
+        !ctx.can_decrypt(&bob, &after).await?,
+        "cannot read new content"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_replicas_agree_on_effective_access() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &carol, &engineering, Admin).await?;
+    ctx.sync_all().await?;
+
+    for observer in [&alice, &bob, &carol] {
+        assert_eq!(
+            ctx.effective_access_seen_by(observer, &bob, &design_doc)
+                .await?,
+            Some(Read),
+            "{} disagrees about bob",
+            observer.name()
+        );
+    }
+    Ok(())
+}
+
+/// A document can be a member of another document and access propagates.
+#[tokio::test]
+async fn admin_on_a_parent_doc_reaches_the_child_doc() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let account = ctx.doc(&alice, "account").await?;
+    let project = ctx.doc(&alice, "project").await?;
+
+    ctx.delegate(&alice, &account, &project, Admin).await?;
+    ctx.delegate(&alice, &bob, &account, Admin).await?;
+
+    assert_eq!(ctx.effective_access(&bob, &account).await?, Some(Admin));
+    assert_eq!(ctx.effective_access(&bob, &project).await?, Some(Admin));
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_reader_cannot_delegate_above_read() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    for access in [Edit, Admin] {
+        match ctx.delegate(&bob, &carol, &design_doc, access).await {
+            Err(TestError::Escalation { wanted, held }) => {
+                assert_eq!(wanted, access);
+                assert_eq!(held, Read);
+            }
+            other => panic!("expected an escalation refusal, got {other:?}"),
+        }
+    }
+    assert_eq!(ctx.effective_access(&carol, &design_doc).await?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_group_removes_only_those_who_needed_it() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Edit).await?;
+    ctx.delegate(&alice, &carol, &engineering, Edit).await?;
+    ctx.delegate(&alice, &carol, &design_doc, Read).await?;
+
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Edit));
+    // Carol has two routes here, Edit through the group and Read directly. Her exact level
+    // therefore depends on the rule for combining multiple routes, which has its own test.
+    // This test is about revocation, so it only checks that she has some access, not which
+    // level.
+    assert!(ctx.effective_access(&carol, &design_doc).await?.is_some());
+
+    ctx.revoke(&alice, &engineering, &design_doc).await?;
+
+    let after = ctx.encrypt(&alice, &design_doc, b"post-revocation").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
+    assert!(
+        !ctx.can_decrypt(&bob, &after).await?,
+        "bob had only the group route"
+    );
+
+    assert_eq!(ctx.effective_access(&carol, &design_doc).await?, Some(Read));
+    assert!(
+        ctx.can_decrypt(&carol, &after).await?,
+        "carol kept her direct route"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -5,6 +5,57 @@ use keyhive_core::access::Access::{self, Admin, Edit, Read, Relay};
 
 #[tokio::test]
 async fn a_group_member_reaches_the_groups_documents() -> Result<()> {
+    // Scenario:
+    // Alice and Bob are separate Keyhive agents
+    //
+    // 1. Alice registers Bob
+    // 2. Alice creates a new group that she owns
+    // 3. Alice adds Bob to the group
+    // 4. Alice creates a new document that the group controls
+    //
+    // Both Alice and Bob should be able to access the document
+    //
+    // ┌─────────────────────┐   ┌─────────────────────┐
+    // │                     │   │                     │
+    // │        Alice        │   │         Bob         │
+    // │                     │   │                     │
+    // └─────────────────────┘   └─────────────────────┘
+    //            ▲                         ▲
+    //            │                         │
+    //            │                         │
+    //            │ ┌─────────────────────┐ │
+    //            │ │                     │ │
+    //            └─│        Group        │─┘
+    //              │                     │
+    //              └─────────────────────┘
+    //                         ▲
+    //                         │
+    //                         │
+    //              ┌─────────────────────┐
+    //              │                     │
+    //              │         Doc         │
+    //              │                     │
+    //              └─────────────────────┘
+    //
+    // Scenario:
+    // Alice creates a doc and a group.
+    // Alice gives the group Edit access to the doc.
+    // Alice adds A and B with Edit access to the group.
+    // A encrypts content to the doc, B decrypts it.
+    //
+    // ┌─────────────────────┐
+    // │        Alice        │  (owner)
+    // └─────────────────────┘
+    //            │
+    //            ▼
+    // ┌─────────────────────┐
+    // │        Group        │  ← A and B are Edit members
+    // └─────────────────────┘
+    //            │ Edit
+    //            ▼
+    // ┌─────────────────────┐
+    // │         Doc         │  ← A encrypts, B decrypts
+    // └─────────────────────┘
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -189,6 +240,34 @@ async fn two_replicas_agree_on_effective_access() -> Result<()> {
 /// A document can be a member of another document and access propagates.
 #[tokio::test]
 async fn admin_on_a_parent_doc_reaches_the_child_doc() -> Result<()> {
+    // Scenario:
+    // Alice owns both Doc A and Doc B.
+    // Alice grants Bob Admin access on Doc A.
+    // Alice adds Doc A as an Admin member of Doc B.
+    //
+    // Question: Does Bob have Admin access to Doc B transitively?
+    //
+    // ┌─────────────────────┐
+    // │                     │
+    // │         Bob         │
+    // │                     │
+    // └─────────────────────┘
+    //            │
+    //            │ Admin
+    //            ▼
+    // ┌─────────────────────┐
+    // │                     │
+    // │       Doc A         │
+    // │                     │
+    // └─────────────────────┘
+    //            │
+    //            │ Admin
+    //            ▼
+    // ┌─────────────────────┐
+    // │                     │
+    // │       Doc B         │
+    // │                     │
+    // └─────────────────────┘
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -205,6 +284,29 @@ async fn admin_on_a_parent_doc_reaches_the_child_doc() -> Result<()> {
 
 #[tokio::test]
 async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
+    // Scenario:
+    // Alice owns Account Doc A and Doc B.
+    // Alice adds Account Doc A as Admin member of Doc B.
+    // Alice adds Bob as Admin member of Account Doc A.
+    //
+    // Bob has transitive Admin access to Doc B (through Account Doc A).
+    //
+    // Test: Bob should be able to call add_member on Doc B to add Carol.
+    //
+    // ┌─────────┐   ┌─────────┐   ┌─────────┐
+    // │  Alice  │   │   Bob   │   │  Carol  │
+    // └────┬────┘   └────┬────┘   └─────────┘
+    //      │             │              ▲
+    //      │ Admin       │ Admin        │ Edit (Bob adds)
+    //      ▼             ▼              │
+    // ┌─────────────────────┐           │
+    // │   Account Doc A     │           │
+    // └─────────┬───────────┘           │
+    //           │ Admin                 │
+    //           ▼                       │
+    // ┌─────────────────────┐           │
+    // │       Doc B         │ ──────────┘
+    // └─────────────────────┘
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -249,6 +351,22 @@ async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
 
 #[tokio::test]
 async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
+    // Same scenario but using a Group as the intermediary.
+    //
+    // ┌─────────┐   ┌─────────┐   ┌─────────┐
+    // │  Alice  │   │   Bob   │   │  Carol  │
+    // └────┬────┘   └────┬────┘   └─────────┘
+    //      │             │              ▲
+    //      │ Admin       │ Admin        │ Edit (Bob adds)
+    //      ▼             ▼              │
+    // ┌─────────────────────┐           │
+    // │      Group G        │           │
+    // └─────────┬───────────┘           │
+    //           │ Admin                 │
+    //           ▼                       │
+    // ┌─────────────────────┐           │
+    // │       Doc B         │ ──────────┘
+    // └─────────────────────┘
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -293,6 +411,40 @@ async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
 /// terminate from either end and neither membership may be lost.
 #[tokio::test]
 async fn a_membership_cycle_still_resolves() -> Result<()> {
+    // Scenario:
+    // Alice and Bob are separate Keyhive agents
+    //
+    // 1. Alice registers Bob
+    // 2. Alice creates a new group that she owns
+    // 3. Alice adds Bob to the group
+    // 4. Alice creates a new document that the group controls
+    // 5. Alice creates a cycle by adding the document to the group
+    //
+    // Both Alice and Bob should be able to access the document
+    //
+    //
+    //
+    // ┌─────────────────────┐   ┌─────────────────────┐
+    // │                     │   │                     │
+    // │        Alice        │   │         Bob         │
+    // │                     │   │                     │
+    // └─────────────────────┘   └─────────────────────┘
+    //            ▲                         ▲
+    //            │                         │
+    //            │                         │
+    //            │ ┌─────────────────────┐ │
+    //            │ │                     │ │
+    //            └─│        Group        │─┘
+    //              │                     │
+    //              └─────────────────────┘
+    //                      ▲     │
+    //                      │     │
+    //                      │     ▼
+    //              ┌─────────────────────┐
+    //              │                     │
+    //              │         Doc         │
+    //              │                     │
+    //              └─────────────────────┘
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -100,9 +100,9 @@ async fn relay_never_permits_decryption() -> Result<()> {
 #[tokio::test]
 #[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
 async fn multi_route_resolution_is_deterministic() -> Result<()> {
-    let mut answers: std::collections::BTreeMap<Option<Access>, u64> = Default::default();
-    for seed in [0x1, 0x2, 0x3, 0x5, 0x8, 0xd, 0x15, 0x22] {
-        let mut ctx = TestContext::with_seed(seed).await;
+    let mut answers: std::collections::BTreeMap<Option<Access>, usize> = Default::default();
+    for round in 0..8 {
+        let mut ctx = TestContext::new().await;
         let alice = ctx.individual("alice").await?;
         let bob = ctx.individual("bob").await?;
         let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -116,12 +116,12 @@ async fn multi_route_resolution_is_deterministic() -> Result<()> {
         ctx.delegate(&alice, &bob, &design_doc, Read).await?;
 
         let access = ctx.effective_access(&bob, &design_doc).await?;
-        answers.entry(access).or_insert(seed);
+        answers.entry(access).or_insert(round);
     }
     assert_eq!(
         answers.len(),
         1,
-        "more than one answer across eight graphs, one seed each: {answers:x?}"
+        "more than one answer across eight graphs, with the round that gave each: {answers:?}"
     );
     assert_eq!(
         answers.into_keys().next().unwrap(),

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -294,6 +294,48 @@ async fn admin_on_a_parent_doc_reaches_the_child_doc() -> Result<()> {
 }
 
 #[tokio::test]
+async fn what_an_agent_reaches_covers_groups_as_well_as_documents() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &carol, &engineering, Admin).await?;
+    ctx.sync_all_unsent().await?;
+
+    let bob_reaches = ctx.memberships_reachable_by(&alice, &bob).await?;
+    assert_eq!(
+        bob_reaches.get("engineering"),
+        Some(&Read),
+        "the group he is a member of"
+    );
+    assert_eq!(
+        bob_reaches.get("design_doc"),
+        Some(&Read),
+        "and the document it holds"
+    );
+    assert_eq!(
+        ctx.documents_reachable_by(&bob).await?.get("design_doc"),
+        Some(&Read),
+        "the narrower question agrees with the wider one"
+    );
+
+    assert_eq!(
+        ctx.memberships_reachable_by(&alice, &carol)
+            .await?
+            .get("engineering"),
+        Some(&Admin),
+        "at the level each member was given, not one level for everyone"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
     // Scenario:
     // Alice owns Account Doc A and Doc B.

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -541,6 +541,63 @@ async fn a_reader_cannot_delegate_above_read() -> Result<()> {
 }
 
 #[tokio::test]
+async fn a_transitive_reader_cannot_delegate_above_read() -> Result<()> {
+    // Scenario:
+    // Alice owns Doc A and Doc B.
+    // Alice adds Doc A as Admin member of Doc B.
+    // Alice adds Bob as READ member of Doc A.
+    //
+    // Bob has transitive Read access to Doc B.
+    // Bob tries to add Carol as Admin of Doc B — should fail with AccessEscalation.
+    //
+    // ┌─────────┐   ┌─────────┐   ┌─────────┐
+    // │  Alice  │   │   Bob   │   │  Carol  │
+    // └────┬────┘   └────┬────┘   └─────────┘
+    //      │             │              ▲
+    //      │ Read        │ Read         │ Admin (Bob tries, should fail)
+    //      ▼             ▼              │
+    // ┌─────────────────────┐           │
+    // │       Doc A         │           │
+    // └─────────┬───────────┘           │
+    //           │ Admin                 │
+    //           ▼                       │
+    // ┌─────────────────────┐           │
+    // │       Doc B         │ ──────────┘
+    // └─────────────────────┘
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let account = ctx.doc(&alice, "account").await?;
+    let project = ctx.doc(&alice, "project").await?;
+
+    ctx.delegate(&alice, &account, &project, Admin).await?;
+    ctx.delegate(&alice, &bob, &account, Read).await?;
+    ctx.sync_all_unsent().await?;
+
+    assert_eq!(
+        ctx.effective_access(&bob, &project).await?,
+        Some(Read),
+        "bob holds Read on account, which attenuates his route to project"
+    );
+
+    for access in [Edit, Admin] {
+        match ctx.delegate(&bob, &carol, &project, access).await {
+            Err(TestError::Escalation { wanted, held }) => {
+                assert_eq!(wanted, access);
+                assert_eq!(
+                    held, Read,
+                    "attenuated along the route, not taken from account"
+                );
+            }
+            other => panic!("expected an escalation refusal, got {other:?}"),
+        }
+    }
+    assert_eq!(ctx.effective_access(&carol, &project).await?, None);
+    Ok(())
+}
+
+#[tokio::test]
 async fn a_revoked_member_cannot_delegate_or_revoke() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -100,6 +100,7 @@ async fn relay_never_permits_decryption() -> Result<()> {
 #[tokio::test]
 #[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
 async fn multi_route_resolution_is_deterministic() -> Result<()> {
+    // 8 distinct instances. The results differ between runs in the presence of a bug.
     let mut answers: std::collections::BTreeMap<Option<Access>, usize> = Default::default();
     for round in 0..8 {
         let mut ctx = TestContext::new().await;
@@ -338,6 +339,7 @@ async fn a_membership_cycle_still_resolves() -> Result<()> {
 #[tokio::test]
 #[ignore = "a member's level comes from the last route explored, not the best one. Fix this."]
 async fn an_attenuated_second_route_does_not_lower_reported_access() -> Result<()> {
+    // 5 distinct instances. The results differ between runs in the presence of a bug.
     for _ in 0..5 {
         let mut ctx = TestContext::new().await;
         let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -67,6 +67,17 @@ async fn a_group_member_reaches_the_groups_documents() -> Result<()> {
     ctx.delegate(&alice, &bob, &engineering, Read).await?;
 
     assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Read));
+
+    // The graph saying Read is not the same as the key agreement having reached him.
+    let ct = ctx
+        .encrypt(&alice, &design_doc, b"through the group")
+        .await?;
+    ctx.sync_all_unsent().await?;
+    assert_eq!(
+        ctx.read(&bob, &ct).await?,
+        b"through the group".to_vec(),
+        "bob reads it through the group, not only reaches it"
+    );
     Ok(())
 }
 
@@ -594,6 +605,27 @@ async fn a_transitive_reader_cannot_delegate_above_read() -> Result<()> {
         }
     }
     assert_eq!(ctx.effective_access(&carol, &project).await?, None);
+
+    // The refusal is about the level, not about the route being transitive: the same
+    // delegation at bob's own level goes through.
+    ctx.delegate(&bob, &carol, &project, Read).await?;
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &carol, &project).await?,
+        Some(Read),
+        "bob delegated at the level he holds"
+    );
+
+    ctx.sync_all_unsent().await?;
+    assert_eq!(
+        ctx.effective_access(&carol, &project).await?,
+        Some(Read),
+        "and alice, who owns the document, honors it"
+    );
+    assert_eq!(
+        ctx.effective_access(&carol, &account).await?,
+        None,
+        "being let into project does not reach back up to the document that holds it"
+    );
     Ok(())
 }
 

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -121,7 +121,7 @@ async fn multi_route_resolution_is_deterministic() -> Result<()> {
     assert_eq!(
         answers.len(),
         1,
-        "the answer depends on key material, one seed each: {answers:x?}"
+        "more than one answer across eight graphs, one seed each: {answers:x?}"
     );
     assert_eq!(
         answers.into_keys().next().unwrap(),
@@ -199,6 +199,144 @@ async fn admin_on_a_parent_doc_reaches_the_child_doc() -> Result<()> {
 
     assert_eq!(ctx.effective_access(&bob, &account).await?, Some(Admin));
     assert_eq!(ctx.effective_access(&bob, &project).await?, Some(Admin));
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_transitive_admin_through_a_document_can_delegate() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let account = ctx.doc(&alice, "account").await?;
+    let project = ctx.doc(&alice, "project").await?;
+
+    ctx.delegate(&alice, &account, &project, Admin).await?;
+    ctx.delegate(&alice, &bob, &account, Admin).await?;
+    ctx.sync_all().await?;
+    assert_eq!(
+        ctx.effective_access(&bob, &project).await?,
+        Some(Admin),
+        "bob reaches project through account"
+    );
+
+    ctx.delegate(&bob, &carol, &project, Edit).await?;
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &carol, &project).await?,
+        Some(Edit),
+        "bob delegated based on a route (through a doc) he does not hold directly"
+    );
+
+    ctx.sync_all().await?;
+    assert_eq!(
+        ctx.effective_access(&carol, &project).await?,
+        Some(Edit),
+        "and alice, who owns the document, honors it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_transitive_admin_through_a_group_can_delegate() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let project = ctx.doc(&alice, "project").await?;
+
+    ctx.delegate(&alice, &engineering, &project, Admin).await?;
+    ctx.delegate(&alice, &bob, &engineering, Admin).await?;
+    ctx.sync_all().await?;
+    assert_eq!(ctx.effective_access(&bob, &project).await?, Some(Admin));
+
+    ctx.delegate(&bob, &carol, &project, Edit).await?;
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &carol, &project).await?,
+        Some(Edit),
+        "bob delegated on the strength of a route he does not hold directly"
+    );
+
+    ctx.sync_all().await?;
+    assert_eq!(
+        ctx.effective_access(&carol, &project).await?,
+        Some(Edit),
+        "bob delegated based on a route (through a group) he does not hold directly"
+    );
+    Ok(())
+}
+
+/// A group holds a document and the document holds the group. Reachability has to
+/// terminate from either end and neither membership may be lost.
+#[tokio::test]
+async fn a_membership_cycle_still_resolves() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &design_doc, &engineering, Read)
+        .await?;
+
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Read));
+
+    let of_the_document = ctx.transitive_members_of(&design_doc).await?;
+    assert_eq!(
+        of_the_document.get("bob"),
+        Some(&Read),
+        "bob reaches the document through the group, even when there's a cycle"
+    );
+    assert_eq!(
+        of_the_document.get("engineering"),
+        Some(&Read),
+        "and the group is still a member of the document"
+    );
+
+    let of_the_group = ctx.transitive_members_of(&engineering).await?;
+    assert_eq!(
+        of_the_group.get("bob"),
+        Some(&Read),
+        "the walk terminates from the other end too"
+    );
+    assert_eq!(
+        of_the_group.get("design_doc"),
+        Some(&Read),
+        "and the reverse edge is what makes it a cycle"
+    );
+    Ok(())
+}
+
+/// Alice creates a group, so she is its admin. Giving a document she owns a `Read`
+/// membership in that group hands her a second, weaker route to it. Her own access must not
+/// drop because of a route she gained.
+#[tokio::test]
+#[ignore = "a member's level comes from the last route explored, not the best one. Fix this."]
+async fn an_attenuated_second_route_does_not_lower_reported_access() -> Result<()> {
+    for _ in 0..5 {
+        let mut ctx = TestContext::new().await;
+        let alice = ctx.individual("alice").await?;
+        let engineering = ctx.group(&alice, "engineering").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+        assert_eq!(
+            ctx.transitive_members_of(&engineering).await?.get("alice"),
+            Some(&Admin),
+            "alice created the group"
+        );
+
+        ctx.delegate(&alice, &design_doc, &engineering, Read)
+            .await?;
+
+        assert_eq!(
+            ctx.transitive_members_of(&engineering).await?.get("alice"),
+            Some(&Admin),
+            "the weaker route took precedence over her own"
+        );
+    }
     Ok(())
 }
 

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -162,7 +162,7 @@ async fn relay_never_permits_decryption() -> Result<()> {
 #[tokio::test]
 #[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
 async fn multi_route_resolution_is_deterministic() -> Result<()> {
-    // 8 distinct instances. The results differ between runs in the presence of a bug.
+    // Eight separate runs. In the presence of a bug the answer differs between them.
     let mut answers: std::collections::BTreeMap<Option<Access>, usize> = Default::default();
     for round in 0..8 {
         let mut ctx = TestContext::new().await;
@@ -544,9 +544,9 @@ async fn a_membership_cycle_still_resolves() -> Result<()> {
 /// membership in that group hands her a second, weaker route to it. Her own access must not
 /// drop because of a route she gained.
 #[tokio::test]
-#[ignore = "a member's level comes from the last route explored, not the best one. Fix this."]
+#[ignore = "a member's level comes from the last route explored, not the best one"]
 async fn an_attenuated_second_route_does_not_lower_reported_access() -> Result<()> {
-    // 5 distinct instances. The results differ between runs in the presence of a bug.
+    // Five separate runs. In the presence of a bug the answer differs between them.
     for _ in 0..5 {
         let mut ctx = TestContext::new().await;
         let alice = ctx.individual("alice").await?;
@@ -600,10 +600,10 @@ async fn a_transitive_reader_cannot_delegate_above_read() -> Result<()> {
     // Scenario:
     // Alice owns Doc A and Doc B.
     // Alice adds Doc A as Admin member of Doc B.
-    // Alice adds Bob as READ member of Doc A.
+    // Alice adds Bob as a Read member of Doc A.
     //
     // Bob has transitive Read access to Doc B.
-    // Bob tries to add Carol as Admin of Doc B — should fail with AccessEscalation.
+    // Bob tries to add Carol as Admin of Doc B. It should fail with an access escalation.
     //
     // ┌─────────┐   ┌─────────┐   ┌─────────┐
     // │  Alice  │   │   Bob   │   │  Carol  │

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -399,20 +399,14 @@ async fn a_revoked_member_cannot_delegate_or_revoke() -> Result<()> {
     ctx.revoke(&alice, &mallory, &design_doc).await?;
     ctx.sync_all_unsent().await?;
 
-    assert!(
-        matches!(
-            ctx.delegate(&mallory, &carol, &design_doc, Read).await,
-            Err(TestError::NoAuthority)
-        ),
-        "a revoked member may not issue a delegation"
-    );
-    assert!(
-        matches!(
-            ctx.revoke(&mallory, &alice, &design_doc).await,
-            Err(TestError::NoAuthority)
-        ),
-        "or a revocation"
-    );
+    match ctx.delegate(&mallory, &carol, &design_doc, Read).await {
+        Err(TestError::NoAuthority) => {}
+        other => panic!("a revoked member may not issue a delegation, got {other:?}"),
+    }
+    match ctx.revoke(&mallory, &alice, &design_doc).await {
+        Err(TestError::NoAuthority) => {}
+        other => panic!("nor a revocation, got {other:?}"),
+    }
     Ok(())
 }
 

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -1,5 +1,3 @@
-//! Tests for three access-control rules, written against the facade in `facade/`.
-
 mod facade;
 
 use facade::{Result, TestContext, TestError};
@@ -220,6 +218,36 @@ async fn a_reader_cannot_delegate_above_read() -> Result<()> {
         }
     }
     assert_eq!(ctx.effective_access(&carol, &design_doc).await?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revoked_member_cannot_delegate_or_revoke() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let mallory = ctx.individual("mallory").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &mallory, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+    ctx.revoke(&alice, &mallory, &design_doc).await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        matches!(
+            ctx.delegate(&mallory, &carol, &design_doc, Read).await,
+            Err(TestError::NoAuthority)
+        ),
+        "a revoked member may not issue a delegation"
+    );
+    assert!(
+        matches!(
+            ctx.revoke(&mallory, &alice, &design_doc).await,
+            Err(TestError::NoAuthority)
+        ),
+        "or a revocation"
+    );
     Ok(())
 }
 

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -320,9 +320,11 @@ async fn what_an_agent_reaches_covers_groups_as_well_as_documents() -> Result<()
         "and the document it holds"
     );
     assert_eq!(
-        ctx.documents_reachable_by(&bob).await?.get("design_doc"),
+        ctx.documents_reachable_by(&bob, &bob)
+            .await?
+            .get("design_doc"),
         Some(&Read),
-        "the narrower question agrees with the wider one"
+        "and bob agrees"
     );
 
     assert_eq!(

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -1,7 +1,7 @@
 mod facade;
 
 use facade::{Result, TestContext, TestError};
-use keyhive_core::access::Access::{Admin, Edit, Read, Relay};
+use keyhive_core::access::Access::{self, Admin, Edit, Read, Relay};
 
 #[tokio::test]
 async fn a_group_member_reaches_the_groups_documents() -> Result<()> {
@@ -100,9 +100,9 @@ async fn relay_never_permits_decryption() -> Result<()> {
 #[tokio::test]
 #[ignore = "fails on main; fixed by jtfm/cgka-authority; un-ignore when that lands"]
 async fn multi_route_resolution_is_deterministic() -> Result<()> {
-    let mut seen = std::collections::BTreeSet::new();
-    for _ in 0..25 {
-        let mut ctx = TestContext::new().await;
+    let mut answers: std::collections::BTreeMap<Option<Access>, u64> = Default::default();
+    for seed in [0x1, 0x2, 0x3, 0x5, 0x8, 0xd, 0x15, 0x22] {
+        let mut ctx = TestContext::with_seed(seed).await;
         let alice = ctx.individual("alice").await?;
         let bob = ctx.individual("bob").await?;
         let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -115,11 +115,16 @@ async fn multi_route_resolution_is_deterministic() -> Result<()> {
         // Route 2: design_doc -Read-> bob, giving Read.
         ctx.delegate(&alice, &bob, &design_doc, Read).await?;
 
-        seen.insert(ctx.effective_access(&bob, &design_doc).await?);
+        let access = ctx.effective_access(&bob, &design_doc).await?;
+        answers.entry(access).or_insert(seed);
     }
-    assert_eq!(seen.len(), 1, "answer varied across runs: {seen:?}");
     assert_eq!(
-        seen.into_iter().next().unwrap(),
+        answers.len(),
+        1,
+        "the answer depends on key material, one seed each: {answers:x?}"
+    );
+    assert_eq!(
+        answers.into_keys().next().unwrap(),
         Some(Edit),
         "the better of the two routes"
     );

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -5,7 +5,7 @@ use keyhive_core::access::Access::{Admin, Edit, Read};
 
 #[tokio::test]
 async fn an_archive_round_trip_preserves_members_access_and_decryption() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let carol = ctx.individual("carol").await?;
@@ -48,7 +48,7 @@ async fn an_archive_round_trip_preserves_members_access_and_decryption() -> Resu
 
 #[tokio::test]
 async fn a_restored_instance_can_still_issue_delegations() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let dave = ctx.individual("dave").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -71,7 +71,7 @@ async fn a_restored_instance_can_still_issue_delegations() -> Result<()> {
 
 #[tokio::test]
 async fn an_old_archive_merged_with_later_events_converges() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let carol = ctx.individual("carol").await?;
@@ -112,7 +112,7 @@ async fn an_old_archive_merged_with_later_events_converges() -> Result<()> {
 
 #[tokio::test]
 async fn ingesting_an_archive_merges_into_a_live_instance() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -39,8 +39,9 @@ async fn an_archive_round_trip_preserves_members_access_and_decryption() -> Resu
             who.name()
         );
     }
-    assert!(
-        ctx.can_decrypt(&restored, &ct).await?,
+    assert_eq!(
+        ctx.read(&restored, &ct).await?,
+        b"before the archive".to_vec(),
         "and it can still read what it could read before"
     );
     Ok(())
@@ -166,6 +167,36 @@ async fn an_instance_caught_up_by_syncing_can_read_what_it_missed() -> Result<()
         ctx.read(&restored, &ct).await?,
         b"hello world".to_vec(),
         "but after sync, it reads content written while it did not exist"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_archive_merged_into_a_rebuild_reaches_a_readable_state() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+
+    let early = ctx.archive(&alice).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let ct = ctx
+        .encrypt(&alice, &design_doc, b"written after the fork")
+        .await?;
+
+    let restored = ctx.rebuild_from_archive(&early, "alice-restored").await?;
+    let latest = ctx.archive(&alice).await?;
+    let pending = ctx.ingest_archive(&restored, latest).await?;
+    assert_eq!(pending, 0, "the later archive was ingested completely");
+
+    // The archive carries the membership graph and not the key state, which is what
+    // `ingesting_an_archive_carries_the_key_state_as_well_as_the_graph` covers.
+    // The events carry the key state, so the two together reach a readable state.
+    ctx.sync_all_unsent().await?;
+
+    assert_eq!(
+        ctx.read(&restored, &ct).await?,
+        b"written after the fork".to_vec(),
+        "rebuilt from the earlier archive, merged with the later one, caught up by events"
     );
     Ok(())
 }

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -1,0 +1,140 @@
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::{Admin, Edit, Read};
+
+#[tokio::test]
+async fn an_archive_round_trip_preserves_members_access_and_decryption() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &carol, &design_doc, Admin).await?;
+    let ct = ctx
+        .encrypt(&alice, &design_doc, b"before the archive")
+        .await?;
+    ctx.sync_all().await?;
+
+    let members_before = ctx.transitive_members_of(&design_doc).await?;
+    let archive = ctx.archive(&alice).await?;
+    let restored = ctx.rebuild_from_archive(&archive, "alice-restored").await?;
+
+    assert_eq!(
+        ctx.transitive_members_of(&design_doc).await?,
+        members_before,
+        "the same people, at the same levels"
+    );
+    for who in [&bob, &carol] {
+        assert_eq!(
+            ctx.effective_access_seen_by(&restored, who, &design_doc)
+                .await?,
+            ctx.effective_access(who, &design_doc).await?,
+            "the restored instance disagrees about {}",
+            who.name()
+        );
+    }
+    assert!(
+        ctx.can_decrypt(&restored, &ct).await?,
+        "and it can still read what it could read before"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_restored_instance_can_still_issue_delegations() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let alice = ctx.individual("alice").await?;
+    let dave = ctx.individual("dave").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.sync_all().await?;
+
+    let archive = ctx.archive(&alice).await?;
+    let restored = ctx.rebuild_from_archive(&archive, "alice-restored").await?;
+
+    ctx.delegate(&restored, &dave, &design_doc, Edit).await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice, &dave, &design_doc)
+            .await?,
+        Some(Edit),
+        "the original instance honors what the restored one signed"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_old_archive_merged_with_later_events_converges() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let old = ctx.archive(&alice).await?;
+
+    // More happens after the archive is created.
+    ctx.delegate(&alice, &carol, &design_doc, Admin).await?;
+    ctx.revoke(&alice, &bob, &design_doc).await?;
+
+    let restored = ctx
+        .rebuild_from_archive(&old, "alice-from-old-archive")
+        .await?;
+    assert_eq!(
+        ctx.effective_access_seen_by(&restored, &carol, &design_doc)
+            .await?,
+        None,
+        "the archive predates carol's grant"
+    );
+
+    ctx.sync_all().await?;
+
+    assert_eq!(
+        ctx.effective_access_seen_by(&restored, &carol, &design_doc)
+            .await?,
+        ctx.effective_access(&carol, &design_doc).await?
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&restored, &bob, &design_doc)
+            .await?,
+        ctx.effective_access(&bob, &design_doc).await?,
+        "including the revocation it never saw"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn ingesting_an_archive_merges_into_a_live_instance() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa4c).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let notes = ctx.doc(&bob, "notes").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.delegate(&bob, &alice, &notes, Read).await?;
+
+    let from_bob = ctx.archive(&bob).await?;
+    let pending = ctx.ingest_archive(&alice, &from_bob).await?;
+
+    assert_eq!(pending, 0, "nothing in bob's archive was unusable to alice");
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice, &alice, &notes).await?,
+        Some(Read),
+        "alice learned about bob's document"
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice, &bob, &design_doc)
+            .await?,
+        Some(Read),
+        "and kept what she already knew"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -19,7 +19,7 @@ async fn an_archive_round_trip_preserves_members_access_and_decryption() -> Resu
     let ct = ctx
         .encrypt(&alice, &design_doc, b"before the archive")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let members_before = ctx.transitive_members_of(&design_doc).await?;
     let archive = ctx.archive(&alice).await?;
@@ -52,13 +52,13 @@ async fn a_restored_instance_can_still_issue_delegations() -> Result<()> {
     let alice = ctx.individual("alice").await?;
     let dave = ctx.individual("dave").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let archive = ctx.archive(&alice).await?;
     let restored = ctx.rebuild_from_archive(&archive, "alice-restored").await?;
 
     ctx.delegate(&restored, &dave, &design_doc, Edit).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         ctx.effective_access_seen_by(&alice, &dave, &design_doc)
@@ -94,7 +94,7 @@ async fn an_old_archive_merged_with_later_events_converges() -> Result<()> {
         "the archive predates carol's delegation"
     );
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         ctx.effective_access_seen_by(&restored, &carol, &design_doc)
@@ -160,7 +160,7 @@ async fn an_instance_caught_up_by_syncing_can_read_what_it_missed() -> Result<()
         "and it can't yet read content written while it did not exist"
     );
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         ctx.read(&restored, &ct).await?,

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -91,7 +91,7 @@ async fn an_old_archive_merged_with_later_events_converges() -> Result<()> {
         ctx.effective_access_seen_by(&restored, &carol, &design_doc)
             .await?,
         None,
-        "the archive predates carol's grant"
+        "the archive predates carol's delegation"
     );
 
     ctx.sync_all().await?;
@@ -135,6 +135,65 @@ async fn ingesting_an_archive_merges_into_a_live_instance() -> Result<()> {
             .await?,
         Some(Read),
         "and kept what she already knew"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_instance_caught_up_by_syncing_can_read_what_it_missed() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+
+    let early = ctx.archive(&alice).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"hello world").await?;
+
+    let restored = ctx.rebuild_from_archive(&early, "alice-restored").await?;
+    assert!(
+        !ctx.has_received(&restored, &design_doc).await?,
+        "the archive predates the document"
+    );
+
+    assert!(
+        !ctx.can_decrypt(&restored, &ct).await?,
+        "and it can't yet read content written while it did not exist"
+    );
+
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.can_decrypt(&restored, &ct).await?,
+        "but after sync, it reads content written while it did not exist"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "ingesting an archive brings the membership graph but not the key state"]
+async fn ingesting_an_archive_carries_the_key_state_as_well_as_the_graph() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+
+    let early = ctx.archive(&alice).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"hello world").await?;
+
+    let restored = ctx.rebuild_from_archive(&early, "alice-restored").await?;
+    let latest = ctx.archive(&alice).await?;
+    let pending = ctx.ingest_archive(&restored, latest).await?;
+
+    assert_eq!(pending, 0, "the archive was ingested completely");
+    assert_eq!(
+        ctx.effective_access_seen_by(&restored, &alice, &design_doc)
+            .await?,
+        Some(Admin),
+        "and it believes it is an admin of the document"
+    );
+    assert!(
+        ctx.can_decrypt(&restored, &ct).await?,
+        "so it should be able to read the document it is an admin of"
     );
     Ok(())
 }

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -122,7 +122,7 @@ async fn ingesting_an_archive_merges_into_a_live_instance() -> Result<()> {
     ctx.delegate(&bob, &alice, &notes, Read).await?;
 
     let from_bob = ctx.archive(&bob).await?;
-    let pending = ctx.ingest_archive(&alice, &from_bob).await?;
+    let pending = ctx.ingest_archive(&alice, from_bob).await?;
 
     assert_eq!(pending, 0, "nothing in bob's archive was unusable to alice");
     assert_eq!(

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -162,8 +162,9 @@ async fn an_instance_caught_up_by_syncing_can_read_what_it_missed() -> Result<()
 
     ctx.sync_all().await?;
 
-    assert!(
-        ctx.can_decrypt(&restored, &ct).await?,
+    assert_eq!(
+        ctx.read(&restored, &ct).await?,
+        b"hello world".to_vec(),
         "but after sync, it reads content written while it did not exist"
     );
     Ok(())

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -145,8 +145,16 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
     assert_eq!(
         walked.missing(),
         1,
-        "and says the root is outstanding rather than failing"
+        "and says something is outstanding rather than failing"
     );
+    let key = walked
+        .key_for_missing(&genesis)
+        .ok_or("the walk did not say which content is outstanding")?;
+    assert!(
+        ctx.decrypt_with_key(&genesis, &key).is_ok(),
+        "and the key it reported for it is the one that opens it, so fetching is enough"
+    );
+
     Ok(())
 }
 
@@ -186,6 +194,55 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
         walked.missing(),
         1,
         "but bob needs to be told which content to go and fetch"
+    );
+    assert!(
+        walked.key_for_missing(&history).is_some(),
+        "with the key to open it once he has it"
+    );
+    Ok(())
+}
+
+/// `CiphertextStore` must stop serving content once it has been decrypted, whether by
+/// removing it or by tracking what has been read.
+///
+/// The consumed content is not reported as outstanding either because the entrypoint lists
+/// it directly. That's handled by `an_ancestor_the_entrypoint_lists_is_reported_when_missing`.
+#[tokio::test]
+async fn a_walk_consumes_the_content_it_reads() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    let genesis = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&genesis), b"head")
+        .await?;
+    ctx.sync_all().await?;
+
+    ctx.deliver_content(&bob, &genesis).await?;
+    ctx.deliver_content(&bob, &head).await?;
+
+    let first = ctx.causal_decrypt(&bob, &head).await?;
+    assert_eq!(first.recovered(), contents(&[b"genesis"]));
+
+    let second = ctx.causal_decrypt(&bob, &head).await?;
+    assert_eq!(
+        second.recovered(),
+        contents(&[]),
+        "the first walk took it out of the store"
+    );
+
+    ctx.deliver_content(&bob, &genesis).await?;
+    let third = ctx.causal_decrypt(&bob, &head).await?;
+    assert_eq!(
+        third.recovered(),
+        contents(&[b"genesis"]),
+        "delivering it again is enough to read it again"
     );
     Ok(())
 }

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -52,7 +52,12 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
     assert_eq!(
         walked.recovered(),
         contents(&[b"genesis", b"left", b"right"]),
-        "the diamond is walked once, not twice, and reaches the root"
+        "the walk reaches the root by both paths"
+    );
+    assert_eq!(
+        walked.recovered_count(),
+        3,
+        "and reads the shared ancestor once rather than once per path"
     );
     assert_eq!(walked.missing(), 0, "bob holds every ancestor");
     Ok(())

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -29,18 +29,13 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
         .await?;
     let left = ctx
-        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&genesis), b"left")
+        .encrypt_in_envelope(&alice, &design_doc, &[&genesis], b"left")
         .await?;
     let right = ctx
-        .encrypt_in_envelope(
-            &alice,
-            &design_doc,
-            std::slice::from_ref(&genesis),
-            b"right",
-        )
+        .encrypt_in_envelope(&alice, &design_doc, &[&genesis], b"right")
         .await?;
     let head = ctx
-        .encrypt_in_envelope(&alice, &design_doc, &[left.clone(), right.clone()], b"head")
+        .encrypt_in_envelope(&alice, &design_doc, &[&left, &right], b"head")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -82,12 +77,7 @@ async fn a_later_member_recovers_earlier_content_by_walking_back() -> Result<()>
     ctx.force_pcs_update(&alice, &design_doc).await?;
 
     let entry_point = ctx
-        .encrypt_in_envelope(
-            &alice,
-            &design_doc,
-            std::slice::from_ref(&history),
-            b"written after bob",
-        )
+        .encrypt_in_envelope(&alice, &design_doc, &[&history], b"written after bob")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -125,15 +115,10 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
         .await?;
     let middle = ctx
-        .encrypt_in_envelope(
-            &alice,
-            &design_doc,
-            std::slice::from_ref(&genesis),
-            b"middle",
-        )
+        .encrypt_in_envelope(&alice, &design_doc, &[&genesis], b"middle")
         .await?;
     let head = ctx
-        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&middle), b"head")
+        .encrypt_in_envelope(&alice, &design_doc, &[&middle], b"head")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -182,7 +167,7 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
         .encrypt_in_envelope(&alice, &design_doc, &[], b"history")
         .await?;
     let head = ctx
-        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&history), b"head")
+        .encrypt_in_envelope(&alice, &design_doc, &[&history], b"head")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -225,7 +210,7 @@ async fn a_walk_consumes_the_content_it_reads() -> Result<()> {
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
         .await?;
     let head = ctx
-        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&genesis), b"head")
+        .encrypt_in_envelope(&alice, &design_doc, &[&genesis], b"head")
         .await?;
     ctx.sync_all_unsent().await?;
 

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -2,7 +2,7 @@
 //!
 //! Content written this way carries, inside its own ciphertext, the keys to the content it
 //! lists. That is how someone who can open one write can open earlier ones they were never
-//! given a key for. Keyhive defines the envelope and walks it; building one is the
+//! given a key for. Keyhive defines the envelope and walks it. Building one is the
 //! application's job, which `encrypt_in_envelope` stands in for.
 
 mod facade;
@@ -148,11 +148,7 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
     Ok(())
 }
 
-/// `Document::try_causal_decrypt_content` collects the entrypoint's missing ancestors into
-/// a local `CausalDecryptionState` and then returns the store walk's own state instead,
-/// dropping what it collected. So a reader passed a write before the content it points at
-/// is told there is nothing outstanding when what it needs is exactly that list and the
-/// keys in it.
+/// Walking from two heads reads their shared ancestor once, not once per head.
 #[tokio::test]
 async fn a_walk_from_two_heads_reads_their_shared_ancestor_once() -> Result<()> {
     let mut ctx = TestContext::new().await;
@@ -184,8 +180,6 @@ async fn a_walk_from_two_heads_reads_their_shared_ancestor_once() -> Result<()> 
         .causal_decrypt_from(&bob, &[&left_head, &right_head])
         .await?;
 
-    // Walking from entrypoints rather than from a document includes the entrypoints
-    // themselves. `causal_decrypt` reports only what it walked back to.
     assert_eq!(
         walked.recovered(),
         contents(&[b"left head", b"right head", b"root"]),
@@ -312,8 +306,13 @@ async fn two_missing_ancestors_are_each_reported_with_their_own_key() -> Result<
     Ok(())
 }
 
+/// `Document::try_causal_decrypt_content` collects the entrypoint's missing ancestors into
+/// a local `CausalDecryptionState` and then returns the store walk's own state instead,
+/// dropping what it collected. So a reader passed a write before the content it points at
+/// is told there is nothing outstanding when what it needs is exactly that list and the
+/// keys in it.
 #[tokio::test]
-#[ignore = "an ancestor the entrypoint lists is dropped from the report when it is missing. Fix this"]
+#[ignore = "an ancestor the entrypoint lists is dropped from the report when it is missing"]
 async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
@@ -330,7 +329,7 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
         .await?;
     ctx.sync_all_unsent().await?;
 
-    // The entrypoint.
+    // Only the entrypoint. Bob is not given the ancestor it lists.
     ctx.deliver_content(&bob, &head).await?;
     let walked = ctx.causal_decrypt(&bob, &head).await?;
 
@@ -354,8 +353,9 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
 /// `CiphertextStore` must stop serving content once it has been decrypted, whether by
 /// removing it or by tracking what has been read.
 ///
-/// The consumed content is not reported as outstanding either because the entrypoint lists
-/// it directly. That's handled by `an_ancestor_the_entrypoint_lists_is_reported_when_missing`.
+/// The second walk does not report the consumed content as outstanding, because the
+/// entrypoint lists it directly.
+/// `an_ancestor_the_entrypoint_lists_is_reported_when_missing` covers that case.
 #[tokio::test]
 async fn a_walk_consumes_the_content_it_reads() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -22,7 +22,7 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     // genesis, then two writes with it as their predecessor, then one with both of those.
     let genesis = ctx
@@ -42,7 +42,7 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
     let head = ctx
         .encrypt_in_envelope(&alice, &design_doc, &[left.clone(), right.clone()], b"head")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     for ct in [&genesis, &left, &right, &head] {
         ctx.deliver_content(&bob, ct).await?;
@@ -73,7 +73,7 @@ async fn a_later_member_recovers_earlier_content_by_walking_back() -> Result<()>
         .await?;
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     ctx.force_pcs_update(&alice, &design_doc).await?;
 
     let entry_point = ctx
@@ -84,7 +84,7 @@ async fn a_later_member_recovers_earlier_content_by_walking_back() -> Result<()>
             b"written after bob",
         )
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         !ctx.can_decrypt(&bob, &history).await?,
@@ -114,7 +114,7 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let genesis = ctx
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
@@ -130,7 +130,7 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
     let head = ctx
         .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&middle), b"head")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     // Everything except the root of the chain.
     ctx.deliver_content(&bob, &head).await?;
@@ -171,7 +171,7 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let history = ctx
         .encrypt_in_envelope(&alice, &design_doc, &[], b"history")
@@ -179,7 +179,7 @@ async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<(
     let head = ctx
         .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&history), b"head")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     // The entrypoint.
     ctx.deliver_content(&bob, &head).await?;
@@ -214,7 +214,7 @@ async fn a_walk_consumes_the_content_it_reads() -> Result<()> {
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let genesis = ctx
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
@@ -222,7 +222,7 @@ async fn a_walk_consumes_the_content_it_reads() -> Result<()> {
     let head = ctx
         .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&genesis), b"head")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     ctx.deliver_content(&bob, &genesis).await?;
     ctx.deliver_content(&bob, &head).await?;

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -1,7 +1,7 @@
-//! Reading a chain of content by walking back through the ancestors each write names.
+//! Reading a chain of content by walking back through the ancestors each write lists.
 //!
 //! Content written this way carries, inside its own ciphertext, the keys to the content it
-//! names. That is how someone who can open one write can open earlier ones they were never
+//! lists. That is how someone who can open one write can open earlier ones they were never
 //! given a key for. Keyhive defines the envelope and walks it; building one is the
 //! application's job, which `encrypt_in_envelope` stands in for.
 
@@ -24,7 +24,7 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     ctx.sync_all().await?;
 
-    // genesis, then two writes naming it, then one naming both of those.
+    // genesis, then two writes with it as their predecessor, then one with both of those.
     let genesis = ctx
         .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
         .await?;
@@ -60,7 +60,7 @@ async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
 
 /// A later member reads earlier content by walking back from a write made after they
 /// joined. This is the shape ARK uses to admit someone to a document that already has
-/// history: rotate, then write something that names what came before.
+/// history: rotate, then write something that lists what came before.
 #[tokio::test]
 async fn a_later_member_recovers_earlier_content_by_walking_back() -> Result<()> {
     let mut ctx = TestContext::new().await;
@@ -150,17 +150,14 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
     Ok(())
 }
 
-/// The same rule one step nearer: the ancestor that is missing is the one the entrypoint
-/// names, rather than one further back.
-///
 /// `Document::try_causal_decrypt_content` collects the entrypoint's missing ancestors into
-/// a local `CausalDecryptionState`, and then returns the store walk's own state instead,
-/// dropping what it collected. So a reader handed a write before the content it points at
-/// is told there is nothing outstanding, when what it needs is exactly that list and the
+/// a local `CausalDecryptionState` and then returns the store walk's own state instead,
+/// dropping what it collected. So a reader passed a write before the content it points at
+/// is told there is nothing outstanding when what it needs is exactly that list and the
 /// keys in it.
 #[tokio::test]
-#[ignore = "an ancestor named by the entrypoint is dropped from the report when it is missing"]
-async fn an_ancestor_named_by_the_entrypoint_is_reported_when_missing() -> Result<()> {
+#[ignore = "an ancestor the entrypoint lists is dropped from the report when it is missing. Fix this"]
+async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -176,7 +173,7 @@ async fn an_ancestor_named_by_the_entrypoint_is_reported_when_missing() -> Resul
         .await?;
     ctx.sync_all().await?;
 
-    // The entrypoint, and nothing it names.
+    // The entrypoint.
     ctx.deliver_content(&bob, &head).await?;
     let walked = ctx.causal_decrypt(&bob, &head).await?;
 

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -1,0 +1,194 @@
+//! Reading a chain of content by walking back through the ancestors each write names.
+//!
+//! Content written this way carries, inside its own ciphertext, the keys to the content it
+//! names. That is how someone who can open one write can open earlier ones they were never
+//! given a key for. Keyhive defines the envelope and walks it; building one is the
+//! application's job, which `encrypt_in_envelope` stands in for.
+
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::Read;
+use std::collections::BTreeSet;
+
+fn contents(of: &[&[u8]]) -> BTreeSet<Vec<u8>> {
+    of.iter().map(|c| c.to_vec()).collect()
+}
+
+#[tokio::test]
+async fn a_reader_walks_back_through_the_ancestors_it_holds() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    // genesis, then two writes naming it, then one naming both of those.
+    let genesis = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
+        .await?;
+    let left = ctx
+        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&genesis), b"left")
+        .await?;
+    let right = ctx
+        .encrypt_in_envelope(
+            &alice,
+            &design_doc,
+            std::slice::from_ref(&genesis),
+            b"right",
+        )
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[left.clone(), right.clone()], b"head")
+        .await?;
+    ctx.sync_all().await?;
+
+    for ct in [&genesis, &left, &right, &head] {
+        ctx.deliver_content(&bob, ct).await?;
+    }
+    let walked = ctx.causal_decrypt(&bob, &head).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"genesis", b"left", b"right"]),
+        "the diamond is walked once, not twice, and reaches the root"
+    );
+    assert_eq!(walked.missing(), 0, "bob holds every ancestor");
+    Ok(())
+}
+
+/// A later member reads earlier content by walking back from a write made after they
+/// joined. This is the shape ARK uses to admit someone to a document that already has
+/// history: rotate, then write something that names what came before.
+#[tokio::test]
+async fn a_later_member_recovers_earlier_content_by_walking_back() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let history = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"written before bob")
+        .await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+
+    let entry_point = ctx
+        .encrypt_in_envelope(
+            &alice,
+            &design_doc,
+            std::slice::from_ref(&history),
+            b"written after bob",
+        )
+        .await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        !ctx.can_decrypt(&bob, &history).await?,
+        "bob cannot derive the key for content written before he joined"
+    );
+    assert!(
+        ctx.can_decrypt(&bob, &entry_point).await?,
+        "he can open the write that came after"
+    );
+
+    ctx.deliver_content(&bob, &history).await?;
+    ctx.deliver_content(&bob, &entry_point).await?;
+    let walked = ctx.causal_decrypt(&bob, &entry_point).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"written before bob"]),
+        "and the write he can open carries the key to the one he cannot"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    let genesis = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
+        .await?;
+    let middle = ctx
+        .encrypt_in_envelope(
+            &alice,
+            &design_doc,
+            std::slice::from_ref(&genesis),
+            b"middle",
+        )
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&middle), b"head")
+        .await?;
+    ctx.sync_all().await?;
+
+    // Everything except the root of the chain.
+    ctx.deliver_content(&bob, &head).await?;
+    ctx.deliver_content(&bob, &middle).await?;
+    let walked = ctx.causal_decrypt(&bob, &head).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"middle"]),
+        "the walk gets as far as it can"
+    );
+    assert_eq!(
+        walked.missing(),
+        1,
+        "and says the root is outstanding rather than failing"
+    );
+    Ok(())
+}
+
+/// The same rule one step nearer: the ancestor that is missing is the one the entrypoint
+/// names, rather than one further back.
+///
+/// `Document::try_causal_decrypt_content` collects the entrypoint's missing ancestors into
+/// a local `CausalDecryptionState`, and then returns the store walk's own state instead,
+/// dropping what it collected. So a reader handed a write before the content it points at
+/// is told there is nothing outstanding, when what it needs is exactly that list and the
+/// keys in it.
+#[tokio::test]
+#[ignore = "an ancestor named by the entrypoint is dropped from the report when it is missing"]
+async fn an_ancestor_named_by_the_entrypoint_is_reported_when_missing() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    let history = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"history")
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, std::slice::from_ref(&history), b"head")
+        .await?;
+    ctx.sync_all().await?;
+
+    // The entrypoint, and nothing it names.
+    ctx.deliver_content(&bob, &head).await?;
+    let walked = ctx.causal_decrypt(&bob, &head).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[]),
+        "there is nothing to walk"
+    );
+    assert_eq!(
+        walked.missing(),
+        1,
+        "but bob needs to be told which content to go and fetch"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/causal.rs
+++ b/keyhive_core/tests/causal.rs
@@ -154,6 +154,165 @@ async fn an_ancestor_that_is_not_held_is_reported_rather_than_failing() -> Resul
 /// is told there is nothing outstanding when what it needs is exactly that list and the
 /// keys in it.
 #[tokio::test]
+async fn a_walk_from_two_heads_reads_their_shared_ancestor_once() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all_unsent().await?;
+
+    // One root, two heads over it, and a third head on no path from either.
+    let root = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"root")
+        .await?;
+    let left_head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&root], b"left head")
+        .await?;
+    let right_head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&root], b"right head")
+        .await?;
+    let unrelated = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"unrelated")
+        .await?;
+    ctx.sync_all_unsent().await?;
+
+    for held in [&root, &left_head, &right_head, &unrelated] {
+        ctx.deliver_content(&bob, held).await?;
+    }
+    let walked = ctx
+        .causal_decrypt_from(&bob, &[&left_head, &right_head])
+        .await?;
+
+    // Walking from entrypoints rather than from a document includes the entrypoints
+    // themselves. `causal_decrypt` reports only what it walked back to.
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"left head", b"right head", b"root"]),
+        "both heads and their shared ancestor, and not the unrelated head"
+    );
+    assert_eq!(
+        walked.recovered_count(),
+        3,
+        "the shared ancestor is read once, not once per head"
+    );
+    assert_eq!(walked.missing(), 0, "bob holds everything the walk reaches");
+
+    let key = walked
+        .key_for_recovered(&root)
+        .ok_or("the walk did not report the key it read the root under")?;
+    assert!(
+        ctx.decrypt_with_key(&root, &key).is_ok(),
+        "and that key is the one that opens it"
+    );
+    assert!(
+        walked.key_for_recovered(&unrelated).is_none(),
+        "no key is reported for content the walk never reached"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn content_that_is_not_an_ancestor_is_not_captured_in_the_walk() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all_unsent().await?;
+
+    let genesis = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"genesis")
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&genesis], b"head")
+        .await?;
+    // Held by bob, in the same document, and on no path from the head.
+    let unrelated = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"unrelated")
+        .await?;
+    ctx.sync_all_unsent().await?;
+
+    for held in [&head, &genesis, &unrelated] {
+        ctx.deliver_content(&bob, held).await?;
+    }
+    let walked = ctx.causal_decrypt(&bob, &head).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"genesis"]),
+        "the walk follows ancestry from the entrypoint rather than reading what is at hand"
+    );
+    assert_eq!(walked.missing(), 0, "nothing is outstanding");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_missing_ancestors_are_each_reported_with_their_own_key() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all_unsent().await?;
+
+    // Two roots, each under its own branch, and a head that joins them.
+    let first_root = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"first root")
+        .await?;
+    let second_root = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[], b"second root")
+        .await?;
+    let left = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&first_root], b"left")
+        .await?;
+    let right = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&second_root], b"right")
+        .await?;
+    let head = ctx
+        .encrypt_in_envelope(&alice, &design_doc, &[&left, &right], b"head")
+        .await?;
+    ctx.sync_all_unsent().await?;
+
+    // Everything except the two roots.
+    for held in [&head, &left, &right] {
+        ctx.deliver_content(&bob, held).await?;
+    }
+    let walked = ctx.causal_decrypt(&bob, &head).await?;
+
+    assert_eq!(
+        walked.recovered(),
+        contents(&[b"left", b"right"]),
+        "both branches are walked, not just the first"
+    );
+    assert_eq!(
+        walked.missing(),
+        2,
+        "one root outstanding per branch, reported separately"
+    );
+
+    let first_key = walked
+        .key_for_missing(&first_root)
+        .ok_or("the walk did not report the first root")?;
+    let second_key = walked
+        .key_for_missing(&second_root)
+        .ok_or("the walk did not report the second root")?;
+    assert_ne!(
+        first_key, second_key,
+        "each outstanding root has its own key, not one key reported twice"
+    );
+    assert!(ctx.decrypt_with_key(&first_root, &first_key).is_ok());
+    assert!(
+        ctx.decrypt_with_key(&second_root, &second_key).is_ok(),
+        "and each key opens the content it was reported for"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 #[ignore = "an ancestor the entrypoint lists is dropped from the report when it is missing. Fix this"]
 async fn an_ancestor_the_entrypoint_lists_is_reported_when_missing() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/certificates.rs
+++ b/keyhive_core/tests/certificates.rs
@@ -36,7 +36,7 @@ async fn certificates_differing_in_any_field_are_distinct() -> Result<()> {
     let all = [&to_bob, &to_carol, &other_doc, &other_level];
     for (i, a) in all.iter().enumerate() {
         for b in &all[i + 1..] {
-            assert_ne!(a, b, "two grants collided: {a:?} and {b:?}");
+            assert_ne!(a, b, "two delegations collided: {a:?} and {b:?}");
         }
     }
     Ok(())

--- a/keyhive_core/tests/certificates.rs
+++ b/keyhive_core/tests/certificates.rs
@@ -1,0 +1,63 @@
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::{Admin, Edit, Read};
+
+#[tokio::test]
+async fn a_certificate_reports_what_it_conveys() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let cert = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+
+    assert_eq!(cert.issuer(), "alice");
+    assert_eq!(cert.audience(), "bob");
+    assert_eq!(cert.subject(), "design_doc");
+    assert_eq!(cert.can(), Read);
+    Ok(())
+}
+
+#[tokio::test]
+async fn certificates_differing_in_any_field_are_distinct() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let notes = ctx.doc(&alice, "notes").await?;
+
+    let to_bob = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let to_carol = ctx.delegate(&alice, &carol, &design_doc, Read).await?;
+    let other_doc = ctx.delegate(&alice, &bob, &notes, Read).await?;
+    let other_level = ctx.delegate(&alice, &carol, &notes, Admin).await?;
+
+    let all = [&to_bob, &to_carol, &other_doc, &other_level];
+    for (i, a) in all.iter().enumerate() {
+        for b in &all[i + 1..] {
+            assert_ne!(a, b, "two grants collided: {a:?} and {b:?}");
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_certificate_keeps_its_identity_as_the_graph_grows() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let to_bob = ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+    let before = to_bob.clone();
+
+    ctx.delegate(&alice, &carol, &design_doc, Read).await?;
+    ctx.encrypt(&alice, &design_doc, b"some content").await?;
+    ctx.revoke(&alice, &carol, &design_doc).await?;
+
+    assert_eq!(to_bob, before);
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Edit));
+    Ok(())
+}

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -1,0 +1,38 @@
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::Read;
+
+#[tokio::test]
+async fn a_member_added_before_a_write_can_derive_its_key() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"hello world").await?;
+    ctx.sync_all().await?;
+
+    assert!(ctx.can_decrypt(&bob, &ct).await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let ct = ctx.encrypt(&alice, &design_doc, b"before bob").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.can_decrypt(&alice, &ct).await?,
+        "the author can still read"
+    );
+    assert!(!ctx.can_decrypt(&bob, &ct).await?, "bob should not be able to derive the key");
+    Ok(())
+}

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -14,7 +14,7 @@ async fn a_member_added_before_a_write_can_derive_its_key() -> Result<()> {
     let ct = ctx.encrypt(&alice, &design_doc, b"hello world").await?;
     ctx.sync_all_unsent().await?;
 
-    assert!(ctx.can_decrypt(&bob, &ct).await?);
+    assert_eq!(ctx.read(&bob, &ct).await?, b"hello world".to_vec());
     Ok(())
 }
 
@@ -29,14 +29,15 @@ async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     ctx.sync_all_unsent().await?;
 
-    assert!(
-        ctx.can_decrypt(&alice, &ct).await?,
+    assert_eq!(
+        ctx.read(&alice, &ct).await?,
+        b"before bob".to_vec(),
         "the author can still read"
     );
-    assert!(
-        !ctx.can_decrypt(&bob, &ct).await?,
-        "bob should not be able to derive the key"
-    );
+    match ctx.read(&bob, &ct).await {
+        Err(TestError::NoKey) => {}
+        other => panic!("bob should hold no key for a write from before he joined, got {other:?}"),
+    }
     Ok(())
 }
 
@@ -277,10 +278,12 @@ async fn a_ciphertext_is_refused_if_tampered_with() -> Result<()> {
         ctx.decrypt_with_key(&tampered, &key).is_err(),
         "the cipher is authenticated so one flipped bit causes an error"
     );
-    assert!(
-        !ctx.can_decrypt(&bob, &tampered).await?,
-        "a flipped bit means no one can decrypt it"
-    );
+    match ctx.read(&bob, &tampered).await {
+        Err(TestError::CiphertextRejected) => {}
+        other => {
+            panic!("a flipped bit should fail authentication, not lose the key, got {other:?}")
+        }
+    }
     Ok(())
 }
 

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -183,6 +183,23 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
 
 // This is a sanity check for the testing facade
 #[tokio::test]
+async fn two_things_cannot_share_a_name() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    ctx.doc(&alice, "design_doc").await?;
+
+    // The members maps are keyed by name. A collision would drop one of them silently.
+    for taken in ["alice", "design_doc", "public"] {
+        match ctx.group(&alice, taken).await {
+            Err(TestError::NameTaken { name }) => assert_eq!(name, taken),
+            other => panic!("{taken:?} is taken, got {other:?}"),
+        }
+    }
+    Ok(())
+}
+
+// This is a sanity check for the testing facade
+#[tokio::test]
 async fn a_predecessor_from_another_document_is_refused() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -172,7 +172,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
     Ok(())
 }
 
-// This is a sanity check for the testing facade
+// This is a sanity check for the testing facade.
 #[tokio::test]
 async fn two_things_cannot_share_a_name() -> Result<()> {
     let mut ctx = TestContext::new().await;
@@ -189,7 +189,7 @@ async fn two_things_cannot_share_a_name() -> Result<()> {
     Ok(())
 }
 
-// This is a sanity check for the testing facade
+// This is a sanity check for the testing facade.
 #[tokio::test]
 async fn a_predecessor_from_another_document_is_refused() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -95,6 +95,87 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn a_key_rotation_changes_the_key_the_same_content_goes_under() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    // The same bytes, so only the document's key material differs between the two writes.
+    let bytes = b"the same bytes twice";
+    let before = ctx.encrypt(&alice, &design_doc, bytes).await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let after = ctx.encrypt(&alice, &design_doc, bytes).await?;
+
+    assert_ne!(
+        ctx.derived_key(&alice, &before).await?,
+        ctx.derived_key(&alice, &after).await?,
+        "the rotation left the same content under the same key"
+    );
+    assert!(
+        ctx.can_decrypt(&alice, &before).await?,
+        "and alice can still read what she wrote before it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_key_rotation_does_not_lock_out_a_current_member() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let ct = ctx
+        .encrypt(&alice, &design_doc, b"after the rotation")
+        .await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "bob was a member across the rotation"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let history = ctx
+        .encrypt(&alice, &design_doc, b"written before bob")
+        .await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let successor = ctx
+        .encrypt_after(
+            &alice,
+            &design_doc,
+            &[history.clone()],
+            b"written after bob",
+        )
+        .await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.can_decrypt(&bob, &successor).await?,
+        "bob reads content written under the key he was given"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &history).await?,
+        "the presence of a predecessor does not provide access to its key"
+    );
+    Ok(())
+}
+
 // This is a sanity check for the testing facade
 #[tokio::test]
 async fn a_predecessor_from_another_document_is_refused() -> Result<()> {

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -51,7 +51,7 @@ async fn predecessors_take_part_in_deriving_the_key() -> Result<()> {
     let bytes = b"the same bytes twice";
     let root = ctx.encrypt(&alice, &design_doc, bytes).await?;
     let after_root = ctx
-        .encrypt_after(&alice, &design_doc, &[root.clone()], bytes)
+        .encrypt_after(&alice, &design_doc, std::slice::from_ref(&root), bytes)
         .await?;
 
     let root_key = ctx
@@ -80,7 +80,12 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
     let before_bob = ctx.encrypt(&alice, &design_doc, b"before bob").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let after_bob = ctx
-        .encrypt_after(&alice, &design_doc, &[before_bob.clone()], b"after bob")
+        .encrypt_after(
+            &alice,
+            &design_doc,
+            std::slice::from_ref(&before_bob),
+            b"after bob",
+        )
         .await?;
     ctx.sync_all().await?;
 
@@ -159,7 +164,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
         .encrypt_after(
             &alice,
             &design_doc,
-            &[history.clone()],
+            std::slice::from_ref(&history),
             b"written after bob",
         )
         .await?;

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -51,7 +51,7 @@ async fn predecessors_take_part_in_deriving_the_key() -> Result<()> {
     let bytes = b"the same bytes twice";
     let root = ctx.encrypt(&alice, &design_doc, bytes).await?;
     let after_root = ctx
-        .encrypt_after(&alice, &design_doc, std::slice::from_ref(&root), bytes)
+        .encrypt_after(&alice, &design_doc, &[&root], bytes)
         .await?;
 
     let root_key = ctx
@@ -80,12 +80,7 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
     let before_bob = ctx.encrypt(&alice, &design_doc, b"before bob").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let after_bob = ctx
-        .encrypt_after(
-            &alice,
-            &design_doc,
-            std::slice::from_ref(&before_bob),
-            b"after bob",
-        )
+        .encrypt_after(&alice, &design_doc, &[&before_bob], b"after bob")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -161,12 +156,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
     ctx.sync_all_unsent().await?;
     ctx.force_pcs_update(&alice, &design_doc).await?;
     let successor = ctx
-        .encrypt_after(
-            &alice,
-            &design_doc,
-            std::slice::from_ref(&history),
-            b"written after bob",
-        )
+        .encrypt_after(&alice, &design_doc, &[&history], b"written after bob")
         .await?;
     ctx.sync_all_unsent().await?;
 
@@ -209,7 +199,7 @@ async fn a_predecessor_from_another_document_is_refused() -> Result<()> {
     let in_design_doc = ctx.encrypt(&alice, &design_doc, b"a paragraph").await?;
 
     match ctx
-        .encrypt_after(&alice, &notes, &[in_design_doc], b"a note")
+        .encrypt_after(&alice, &notes, &[&in_design_doc], b"a note")
         .await
     {
         Err(TestError::WrongDocument { holds, doc }) => {

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -95,7 +95,7 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
     );
     assert!(
         !ctx.can_decrypt(&bob, &before_bob).await?,
-        "a successor naming earlier content does not hand over the earlier key"
+        "a successor naming earlier content does not let bob derive the earlier key"
     );
     Ok(())
 }
@@ -176,7 +176,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
     );
     assert!(
         !ctx.can_decrypt(&bob, &history).await?,
-        "the presence of a predecessor does not provide access to its key"
+        "the presence of a predecessor does not let bob derive its key"
     );
     Ok(())
 }

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -41,6 +41,80 @@ async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
 }
 
 #[tokio::test]
+async fn predecessors_take_part_in_deriving_the_key() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    // The same bytes, so the content hash is the same both times and only the position in
+    // the content DAG differs.
+    let bytes = b"the same bytes twice";
+    let root = ctx.encrypt(&alice, &design_doc, bytes).await?;
+    let after_root = ctx
+        .encrypt_after(&alice, &design_doc, &[root.clone()], bytes)
+        .await?;
+
+    let root_key = ctx
+        .derived_key(&alice, &root)
+        .await?
+        .ok_or("alice wrote the root and cannot derive its key")?;
+    let after_root_key = ctx
+        .derived_key(&alice, &after_root)
+        .await?
+        .ok_or("alice wrote the successor and cannot derive its key")?;
+
+    assert_ne!(
+        root_key, after_root_key,
+        "identical bytes at different points in the DAG went under one key"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let before_bob = ctx.encrypt(&alice, &design_doc, b"before bob").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let after_bob = ctx
+        .encrypt_after(&alice, &design_doc, &[before_bob.clone()], b"after bob")
+        .await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.can_decrypt(&bob, &after_bob).await?,
+        "bob was a member when this was written"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &before_bob).await?,
+        "a successor naming earlier content does not hand over the earlier key"
+    );
+    Ok(())
+}
+
+// This is a sanity check for the testing facade
+#[tokio::test]
+async fn a_predecessor_from_another_document_is_refused() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let notes = ctx.doc(&alice, "notes").await?;
+
+    let in_design_doc = ctx.encrypt(&alice, &design_doc, b"a paragraph").await?;
+
+    assert!(
+        ctx.encrypt_after(&alice, &notes, &[in_design_doc], b"a note")
+            .await
+            .is_err(),
+        "content in one document cannot precede content in another"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn the_reader_derives_the_key_the_writer_used() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -1,7 +1,7 @@
 mod facade;
 
 use facade::{Result, TestContext};
-use keyhive_core::access::Access::Read;
+use keyhive_core::access::Access::{Edit, Read};
 
 #[tokio::test]
 async fn a_member_added_before_a_write_can_derive_its_key() -> Result<()> {
@@ -34,5 +34,95 @@ async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
         "the author can still read"
     );
     assert!(!ctx.can_decrypt(&bob, &ct).await?, "bob should not be able to derive the key");
+    Ok(())
+}
+
+#[tokio::test]
+async fn the_reader_derives_the_key_the_writer_used() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let (ct, written_under) = ctx.encrypt_keyed(&alice, &design_doc, b"hello").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(
+        ctx.derived_key(&bob, &ct).await?,
+        Some(written_under),
+        "bob derived a different application secret"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_non_member_derives_no_key() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let mallory = ctx.individual("mallory").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let (ct, _) = ctx.encrypt_keyed(&alice, &design_doc, b"secret").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(ctx.derived_key(&mallory, &ct).await?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn the_wrong_key_does_not_decrypt() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    let (first, first_key) = ctx.encrypt_keyed(&alice, &design_doc, b"one").await?;
+    let (second, second_key) = ctx.encrypt_keyed(&alice, &design_doc, b"two").await?;
+    assert_ne!(first_key, second_key, "two writes reused one key");
+
+    assert_eq!(ctx.decrypt_with_key(&first, &first_key)?, b"one".to_vec());
+    assert_eq!(ctx.decrypt_with_key(&second, &second_key)?, b"two".to_vec());
+    assert!(ctx.decrypt_with_key(&first, &second_key).is_err());
+    assert!(ctx.decrypt_with_key(&second, &first_key).is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_ciphertext_is_refused_if_tampered_with() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let (ct, key) = ctx.encrypt_keyed(&alice, &design_doc, b"authentic").await?;
+    ctx.sync_all().await?;
+
+    let tampered = ct.with_a_flipped_bit();
+    assert!(
+        ctx.decrypt_with_key(&tampered, &key).is_err(),
+        "the cipher is authenticated so one flipped bit causes an error"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &tampered).await?,
+        "a flipped bit means no one can decrypt it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_reader_can_read_what_an_editor_wrote() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+    let msg = b"Design Doc";
+    let (ct, key) = ctx.encrypt_keyed(&alice, &design_doc, msg).await?;
+    ctx.sync_all().await?;
+
+    assert!(ctx.can_decrypt(&bob, &ct).await?);
+    assert_eq!(ctx.decrypt_with_key(&ct, &key)?, msg.to_vec());
     Ok(())
 }

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -1,6 +1,6 @@
 mod facade;
 
-use facade::{Result, TestContext};
+use facade::{Result, TestContext, TestError};
 use keyhive_core::access::Access::{Edit, Read};
 
 #[tokio::test]
@@ -191,12 +191,16 @@ async fn a_predecessor_from_another_document_is_refused() -> Result<()> {
 
     let in_design_doc = ctx.encrypt(&alice, &design_doc, b"a paragraph").await?;
 
-    assert!(
-        ctx.encrypt_after(&alice, &notes, &[in_design_doc], b"a note")
-            .await
-            .is_err(),
-        "content in one document cannot precede content in another"
-    );
+    match ctx
+        .encrypt_after(&alice, &notes, &[in_design_doc], b"a note")
+        .await
+    {
+        Err(TestError::WrongDocument { holds, doc }) => {
+            assert_eq!(holds, "design_doc");
+            assert_eq!(doc, "notes");
+        }
+        other => panic!("content in one document cannot precede content in another, got {other:?}"),
+    }
     Ok(())
 }
 

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -33,7 +33,10 @@ async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
         ctx.can_decrypt(&alice, &ct).await?,
         "the author can still read"
     );
-    assert!(!ctx.can_decrypt(&bob, &ct).await?, "bob should not be able to derive the key");
+    assert!(
+        !ctx.can_decrypt(&bob, &ct).await?,
+        "bob should not be able to derive the key"
+    );
     Ok(())
 }
 

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -95,7 +95,7 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
     );
     assert!(
         !ctx.can_decrypt(&bob, &before_bob).await?,
-        "a successor naming earlier content does not let bob derive the earlier key"
+        "a successor with an earlier predecessor does not let bob derive the earlier key"
     );
     Ok(())
 }

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -12,7 +12,7 @@ async fn a_member_added_before_a_write_can_derive_its_key() -> Result<()> {
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let ct = ctx.encrypt(&alice, &design_doc, b"hello world").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(ctx.can_decrypt(&bob, &ct).await?);
     Ok(())
@@ -27,7 +27,7 @@ async fn a_member_added_after_a_write_cannot_derive_its_key() -> Result<()> {
 
     let ct = ctx.encrypt(&alice, &design_doc, b"before bob").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         ctx.can_decrypt(&alice, &ct).await?,
@@ -87,7 +87,7 @@ async fn a_predecessor_does_not_make_its_earlier_key_derivable() -> Result<()> {
             b"after bob",
         )
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         ctx.can_decrypt(&bob, &after_bob).await?,
@@ -132,13 +132,13 @@ async fn a_key_rotation_does_not_lock_out_a_current_member() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     ctx.force_pcs_update(&alice, &design_doc).await?;
     let ct = ctx
         .encrypt(&alice, &design_doc, b"after the rotation")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         ctx.can_decrypt(&bob, &ct).await?,
@@ -158,7 +158,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
         .encrypt(&alice, &design_doc, b"written before bob")
         .await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     ctx.force_pcs_update(&alice, &design_doc).await?;
     let successor = ctx
         .encrypt_after(
@@ -168,7 +168,7 @@ async fn content_written_after_a_rotation_does_not_open_what_came_before() -> Re
             b"written after bob",
         )
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         ctx.can_decrypt(&bob, &successor).await?,
@@ -209,7 +209,7 @@ async fn the_reader_derives_the_key_the_writer_used() -> Result<()> {
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let (ct, written_under) = ctx.encrypt_keyed(&alice, &design_doc, b"hello").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         ctx.derived_key(&bob, &ct).await?,
@@ -227,7 +227,7 @@ async fn a_non_member_derives_no_key() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
     let (ct, _) = ctx.encrypt_keyed(&alice, &design_doc, b"secret").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(ctx.derived_key(&mallory, &ct).await?, None);
     Ok(())
@@ -259,7 +259,7 @@ async fn a_ciphertext_is_refused_if_tampered_with() -> Result<()> {
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let (ct, key) = ctx.encrypt_keyed(&alice, &design_doc, b"authentic").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let tampered = ct.with_a_flipped_bit();
     assert!(
@@ -283,7 +283,7 @@ async fn a_reader_can_read_what_an_editor_wrote() -> Result<()> {
     ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
     let msg = b"Design Doc";
     let (ct, key) = ctx.encrypt_keyed(&alice, &design_doc, msg).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(ctx.can_decrypt(&bob, &ct).await?);
     assert_eq!(ctx.decrypt_with_key(&ct, &key)?, msg.to_vec());

--- a/keyhive_core/tests/delegations.rs
+++ b/keyhive_core/tests/delegations.rs
@@ -3,24 +3,25 @@ mod facade;
 use facade::{Result, TestContext};
 use keyhive_core::access::Access::{Admin, Edit, Read};
 
+// Facade sanity check
 #[tokio::test]
-async fn a_certificate_reports_what_it_conveys() -> Result<()> {
+async fn a_delegation_reports_what_it_conveys() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
-    let cert = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let dlg = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
 
-    assert_eq!(cert.issuer(), "alice");
-    assert_eq!(cert.audience(), "bob");
-    assert_eq!(cert.subject(), "design_doc");
-    assert_eq!(cert.can(), Read);
+    assert_eq!(dlg.issuer(), "alice");
+    assert_eq!(dlg.audience(), "bob");
+    assert_eq!(dlg.subject(), "design_doc");
+    assert_eq!(dlg.can(), Read);
     Ok(())
 }
 
 #[tokio::test]
-async fn certificates_differing_in_any_field_are_distinct() -> Result<()> {
+async fn delegations_differing_in_any_field_are_distinct() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -39,11 +40,22 @@ async fn certificates_differing_in_any_field_are_distinct() -> Result<()> {
             assert_ne!(a, b, "two delegations collided: {a:?} and {b:?}");
         }
     }
+
+    let for_design_doc = ctx.delegations_for(&alice, &design_doc).await?;
+    let for_notes = ctx.delegations_for(&alice, &notes).await?;
+    for (dlg, sub) in [
+        (&to_bob, &for_design_doc),
+        (&to_carol, &for_design_doc),
+        (&other_doc, &for_notes),
+        (&other_level, &for_notes),
+    ] {
+        assert!(sub.contains(dlg), "{dlg:?} is not in {sub:?}");
+    }
     Ok(())
 }
 
 #[tokio::test]
-async fn a_certificate_keeps_its_identity_as_the_graph_grows() -> Result<()> {
+async fn a_delegation_keeps_its_identity_as_the_graph_grows() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -51,13 +63,16 @@ async fn a_certificate_keeps_its_identity_as_the_graph_grows() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
     let to_bob = ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
-    let before = to_bob.clone();
 
     ctx.delegate(&alice, &carol, &design_doc, Read).await?;
     ctx.encrypt(&alice, &design_doc, b"some content").await?;
     ctx.revoke(&alice, &carol, &design_doc).await?;
 
-    assert_eq!(to_bob, before);
+    let for_design_doc = ctx.delegations_for(&alice, &design_doc).await?;
+    assert!(
+        for_design_doc.contains(&to_bob),
+        "bob's delegation should be unchanged: {to_bob:?} is not in {for_design_doc:?}"
+    );
     assert_eq!(ctx.effective_access(&bob, &design_doc).await?, Some(Edit));
     Ok(())
 }

--- a/keyhive_core/tests/delegations.rs
+++ b/keyhive_core/tests/delegations.rs
@@ -3,7 +3,7 @@ mod facade;
 use facade::{Result, TestContext};
 use keyhive_core::access::Access::{Admin, Edit, Read};
 
-// Facade sanity check
+// This is a sanity check for the testing facade.
 #[tokio::test]
 async fn a_delegation_reports_what_it_conveys() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -19,6 +19,8 @@ Once you have a context, you can use it to create entities:
 * `ctx.individual(name) -> TestIndividual`: Creates a keyhive identity.
 * `ctx.group(creator: &TestIndividual, name) -> TestGroup`
 * `ctx.doc(creator: &TestIndividual, name) -> TestDocument`
+* `ctx.public() -> TestPublic`: The public agent.
+* `ctx.second_instance(of: &TestIndividual, name) -> TestIndividual`: Another `Keyhive` instance for an existing identity with the same signing key.
 
 These test objects have a `name()` method for use in assertion messages.
 
@@ -26,26 +28,56 @@ You can then delegate and revoke access:
 
 * `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered, level)`:  `issuer` delegates `level` over `resource` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
 * `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`.
+* `ctx.delegations_for(observer: &TestIndividual, resource: &impl TestMembered) -> Vec<TestDelegation>`: Every delegation `observer` holds for `resource`.
 
-You can also create content and sync state between keyhive identities:
+You can also create content:
 
 * `ctx.encrypt(who: &TestIndividual, doc: &TestDocument, bytes) -> TestEncryptedContent`. A `TestEncryptedContent` can be passed to `can_decrypt` to check if an individual can decrypt it.
+* `ctx.encrypt_keyed(who, doc, bytes) -> (TestEncryptedContent, TestSymmetricKey)`: Also returns the application secret the content was encrypted with.
+* `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
+* `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
+* `content.with_a_flipped_bit() -> TestEncryptedContent`: The same content with one bit of the ciphertext changed.
+
+And sync state between keyhive identities:
+
 * `ctx.sync(from: &TestIndividual, to: &TestIndividual) -> usize`: Sends `from`'s events to `to`. The return value is how many events `to` could not yet apply.
 * `ctx.sync_all()`: Sends events between every pair of individuals.
+* `ctx.sync_without(from, to, kind: TestEventKind) -> usize`: Sends everything except one kind of event. For example, exclude sending CGKA ops.
+* `ctx.sync_in_batches(from, to, batch: usize) -> usize`: Sends everything `batch` events at a time, ingesting each batch before sending the next.
+* `ctx.sync_shuffled(from, to, seed: u64) -> usize`: Sends everything in an order decided by `seed`, so a failing order can be replayed.
+* `ctx.static_events_for(from, to) -> Vec<TestStaticEvent>`: What `from` would send `to`, without sending it.
+* `ctx.pending_events(who: &TestIndividual) -> usize`: How many events `who` holds but can't yet apply.
+* `ctx.share_prekey_secrets(from: &TestIndividual, to: &TestIndividual) -> usize`: Gives one `Keyhive` instance's prekey secrets to another instance of the same identity. Returns how many held events `to` could apply after receiving the prekeys.
 
 Then you can check properties:
+
 * `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access. |
 * `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
 * `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
 * `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
+* `ctx.best_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: The higher of `who`'s own access and public's access.
+* `ctx.has_received(who: &TestIndividual, what: &impl TestAgent) -> bool`: Whether `who` has received the events needed to learn that `what` exists. `effective_access()` returns `None` both for no access and for never having heard of the subject. This can be used to distinguish those cases.
 
-Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They need to be checked independently since they can come apart if there's a bug (this has happened before).
+Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They need to be checked independently since they can come apart if there's a bug. This has happened before.
 
 You need to call `sync_all()` before:
 
-* checking `can_decrypt` for anyone other than the person who called `encrypt`,
+* checking `can_decrypt` for anyone other than the identity who called `encrypt`,
 * checking `effective_access_seen_by` about an identity other than the resource owner,
-* having an individual issue a delegation over a resource they did not create, because they need to know that resource exists first.
+* having an individual issue a delegation for a resource they did not create. They need to know that resource exists first.
+
+Prekeys have their own methods:
+
+* `ctx.expand_prekeys(who: &TestIndividual) -> TestShareKey`: Adds a prekey and returns the key added.
+* `ctx.rotate_prekey(who: &TestIndividual, old: &TestShareKey) -> TestShareKey`: Replaces `old` with a fresh key and returns the replacement.
+* `ctx.prekeys(observer: &TestIndividual, of: &TestIndividual) -> BTreeSet<TestShareKey>`: The prekeys `observer` holds for `of`.
+* `ctx.prekey_ops(observer: &TestIndividual, of: &TestIndividual) -> Vec<TestPrekeyOp>`: The operations behind that set. Each is `Added` or `Rotated` and reports `new_key()`.
+
+So does archiving:
+
+* `ctx.archive(who: &TestIndividual) -> TestArchive`: Serializes an instance.
+* `ctx.rebuild_from_archive(archive: &TestArchive, name) -> TestIndividual`: Rebuilds an archive as a new instance of the same identity with a fresh ciphertext store.
+* `ctx.ingest_archive(into: &TestIndividual, archive: &TestArchive) -> usize`: Merges an archive into a live instance. Returns how many events remain pending.
 
 If you forget to do this, the test will probably fail with `TestError::NotSynced { individual, subject }`.
 
@@ -57,6 +89,8 @@ Every method returns `Result<T, TestError>`, with variants representing reasons 
 * `TestError::NoAuthority`: The issuer has no access to the resource.
 * `TestError::NotSynced { individual: String, subject: String }`: The individual has not yet received the required events.
 * `TestError::Other(String)`: Anything else, wrapping the underlying error as a `String`.
+
+`NotSynced` also covers the case where the individual has no access to the subject and was therefore never sent it, because the facade has to find the resource in their `Keyhive` before it can ask about authority. An individual who was never a member gets `NotSynced` rather than `NoAuthority`.
 
 Use these variants to check specific properties. For example:
 
@@ -77,24 +111,32 @@ Here is an example of a declarative test that involves only the minimal number o
 ```rust
 mod facade;
 use facade::{Result, TestContext};
-use keyhive_core::access::Access::{Edit, Read};
+use keyhive_core::access::Access::Read;
 
 #[tokio::test]
-async fn a_relay_cannot_decrypt() -> Result<()> {
+async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
-    let server = ctx.individual("server").await?;
+    let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
-    let relays = ctx.group(&alice, "relays").await?;
 
-    ctx.delegate(&alice, &relays, &design_doc, Relay).await?;
-    ctx.delegate(&alice, &server, &relays, Admin).await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let before = ctx.encrypt(&alice, &design_doc, b"first").await?;
+    ctx.sync_all().await?;
+    assert!(
+        ctx.can_decrypt(&bob, &before).await?,
+        "bob could read before"
+    );
 
-    let ct = ctx.encrypt(&alice, &design_doc, b"secret").await?;
+    ctx.revoke(&alice, &bob, &design_doc).await?;
+    let after = ctx.encrypt(&alice, &design_doc, b"second").await?;
     ctx.sync_all().await?;
 
-    assert_eq!(ctx.effective_access(&server, &design_doc).await?, Some(Relay));
-    assert!(!ctx.can_decrypt(&server, &ct).await?, "a relay may not decrypt");
+    assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
+    assert!(
+        !ctx.can_decrypt(&bob, &after).await?,
+        "cannot read new content"
+    );
     Ok(())
 }
 ```
@@ -112,8 +154,9 @@ async fn a_relay_cannot_decrypt() -> Result<()> {
 New methods should be phrased as actions or questions about entities. They must not return
 internal types (e.g., return `TestIndividual` instead of `Individual`). They should abstract away irrelevant lower-level details. And they may correspond to multiple actions at the lower level.
 
+One exception is if the `keyhive` type is a simple `enum` without type parameters or methods, such as `Access`.
+
 If you need a new entity, then prefix its name with `Test` and add a creation method to `TestContext`. Don't add methods to that entity for use in tests except for `name()`. Prefer passing the handle into `TestContext` methods so it can manage related lower-level plumbing and state.
 
 If a method can be refused for more than one reason, add a `TestError` variant rather than
 letting it fall into `Other`. Tests should be able to check why an operation failed.
-

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -36,7 +36,7 @@ You can also create content:
 
 * `ctx.encrypt(who: &TestIndividual, doc: &TestDocument, bytes) -> TestEncryptedContent`. A `TestEncryptedContent` can be passed to `can_decrypt` to check if an individual can decrypt it.
 * `ctx.encrypt_keyed(who, doc, bytes) -> (TestEncryptedContent, TestSymmetricKey)`: Also returns the application secret the content was encrypted with.
-* `ctx.encrypt_after(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content that follows `after` in the document's content DAG.
+* `ctx.encrypt_after(who, doc, after: &[&TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content that follows `after` in the document's content DAG.
 * `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
 * `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -37,6 +37,7 @@ You can also create content:
 * `ctx.encrypt_after(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content that follows `after` in the document's content DAG.
 * `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
 * `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
+* `ctx.force_pcs_update(who: &TestIndividual, doc: &TestDocument) -> TestShareKey`: Forces a PCS key update for the document. Returns the share key the rotation introduced.
 * `content.with_a_flipped_bit() -> TestEncryptedContent`: The same content with one bit of the ciphertext changed.
 
 And sync state between keyhive identities:

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -16,7 +16,7 @@ You start a test by creating a `TestContext` via `TestContext::new()`. The conte
 
 Once you have a context, you can use it to create entities:
 
-* `ctx.individual(name) -> TestIndividual`: Creates a keyhive identity.
+* `ctx.individual(name) -> TestIndividual`: Creates a keyhive identity and exchanges contact cards with every other individual.
 * `ctx.group(creator: &TestIndividual, name) -> TestGroup`
 * `ctx.doc(creator: &TestIndividual, name) -> TestDocument`
 * `ctx.public() -> TestPublic`: The public agent.
@@ -26,11 +26,11 @@ These test objects have a `name()` method for use in assertion messages.
 
 You can then delegate and revoke access:
 
-* `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered, level)`:  `issuer` delegates `level` over `resource` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
-* `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`. Members that `audience` had admitted keep their access, because their delegations are re-issued.
-* `ctx.revoke_cascading(issuer, audience, resource)`: Like `revoke`, but without keeping the members `audience` admitted.
-* `ctx.revoked_members_of(resource: &impl TestMembered) -> BTreeMap<String, Access>`: Everyone whose membership was revoked and not replaced, with the access their revoked delegation had conveyed. Someone revoked and then delegated again is excluded from this result.
-* `ctx.delegations_for(observer: &TestIndividual, resource: &impl TestMembered) -> Vec<TestDelegation>`: Every delegation `observer` holds for `resource`.
+* `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, membered: &impl TestMembered, level)`:  `issuer` delegates `level` over `membered` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
+* `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, membered: &impl TestMembered)`: `issuer` removes `audience`'s membership in `membered`. Members that `audience` had admitted keep their access, because their delegations are re-issued.
+* `ctx.revoke_cascading(issuer, audience, membered)`: Like `revoke`, but without keeping the members `audience` admitted.
+* `ctx.revoked_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Everyone whose membership was revoked and not replaced, with the access their revoked delegation had conveyed. Someone revoked and then delegated again is excluded from this result.
+* `ctx.delegations_for(observer: &TestIndividual, membered: &impl TestMembered) -> Vec<TestDelegation>`: Every delegation `observer` holds for `membered`.
 
 You can also create content:
 
@@ -40,9 +40,10 @@ You can also create content:
 * `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
 * `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
 
-* `ctx.encrypt_in_envelope(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content with an envelope listing the ancestors and carrying the keys to open them. This simulates the application layer.
+* `ctx.encrypt_in_envelope(who, doc, after: &[&TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content with an envelope listing the ancestors and carrying the keys to open them. This simulates the application layer.
 * `ctx.deliver_content(to: &TestIndividual, content: &TestEncryptedContent)`: Gives `to` a copy of the content. Sync sends CGKA and membership ops, not content.
 * `ctx.causal_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> TestCausalDecryption`: Walks back from `content` through the ancestors it lists. Returns what it `recovered()` and how many ancestors are `missing()`.
+* `ctx.causal_decrypt_from(who: &TestIndividual, entrypoints: &[&TestEncryptedContent]) -> TestCausalDecryption`: Walks back from more than one head at once. The recovered set includes the entrypoints themselves, unlike `causal_decrypt`.
 * `ctx.force_pcs_update(who: &TestIndividual, doc: &TestDocument) -> TestShareKey`: Forces a PCS key update for the document. Returns the share key the rotation introduced.
 * `content.with_a_flipped_bit() -> TestEncryptedContent`: The same content with one bit of the ciphertext changed.
 
@@ -53,16 +54,18 @@ And sync state between keyhive identities:
 * `ctx.sync_as_public(from, to) -> usize`: Sends `to` everything the public agent may see.
 * `ctx.sync_without(from, to, kind: TestEventKind) -> usize`: Sends everything except one kind of event. For example, exclude sending CGKA ops.
 * `ctx.sync_in_batches(from, to, batch: usize) -> usize`: Sends everything `batch` events at a time, ingesting each batch before sending the next.
-* `ctx.sync_shuffled(from, to, seed: u64) -> usize`: Sends everything in an order decided by `seed` so a failing order can be replayed.
+* `ctx.sync_shuffled(from, to, seed: u64) -> usize`: Sends everything in an order decided by `seed`. The same seed permutes the same set of events the same way, but it does not reproduce an order across runs, because a context seeds itself freshly each time.
 * `ctx.static_events_for(from, to) -> Vec<TestStaticEvent>`: Returns what `from` would send `to`, without sending it.
 * `ctx.pending_events(who: &TestIndividual) -> usize`: How many events `who` holds but can't yet apply.
+* `ctx.pending_events_of_kind(who: &TestIndividual, kind: TestEventKind) -> usize`: Like `pending_events`, but for one kind of event.
+* `ctx.events_last_delivered() -> usize`: How many events the last delivery carried. `sync_in_batches` and `sync_all_unsent` deliver more than once, so after those this is the final batch or the final pair's delta rather than the call's total.
 * `ctx.share_prekey_secrets(from: &TestIndividual, to: &TestIndividual) -> usize`: Gives one `Keyhive` instance's prekey secrets to another instance of the same identity. Returns how many held events `to` could apply after receiving the prekeys.
 
 Then you can check properties:
 
 * `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access.
 * `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
-* `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
+* `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `membered`, including through nested groups.
 * `ctx.documents_reachable_by(observer: &TestIndividual, who: &impl TestAgent) -> BTreeMap<String, Access>`: The documents `who` reaches, as `observer` sees it. A document delegated to Public is not included unless it's passed as `who`.
 * `ctx.memberships_reachable_by(observer: &TestIndividual, who: &impl TestAgent) -> BTreeMap<String, Access>`: Like `documents_reachable_by`, but also includes groups.
 * `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
@@ -70,7 +73,7 @@ Then you can check properties:
 * `ctx.best_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: The higher of `who`'s own access and public's access.
 * `ctx.has_received(who: &TestIndividual, what: &impl TestAgent) -> bool`: Whether `who` has received the events needed to learn that `what` exists. `effective_access()` returns `None` both for no access and for never having heard of the subject. This can be used to distinguish those cases.
 
-Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They need to be checked independently since they can come apart if there's a bug. This has happened before.
+Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They can come apart when there is a bug, so check them independently.
 
 You need to call `sync_all_unsent()` before:
 
@@ -96,7 +99,7 @@ So does archiving:
 
 ### Test errors for checking properties
 
-Every method returns `Result<T, TestError>`, with variants representing reasons an operation would be refused:
+Most methods return `Result<T, TestError>`, with variants representing reasons an operation would be refused:
 
 * `TestError::Escalation { wanted: Access, held: Access }`: The issuer holds some access over the resource, but less than they tried to delegate.
 * `TestError::NoAuthority`: The issuer has no access to the resource.
@@ -124,7 +127,7 @@ match ctx.delegate(&bob, &carol, &design_doc, Admin).await {
 
 ## 3. An example test
 
-Here is an example of a declarative test that involves only the minimal number of higher level steps to check that a rule is satisfied:
+For example:
 
 ```rust
 mod facade;
@@ -161,11 +164,11 @@ async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
 
 ### Guidelines
 
-**Focus on the high-level rules, behaviors, and properties we expect keyhive to respect.** For checking lower-level details, write unit tests in those modules.
+Focus on the high-level rules, behaviors, and properties we expect keyhive to respect. For checking lower-level details, write unit tests in those modules.
 
-**Check one rule per test.** If a test could fail for two unrelated reasons, split it.
+Check one rule per test. If a test could fail for two unrelated reasons, split it.
 
-**Name a test after the rule it's checking.** `a_reader_cannot_delegate_edit_or_above` rather than `test_add_member_3`.
+Name a test after the rule it's checking. `a_reader_cannot_delegate_edit_or_above` rather than `test_add_member_3`.
 
 ## 4. Adding methods and entities to the facade
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -98,6 +98,7 @@ Every method returns `Result<T, TestError>`, with variants representing reasons 
 * `TestError::Escalation { wanted: Access, held: Access }`: The issuer holds some access over the resource, but less than they tried to delegate.
 * `TestError::NoAuthority`: The issuer has no access to the resource.
 * `TestError::NotSynced { individual: String, subject: String }`: The individual has not yet received the required events.
+* `TestError::NameTaken { name }`: Two things in one context cannot share a name since the member maps are keyed by name.
 * `TestError::WrongDocument { holds, doc }`: A predecessor was named that belongs to a different document.
 * `TestError::DifferentIdentity { from, to }`: Prekey secrets belong to one identity and cannot be given to another.
 * `TestError::Other(String)`: Anything else, wrapping the underlying error as a `String`.

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -63,6 +63,7 @@ Then you can check properties:
 * `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
 * `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
 * `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
+* `ctx.read(who: &TestIndividual, content: &TestEncryptedContent) -> Vec<u8>`: What `who` reads back, or an error if they can't. Use this where the point is that the content survived the round trip, and `can_decrypt` where the point is who may read.
 * `ctx.best_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: The higher of `who`'s own access and public's access.
 * `ctx.has_received(who: &TestIndividual, what: &impl TestAgent) -> bool`: Whether `who` has received the events needed to learn that `what` exists. `effective_access()` returns `None` both for no access and for never having heard of the subject. This can be used to distinguish those cases.
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -27,7 +27,8 @@ These test objects have a `name()` method for use in assertion messages.
 You can then delegate and revoke access:
 
 * `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered, level)`:  `issuer` delegates `level` over `resource` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
-* `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`.
+* `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`. Members that `audience` had admitted keep their access, because their delegations are re-issued.
+* `ctx.revoke_cascading(issuer, audience, resource)`: Like `revoke`, but without keeping the members `audience` admitted.
 * `ctx.delegations_for(observer: &TestIndividual, resource: &impl TestMembered) -> Vec<TestDelegation>`: Every delegation `observer` holds for `resource`.
 
 You can also create content:

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -29,6 +29,7 @@ You can then delegate and revoke access:
 * `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered, level)`:  `issuer` delegates `level` over `resource` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
 * `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`. Members that `audience` had admitted keep their access, because their delegations are re-issued.
 * `ctx.revoke_cascading(issuer, audience, resource)`: Like `revoke`, but without keeping the members `audience` admitted.
+* `ctx.revoked_members_of(resource: &impl TestMembered) -> BTreeMap<String, Access>`: Everyone whose membership was revoked and not replaced, with the access their revoked delegation had conveyed. Someone revoked and then delegated again is excluded from this result.
 * `ctx.delegations_for(observer: &TestIndividual, resource: &impl TestMembered) -> Vec<TestDelegation>`: Every delegation `observer` holds for `resource`.
 
 You can also create content:

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -60,7 +60,7 @@ And sync state between keyhive identities:
 
 Then you can check properties:
 
-* `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access. |
+* `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access.
 * `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
 * `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
 * `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
@@ -76,6 +76,8 @@ You need to call `sync_all_unsent()` before:
 * checking `effective_access_seen_by` about an identity other than the resource owner,
 * having an individual issue a delegation for a resource they did not create. They need to know that resource exists first.
 
+If you forget, the test will probably fail with `TestError::NotSynced { individual, subject }`.
+
 Prekeys have their own methods:
 
 * `ctx.expand_prekeys(who: &TestIndividual) -> TestShareKey`: Adds a prekey and returns the key added.
@@ -89,7 +91,6 @@ So does archiving:
 * `ctx.rebuild_from_archive(archive: &TestArchive, name) -> TestIndividual`: Rebuilds an archive as a new instance of the same identity with a fresh ciphertext store.
 * `ctx.ingest_archive(into: &TestIndividual, archive: TestArchive) -> usize`: Merges an archive into a live instance. Returns how many events remain pending.
 
-If you forget to do this, the test will probably fail with `TestError::NotSynced { individual, subject }`.
 
 ### Test errors for checking properties
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -49,11 +49,12 @@ You can also create content:
 And sync state between keyhive identities:
 
 * `ctx.sync(from: &TestIndividual, to: &TestIndividual) -> usize`: Sends `from`'s events to `to`. The return value is how many events `to` could not yet apply.
-* `ctx.sync_all()`: Sends events between every pair of individuals.
+* `ctx.sync_all_unsent()`: Sends events between every pair of individuals, until a round changes nothing. This method skips events it has already sent over.
+* `ctx.sync_as_public(from, to) -> usize`: Sends `to` everything the public agent may see.
 * `ctx.sync_without(from, to, kind: TestEventKind) -> usize`: Sends everything except one kind of event. For example, exclude sending CGKA ops.
 * `ctx.sync_in_batches(from, to, batch: usize) -> usize`: Sends everything `batch` events at a time, ingesting each batch before sending the next.
-* `ctx.sync_shuffled(from, to, seed: u64) -> usize`: Sends everything in an order decided by `seed`, so a failing order can be replayed.
-* `ctx.static_events_for(from, to) -> Vec<TestStaticEvent>`: What `from` would send `to`, without sending it.
+* `ctx.sync_shuffled(from, to, seed: u64) -> usize`: Sends everything in an order decided by `seed` so a failing order can be replayed.
+* `ctx.static_events_for(from, to) -> Vec<TestStaticEvent>`: Returns what `from` would send `to`, without sending it.
 * `ctx.pending_events(who: &TestIndividual) -> usize`: How many events `who` holds but can't yet apply.
 * `ctx.share_prekey_secrets(from: &TestIndividual, to: &TestIndividual) -> usize`: Gives one `Keyhive` instance's prekey secrets to another instance of the same identity. Returns how many held events `to` could apply after receiving the prekeys.
 
@@ -69,7 +70,7 @@ Then you can check properties:
 
 Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They need to be checked independently since they can come apart if there's a bug. This has happened before.
 
-You need to call `sync_all()` before:
+You need to call `sync_all_unsent()` before:
 
 * checking `can_decrypt` for anyone other than the identity who called `encrypt`,
 * checking `effective_access_seen_by` about an identity other than the resource owner,
@@ -131,7 +132,7 @@ async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
 
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     let before = ctx.encrypt(&alice, &design_doc, b"first").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert!(
         ctx.can_decrypt(&bob, &before).await?,
         "bob could read before"
@@ -139,7 +140,7 @@ async fn a_revoked_member_cannot_read_new_content() -> Result<()> {
 
     ctx.revoke(&alice, &bob, &design_doc).await?;
     let after = ctx.encrypt(&alice, &design_doc, b"second").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(ctx.effective_access(&bob, &design_doc).await?, None);
     assert!(

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -79,7 +79,7 @@ So does archiving:
 
 * `ctx.archive(who: &TestIndividual) -> TestArchive`: Serializes an instance.
 * `ctx.rebuild_from_archive(archive: &TestArchive, name) -> TestIndividual`: Rebuilds an archive as a new instance of the same identity with a fresh ciphertext store.
-* `ctx.ingest_archive(into: &TestIndividual, archive: &TestArchive) -> usize`: Merges an archive into a live instance. Returns how many events remain pending.
+* `ctx.ingest_archive(into: &TestIndividual, archive: TestArchive) -> usize`: Merges an archive into a live instance. Returns how many events remain pending.
 
 If you forget to do this, the test will probably fail with `TestError::NotSynced { individual, subject }`.
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -37,6 +37,10 @@ You can also create content:
 * `ctx.encrypt_after(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content that follows `after` in the document's content DAG.
 * `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
 * `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
+
+* `ctx.encrypt_in_envelope(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content with an envelope listing the ancestors and carrying the keys to open them. This simulates the application layer.
+* `ctx.deliver_content(to: &TestIndividual, content: &TestEncryptedContent)`: Gives `to` a copy of the content. Sync sends CGKA and membership ops, not content.
+* `ctx.causal_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> TestCausalDecryption`: Walks back from `content` through the ancestors it lists. Returns what it `recovered()` and how many ancestors are `missing()`.
 * `ctx.force_pcs_update(who: &TestIndividual, doc: &TestDocument) -> TestShareKey`: Forces a PCS key update for the document. Returns the share key the rotation introduced.
 * `content.with_a_flipped_bit() -> TestEncryptedContent`: The same content with one bit of the ciphertext changed.
 

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -98,6 +98,8 @@ Every method returns `Result<T, TestError>`, with variants representing reasons 
 * `TestError::Escalation { wanted: Access, held: Access }`: The issuer holds some access over the resource, but less than they tried to delegate.
 * `TestError::NoAuthority`: The issuer has no access to the resource.
 * `TestError::NotSynced { individual: String, subject: String }`: The individual has not yet received the required events.
+* `TestError::WrongDocument { holds, doc }`: A predecessor was named that belongs to a different document.
+* `TestError::DifferentIdentity { from, to }`: Prekey secrets belong to one identity and cannot be given to another.
 * `TestError::Other(String)`: Anything else, wrapping the underlying error as a `String`.
 
 `NotSynced` also covers the case where the individual has no access to the subject and was therefore never sent it, because the facade has to find the resource in their `Keyhive` before it can ask about authority. An individual who was never a member gets `NotSynced` rather than `NoAuthority`.

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -63,6 +63,8 @@ Then you can check properties:
 * `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access.
 * `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
 * `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
+* `ctx.documents_reachable_by(observer: &TestIndividual, who: &impl TestAgent) -> BTreeMap<String, Access>`: The documents `who` reaches, as `observer` sees it. A document delegated to Public is not included unless it's passed as `who`.
+* `ctx.memberships_reachable_by(observer: &TestIndividual, who: &impl TestAgent) -> BTreeMap<String, Access>`: Like `documents_reachable_by`, but also includes groups.
 * `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
 * `ctx.read(who: &TestIndividual, content: &TestEncryptedContent) -> Vec<u8>`: What `who` reads back, or an error if they can't. Use this where the point is that the content survived the round trip, and `can_decrypt` where the point is who may read.
 * `ctx.best_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: The higher of `who`'s own access and public's access.
@@ -102,6 +104,8 @@ Every method returns `Result<T, TestError>`, with variants representing reasons 
 * `TestError::NameTaken { name }`: Two things in one context cannot share a name since the member maps are keyed by name.
 * `TestError::WrongDocument { holds, doc }`: A predecessor was named that belongs to a different document.
 * `TestError::DifferentIdentity { from, to }`: Prekey secrets belong to one identity and cannot be given to another.
+* `TestError::NoKey`: The reader holds no secret key that could be used to derive this content's encryption key.
+* `TestError::CiphertextRejected`: A key was derived but the ciphertext did not authenticate under it.
 * `TestError::Other(String)`: Anything else, wrapping the underlying error as a `String`.
 
 `NotSynced` also covers the case where the individual has no access to the subject and was therefore never sent it, because the facade has to find the resource in their `Keyhive` before it can ask about authority. An individual who was never a member gets `NotSynced` rather than `NoAuthority`.

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -1,0 +1,119 @@
+# Writing tests using the testing facade
+
+## 1. Why a testing facade?
+
+`keyhive_core/tests/facade/mod.rs` defines a testing facade that higher-level tests can
+use instead of calling the `Keyhive` API directly. It serves a number of purposes:
+
+* Makes higher-level tests easier to read and write by providing a reusable API that abstracts away managing the details of setting up keyhives, syncing state, and checking properties, as well as abstracting away complicated signatures when their details are not important.
+* Ensures tests clearly express the concepts we care about in the context of the test.
+* Avoids coupling tests with lower-level details when those details are not what we care about.
+* Makes it easy to rely on the higher-level test suite for checking regressions when implementing significant architectural changes. If the tests are unnecessarily coupled to lower-level details, then we would need to also change the tests themselves, making them unreliable indicators of regressions.
+
+## 2. The testing facade API
+
+You start a test by creating a `TestContext` via `TestContext::new()`. The context manages the lower-level details of the `keyhive` API, state, and property checking.
+
+Once you have a context, you can use it to create entities:
+
+* `ctx.individual(name) -> TestIndividual`: Creates a keyhive identity.
+* `ctx.group(creator: &TestIndividual, name) -> TestGroup`
+* `ctx.doc(creator: &TestIndividual, name) -> TestDocument`
+
+These test objects have a `name()` method for use in assertion messages.
+
+You can then delegate and revoke access:
+
+* `ctx.delegate(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered, level)`:  `issuer` delegates `level` over `resource` to `audience`. Signed by the issuer's own instance. Returns an error if the issuer may not do this.
+* `ctx.revoke(issuer: &TestIndividual, audience: &impl TestAgent, resource: &impl TestMembered)`: `issuer` removes `audience`'s membership in `resource`.
+
+You can also create content and sync state between keyhive identities:
+
+* `ctx.encrypt(who: &TestIndividual, doc: &TestDocument, bytes) -> TestEncryptedContent`. A `TestEncryptedContent` can be passed to `can_decrypt` to check if an individual can decrypt it.
+* `ctx.sync(from: &TestIndividual, to: &TestIndividual) -> usize`: Sends `from`'s events to `to`. The return value is how many events `to` could not yet apply.
+* `ctx.sync_all()`: Sends events between every pair of individuals.
+
+Then you can check properties:
+* `ctx.effective_access(who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Check `who`'s access level for `doc`. `None` for no access. |
+* `ctx.effective_access_seen_by(observer: &TestIndividual, who: &impl TestAgent, doc: &TestDocument) -> Option<Access>`: Same as `effective_access()`, but from the point of view of `observer`'s `Keyhive`.
+* `ctx.transitive_members_of(membered: &impl TestMembered) -> BTreeMap<String, Access>`: Returns everyone who has access to `resource`, including through nested groups.
+* `ctx.can_decrypt(who: &TestIndividual, content: &TestEncryptedContent) -> bool`: Whether `who` can successfully decrypt content.
+
+Note that `effective_access()` and `can_decrypt()` are checking different properties. `effective_access()` tells you what the Keyhive graph says someone may do. `can_decrypt()` tells you whether decryption actually succeeds. They need to be checked independently since they can come apart if there's a bug (this has happened before).
+
+You need to call `sync_all()` before:
+
+* checking `can_decrypt` for anyone other than the person who called `encrypt`,
+* checking `effective_access_seen_by` about an identity other than the resource owner,
+* having an individual issue a delegation over a resource they did not create, because they need to know that resource exists first.
+
+If you forget to do this, the test will probably fail with `TestError::NotSynced { individual, subject }`.
+
+### Test errors for checking properties
+
+Every method returns `Result<T, TestError>`, with variants representing reasons an operation would be refused:
+
+* `TestError::Escalation { wanted: Access, held: Access }`: The issuer holds some access over the resource, but less than they tried to delegate.
+* `TestError::NoAuthority`: The issuer has no access to the resource.
+* `TestError::NotSynced { individual: String, subject: String }`: The individual has not yet received the required events.
+* `TestError::Other(String)`: Anything else, wrapping the underlying error as a `String`.
+
+Use these variants to check specific properties. For example:
+
+```rust
+match ctx.delegate(&bob, &carol, &design_doc, Admin).await {
+    Err(TestError::Escalation { wanted, held }) => {
+        assert_eq!(wanted, Admin);
+        assert_eq!(held, Read);
+    }
+    other => panic!("expected an escalation refusal, got {other:?}"),
+}
+```
+
+## 3. An example test
+
+Here is an example of a declarative test that involves only the minimal number of higher level steps to check that a rule is satisfied:
+
+```rust
+mod facade;
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::{Edit, Read};
+
+#[tokio::test]
+async fn a_relay_cannot_decrypt() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let server = ctx.individual("server").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let relays = ctx.group(&alice, "relays").await?;
+
+    ctx.delegate(&alice, &relays, &design_doc, Relay).await?;
+    ctx.delegate(&alice, &server, &relays, Admin).await?;
+
+    let ct = ctx.encrypt(&alice, &design_doc, b"secret").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(ctx.effective_access(&server, &design_doc).await?, Some(Relay));
+    assert!(!ctx.can_decrypt(&server, &ct).await?, "a relay may not decrypt");
+    Ok(())
+}
+```
+
+### Guidelines
+
+**Focus on the high-level rules, behaviors, and properties we expect keyhive to respect.** For checking lower-level details, write unit tests in those modules.
+
+**Check one rule per test.** If a test could fail for two unrelated reasons, split it.
+
+**Name a test after the rule it's checking.** `a_reader_cannot_delegate_edit_or_above` rather than `test_add_member_3`.
+
+## 4. Adding methods and entities to the facade
+
+New methods should be phrased as actions or questions about entities. They must not return
+internal types (e.g., return `TestIndividual` instead of `Individual`). They should abstract away irrelevant lower-level details. And they may correspond to multiple actions at the lower level.
+
+If you need a new entity, then prefix its name with `Test` and add a creation method to `TestContext`. Don't add methods to that entity for use in tests except for `name()`. Prefer passing the handle into `TestContext` methods so it can manage related lower-level plumbing and state.
+
+If a method can be refused for more than one reason, add a `TestError` variant rather than
+letting it fall into `Other`. Tests should be able to check why an operation failed.
+

--- a/keyhive_core/tests/facade/README.md
+++ b/keyhive_core/tests/facade/README.md
@@ -34,6 +34,7 @@ You can also create content:
 
 * `ctx.encrypt(who: &TestIndividual, doc: &TestDocument, bytes) -> TestEncryptedContent`. A `TestEncryptedContent` can be passed to `can_decrypt` to check if an individual can decrypt it.
 * `ctx.encrypt_keyed(who, doc, bytes) -> (TestEncryptedContent, TestSymmetricKey)`: Also returns the application secret the content was encrypted with.
+* `ctx.encrypt_after(who, doc, after: &[TestEncryptedContent], bytes) -> TestEncryptedContent`: Writes content that follows `after` in the document's content DAG.
 * `ctx.derived_key(who: &TestIndividual, content: &TestEncryptedContent) -> Option<TestSymmetricKey>`: The application secret `who` derives for this content or `None` if they can't derive one.
 * `ctx.decrypt_with_key(content: &TestEncryptedContent, key: &TestSymmetricKey) -> Vec<u8>`: Decrypts with a key the test obtained some other way, rather than with one derived through the graph.
 * `content.with_a_flipped_bit() -> TestEncryptedContent`: The same content with one bit of the ciphertext changed.

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -688,6 +688,29 @@ impl TestContext {
             .collect())
     }
 
+    /// Everyone whose membership in `membered` was revoked and not replaced, with the
+    /// access their revoked delegation had conveyed.
+    ///
+    /// Someone who was revoked and then delegated again is excluded from this result.
+    pub async fn revoked_members_of(
+        &self,
+        membered: &impl TestMembered,
+    ) -> Result<BTreeMap<String, Access>> {
+        let owner = match membered.as_membered() {
+            TestMemberedRef::Group(g) => g.owner,
+            TestMemberedRef::Doc(d) => d.owner,
+        };
+        let observer = self.individual_by_instance(owner)?;
+        let raw = match self.get_membered(&observer, membered).await? {
+            Membered::Group(_, group) => group.lock().await.revoked_members(),
+            Membered::Document(_, doc) => doc.lock().await.revoked_members(),
+        };
+        Ok(raw
+            .into_iter()
+            .map(|(id, (_, access))| (self.name_of(id, &id.to_string()).to_string(), access))
+            .collect())
+    }
+
     /// Every delegation `observer` holds for `membered`.
     pub async fn delegations_for(
         &self,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -118,8 +118,6 @@ impl From<RevokeMemberError> for TestError {
     }
 }
 
-/// Everything else the facade calls reports as `Other`. None of it is a refusal that a
-/// test should be distinguishing.
 impl From<SigningError> for TestError {
     fn from(e: SigningError) -> Self {
         TestError::Other(e.to_string())
@@ -162,10 +160,15 @@ impl From<&str> for TestError {
     }
 }
 
-/// A keyhive identity with their own `Keyhive` instance and signing key.
+/// Identifies one `Keyhive`. A single keyhive identity can be running more than one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TestInstanceId(u32);
+
+/// A keyhive identity.
 #[derive(Clone, Debug)]
 pub struct TestIndividual {
-    id: IndividualId,
+    identity: IndividualId,
+    instance: TestInstanceId,
     name: Arc<str>,
 }
 
@@ -173,14 +176,14 @@ pub struct TestIndividual {
 pub struct TestGroup {
     id: GroupId,
     name: Arc<str>,
-    owner: IndividualId,
+    owner: TestInstanceId,
 }
 
 #[derive(Clone, Debug)]
 pub struct TestDocument {
     id: DocumentId,
     name: Arc<str>,
-    owner: IndividualId,
+    owner: TestInstanceId,
 }
 
 /// Encrypted content, with the id for the document it belongs to.
@@ -326,8 +329,9 @@ pub enum TestMemberedRef<'a> {
 }
 
 impl TestAgent for TestIndividual {
+    /// A keyhive identity's id.
     fn agent_id(&self) -> Identifier {
-        self.id.into()
+        self.identity.into()
     }
     fn name(&self) -> &str {
         &self.name
@@ -372,7 +376,11 @@ impl TestMembered for TestDocument {
 
 /// A set of individuals, groups and documents, with one `Keyhive` instance per individual.
 pub struct TestContext {
-    hives: BTreeMap<IndividualId, Hive>,
+    hives: BTreeMap<TestInstanceId, Hive>,
+    /// One signing key per identity. A second instance can be given the same one.
+    signers: BTreeMap<IndividualId, MemorySigner>,
+    handles: BTreeMap<TestInstanceId, TestIndividual>,
+    next_instance: u32,
     names: BTreeMap<Identifier, Arc<str>>,
     csprng: StdRng,
     seed: u64,
@@ -392,6 +400,9 @@ impl TestContext {
         names.insert(Public.id(), PUBLIC_NAME.into());
         TestContext {
             hives: BTreeMap::new(),
+            signers: BTreeMap::new(),
+            handles: BTreeMap::new(),
+            next_instance: 0,
             names,
             docs: Vec::new(),
             csprng: StdRng::seed_from_u64(seed),
@@ -414,26 +425,58 @@ impl TestContext {
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
         let mut hive_rng = StdRng::seed_from_u64(self.csprng.gen());
         let signer = MemorySigner::generate(&mut hive_rng);
-        let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
-            signer,
-            MemoryCiphertextStore::new(),
-            NoListener,
-            hive_rng,
-        )
-        .await?;
+        let handle = self.add_instance(signer.clone(), hive_rng, name).await?;
+        self.signers.insert(handle.identity, signer);
+        self.names
+            .insert(handle.identity.into(), handle.name.clone());
+        Ok(handle)
+    }
 
-        let card = hive.contact_card().await?;
-        for other in self.hives.values() {
-            other.receive_contact_card(&card).await?;
-            hive.receive_contact_card(&other.contact_card().await?)
-                .await?;
+    /// A second `Keyhive` for an existing identity, sharing its signing key.
+    pub async fn second_instance(
+        &mut self,
+        of: &TestIndividual,
+        name: &str,
+    ) -> Result<TestIndividual> {
+        let signer = self
+            .signers
+            .get(&of.identity)
+            .ok_or_else(|| format!("{:?} was not created by this TestContext", of.name))?
+            .clone();
+        let hive_rng = StdRng::seed_from_u64(self.csprng.gen());
+        let handle = self.add_instance(signer, hive_rng, name).await?;
+        assert_eq!(handle.identity, of.identity);
+        Ok(handle)
+    }
+
+    /// Give one instance's prekey secrets to another instance of the same identity.
+    ///
+    /// An invitation is addressed to one specific prekey, so an instance can't open one
+    /// aimed at a sibling's prekey until it has that sibling's secrets. Returns how many
+    /// events `to` was holding that it could then apply.
+    pub async fn share_prekey_secrets(
+        &mut self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+    ) -> Result<usize> {
+        if from.identity != to.identity {
+            return Err(format!(
+                "{:?} and {:?} are different people; prekey secrets are not transferable",
+                from.name, to.name
+            )
+            .into());
         }
-
-        let id = hive.id();
-        let name: Arc<str> = name.into();
-        self.names.insert(id.into(), name.clone());
-        self.hives.insert(id, hive);
-        Ok(TestIndividual { id, name })
+        let blob = self
+            .hive(from)?
+            .export_prekey_secrets()
+            .await
+            .map_err(|e| TestError::Other(e.to_string()))?;
+        let before = self.pending_events(to).await?;
+        self.hive(to)?
+            .import_prekey_secrets(&blob)
+            .await
+            .map_err(|e| TestError::Other(e.to_string()))?;
+        Ok(before.saturating_sub(self.pending_events(to).await?))
     }
 
     pub async fn group(&mut self, owner: &TestIndividual, name: &str) -> Result<TestGroup> {
@@ -444,7 +487,7 @@ impl TestContext {
         Ok(TestGroup {
             id,
             name,
-            owner: owner.id,
+            owner: owner.instance,
         })
     }
 
@@ -459,7 +502,7 @@ impl TestContext {
         let handle = TestDocument {
             id,
             name,
-            owner: owner.id,
+            owner: owner.instance,
         };
         self.docs.push(handle.clone());
         Ok(handle)
@@ -511,7 +554,7 @@ impl TestContext {
         who: &impl TestAgent,
         doc: &TestDocument,
     ) -> Result<Option<Access>> {
-        let observer = self.individual_by_id(doc.owner)?;
+        let observer = self.individual_by_instance(doc.owner)?;
         self.effective_access_seen_by(&observer, who, doc).await
     }
 
@@ -541,7 +584,7 @@ impl TestContext {
             TestMemberedRef::Group(g) => g.owner,
             TestMemberedRef::Doc(d) => d.owner,
         };
-        let observer = self.individual_by_id(owner)?;
+        let observer = self.individual_by_instance(owner)?;
         let handle = self.get_membered(&observer, membered).await?;
         let raw = self.hive(&observer)?.reachable_members(handle).await;
 
@@ -580,7 +623,7 @@ impl TestContext {
         who: &impl TestAgent,
         doc: &TestDocument,
     ) -> Result<Option<Access>> {
-        let observer = self.individual_by_id(doc.owner)?;
+        let observer = self.individual_by_instance(doc.owner)?;
         let handle = self.get_membered(&observer, doc).await?;
         let members = self.hive(&observer)?.reachable_members(handle).await;
         let direct = members.get(&who.agent_id()).map(|(_, a)| *a);
@@ -745,13 +788,13 @@ impl TestContext {
 
     /// Sends events between every pair of individuals.
     pub async fn sync_all(&mut self) -> Result<()> {
-        let ids: Vec<IndividualId> = self.hives.keys().copied().collect();
+        let ids: Vec<TestInstanceId> = self.hives.keys().copied().collect();
         for _ in 0..3 {
             for from in &ids {
                 for to in &ids {
                     if from != to {
-                        let a = self.individual_by_id(*from)?;
-                        let b = self.individual_by_id(*to)?;
+                        let a = self.individual_by_instance(*from)?;
+                        let b = self.individual_by_instance(*to)?;
                         self.sync(&a, &b).await?;
                     }
                 }
@@ -768,7 +811,7 @@ impl TestContext {
         from: &TestIndividual,
         to: &TestIndividual,
     ) -> Result<Vec<StaticEvent<[u8; 32]>>> {
-        let to_agent = self.get_agent(from, to.id.into(), &to.name).await?;
+        let to_agent = self.get_agent(from, to.identity.into(), &to.name).await?;
         Ok(self
             .hive(from)?
             .static_events_for_agent(&to_agent)
@@ -799,17 +842,49 @@ impl TestContext {
 
     fn hive(&self, who: &TestIndividual) -> Result<&Hive> {
         self.hives
-            .get(&who.id)
+            .get(&who.instance)
             .ok_or_else(|| format!("{:?} is not in this TestContext", who.name).into())
     }
 
-    fn individual_by_id(&self, id: IndividualId) -> Result<TestIndividual> {
-        let name = self
-            .names
-            .get(&id.into())
-            .ok_or("unknown actor id")?
-            .clone();
-        Ok(TestIndividual { id, name })
+    fn individual_by_instance(&self, instance: TestInstanceId) -> Result<TestIndividual> {
+        self.handles
+            .get(&instance)
+            .cloned()
+            .ok_or_else(|| "unknown instance".into())
+    }
+
+    async fn add_instance(
+        &mut self,
+        signer: MemorySigner,
+        rng: StdRng,
+        name: &str,
+    ) -> Result<TestIndividual> {
+        let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
+            signer,
+            MemoryCiphertextStore::new(),
+            NoListener,
+            rng,
+        )
+        .await?;
+
+        let card = hive.contact_card().await?;
+        for other in self.hives.values() {
+            other.receive_contact_card(&card).await?;
+            hive.receive_contact_card(&other.contact_card().await?)
+                .await?;
+        }
+
+        let identity = hive.id();
+        let instance = TestInstanceId(self.next_instance);
+        self.next_instance += 1;
+        self.hives.insert(instance, hive);
+        let handle = TestIndividual {
+            identity,
+            instance,
+            name: name.into(),
+        };
+        self.handles.insert(instance, handle.clone());
+        Ok(handle)
     }
 
     async fn get_agent(

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -165,7 +165,8 @@ impl From<&str> for TestError {
     }
 }
 
-/// Identifies one `Keyhive`. A single keyhive identity can be running more than one.
+/// Identifies one `Keyhive` instance. A single keyhive identity can be
+/// running more than one.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TestInstanceId(u32);
 
@@ -191,7 +192,7 @@ pub struct TestDocument {
     owner: TestInstanceId,
 }
 
-/// Encrypted content, with the id for the document it belongs to.
+/// Encrypted content with the id for the document it belongs to.
 #[derive(Clone)]
 pub struct TestEncryptedContent {
     doc: DocumentId,
@@ -430,7 +431,7 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    /// A context, recording a seed for replayability
+    /// A context, recording a seed for replayability.
     pub async fn new() -> Self {
         Self::with_seed(rand::rngs::OsRng.gen()).await
     }
@@ -681,7 +682,7 @@ impl TestContext {
     /// Whether `who` has received the events needed to learn about `what`.
     ///
     /// `effective_access` returns `None` both for no access and for never having heard of
-    /// the subject. This can distinguish those cases.
+    /// the subject. This method can distinguish those cases.
     pub async fn has_received(&self, who: &TestIndividual, what: &impl TestAgent) -> Result<bool> {
         Ok(self.hive(who)?.get_agent(what.agent_id()).await.is_some())
     }
@@ -813,8 +814,7 @@ impl TestContext {
 
     /// Rebuild an instance from an archive, as a new instance of the same identity.
     ///
-    /// The restored instance gets a fresh ciphertext store. It can compute keys but
-    /// holds no stored ciphertexts of its own.
+    /// The restored instance gets a fresh ciphertext store.
     pub async fn rebuild_from_archive(
         &mut self,
         archive: &TestArchive,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -644,6 +644,29 @@ impl TestContext {
             .collect())
     }
 
+    /// Every delegation `observer` holds for `membered`.
+    pub async fn delegations_for(
+        &self,
+        observer: &TestIndividual,
+        membered: &impl TestMembered,
+    ) -> Result<Vec<TestDelegation>> {
+        let handle = self.get_membered(observer, membered).await?;
+        let subject = self.name_of(membered.agent_id(), membered.name());
+        let mut out = vec![];
+        for signed in handle.members().await.values().flat_map(|d| d.iter()) {
+            let issuer = Identifier::from(signed.issuer());
+            let audience = signed.payload().delegate().id();
+            out.push(TestDelegation {
+                digest: *signed.digest().raw.as_bytes(),
+                issuer: self.name_of(issuer, &issuer.to_string()),
+                audience: self.name_of(audience, &audience.to_string()),
+                subject: subject.clone(),
+                can: signed.payload().can(),
+            });
+        }
+        Ok(out)
+    }
+
     /// Whether `who` can actually decrypt the encrypted content.
     pub async fn can_decrypt(
         &self,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -299,7 +299,7 @@ impl TestPrekeyOp {
 #[derive(Clone, Debug)]
 pub struct TestCausalDecryption {
     recovered: Vec<Vec<u8>>,
-    missing: usize,
+    missing: BTreeMap<[u8; 32], SymmetricKey>,
 }
 
 impl TestCausalDecryption {
@@ -311,7 +311,15 @@ impl TestCausalDecryption {
     /// How many ancestors were listed but not held. Their keys are known, so they can be
     /// decrypted as soon as they arrive.
     pub fn missing(&self) -> usize {
+        self.missing.len()
+    }
+
+    /// The key the walk reported for an ancestor it could not find, if it reported one.
+    pub fn key_for_missing(&self, ct: &TestEncryptedContent) -> Option<TestSymmetricKey> {
         self.missing
+            .get(&ct.inner.content_ref)
+            .copied()
+            .map(TestSymmetricKey)
     }
 }
 
@@ -720,13 +728,27 @@ impl TestContext {
         Ok(out)
     }
 
+    /// The content `who` reads back, or an error if they cannot read it.
+    ///
+    /// For content written with `encrypt_in_envelope` this is the envelope rather than the
+    /// payload since unwrapping it is `causal_decrypt`'s role.
+    pub async fn read(&self, who: &TestIndividual, ct: &TestEncryptedContent) -> Result<Vec<u8>> {
+        let handle = self
+            .get_document_by_id(who, ct.doc, "that document")
+            .await?;
+        Ok(self
+            .hive(who)?
+            .try_decrypt_content(handle, &ct.inner)
+            .await?)
+    }
+
     /// Whether `who` can actually decrypt the encrypted content.
     pub async fn can_decrypt(
         &self,
         who: &TestIndividual,
         ct: &TestEncryptedContent,
     ) -> Result<bool> {
-        Ok(self.derived_key(who, ct).await?.is_some())
+        Ok(self.read(who, ct).await.is_ok())
     }
 
     /// The higher of `who`'s own access and public's access.
@@ -882,7 +904,7 @@ impl TestContext {
             .map_err(|e| TestError::Other(e.to_string()))?;
         Ok(TestCausalDecryption {
             recovered: state.complete.into_iter().map(|(_, p)| p).collect(),
-            missing: state.next.len(),
+            missing: state.next.into_iter().collect(),
         })
     }
 

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -366,11 +366,6 @@ impl TestCausalDecryption {
             .copied()
             .map(TestSymmetricKey)
     }
-
-    /// How many distinct pieces of content the walk holds a key for.
-    pub fn recovered_key_count(&self) -> usize {
-        self.recovered_keys.len()
-    }
 }
 
 /// A serialized `Keyhive`.
@@ -720,6 +715,38 @@ impl TestContext {
             .await
             .get(&doc.id)
             .map(|a| a.can()))
+    }
+
+    /// The groups and documents `audience` reaches, as `observer` sees it, and at what level.
+    pub async fn memberships_reachable_by(
+        &self,
+        observer: &TestIndividual,
+        audience: &impl TestAgent,
+    ) -> Result<BTreeMap<String, Access>> {
+        let aud = self
+            .get_agent(observer, audience.agent_id(), audience.name())
+            .await?;
+        Ok(self
+            .hive(observer)?
+            .membered_reachable_by_agent(&aud)
+            .await
+            .into_iter()
+            .map(|(id, (_, access))| (self.name_of(id.into()).to_string(), access))
+            .collect())
+    }
+
+    /// Which documents `who` reaches and at what level.
+    ///
+    /// A document delegated to Public is not included.
+    pub async fn documents_reachable_by(
+        &self,
+        who: &TestIndividual,
+    ) -> Result<BTreeMap<String, Access>> {
+        let raw = self.hive(who)?.reachable_docs().await;
+        Ok(raw
+            .into_iter()
+            .map(|(id, ability)| (self.name_of(id.into()).to_string(), ability.can()))
+            .collect())
     }
 
     /// Everyone who can reach `membered`, including through nested groups.

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -69,6 +69,10 @@ pub enum TestError {
     #[error("{individual:?} does not know about {subject:?}. Sync first.")]
     NotSynced { individual: String, subject: String },
 
+    /// Two things in one context cannot share a name.
+    #[error("{name:?} is already the name of something in this TestContext")]
+    NameTaken { name: String },
+
     /// A predecessor was named that belongs to a different document.
     #[error("that content is in {holds:?}, not in {doc:?}")]
     WrongDocument { holds: String, doc: String },
@@ -509,6 +513,7 @@ impl TestContext {
     ///
     /// Every individual learns every other individual's contact card.
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
+        self.claim_name(name)?;
         let mut hive_rng = StdRng::seed_from_u64(self.csprng.gen());
         let signer = MemorySigner::generate(&mut hive_rng);
         let handle = self.add_instance(signer.clone(), hive_rng, name).await?;
@@ -524,6 +529,7 @@ impl TestContext {
         of: &TestIndividual,
         name: &str,
     ) -> Result<TestIndividual> {
+        self.claim_name(name)?;
         let signer = self
             .signers
             .get(&of.identity)
@@ -565,6 +571,7 @@ impl TestContext {
     }
 
     pub async fn group(&mut self, owner: &TestIndividual, name: &str) -> Result<TestGroup> {
+        self.claim_name(name)?;
         let g = self.hive(owner)?.generate_group(vec![]).await?;
         let id = { g.lock().await.group_id() };
         let name: Arc<str> = name.into();
@@ -577,6 +584,7 @@ impl TestContext {
     }
 
     pub async fn doc(&mut self, owner: &TestIndividual, name: &str) -> Result<TestDocument> {
+        self.claim_name(name)?;
         let d = self
             .hive(owner)?
             .generate_doc(vec![], nonempty![[0u8; 32]])
@@ -1265,6 +1273,18 @@ impl TestContext {
             .or_default()
             .extend(digests);
         Ok(pending)
+    }
+
+    /// Refuse a name that is already in use.
+    fn claim_name(&self, name: &str) -> Result<()> {
+        let taken = self.names.values().any(|n| &**n == name)
+            || self.handles.values().any(|h| &*h.name == name);
+        if taken {
+            return Err(TestError::NameTaken {
+                name: name.to_string(),
+            });
+        }
+        Ok(())
     }
 
     fn name_of(&self, id: Identifier, fallback: &str) -> Arc<str> {

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -7,6 +7,7 @@ use futures::lock::Mutex;
 use keyhive_core::{
     access::Access,
     archive::Archive,
+    crypto::envelope::Envelope,
     event::static_event::StaticEvent,
     keyhive::{EncryptContentError, Keyhive},
     listener::no_listener::NoListener,
@@ -47,6 +48,7 @@ type Hive = Keyhive<
 type AgentHandle = Agent<future_form::Sendable, MemorySigner, [u8; 32], NoListener>;
 type MemberedHandle = Membered<future_form::Sendable, MemorySigner, [u8; 32], NoListener>;
 type DocHandle = Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>;
+type ContentStore = MemoryCiphertextStore<[u8; 32], Vec<u8>>;
 
 pub type Result<T> = std::result::Result<T, TestError>;
 
@@ -293,6 +295,26 @@ impl TestPrekeyOp {
     }
 }
 
+/// What was recovered by walking back through an envelope's ancestors.
+#[derive(Clone, Debug)]
+pub struct TestCausalDecryption {
+    recovered: Vec<Vec<u8>>,
+    missing: usize,
+}
+
+impl TestCausalDecryption {
+    /// The content recovered by the walk, in no order.
+    pub fn recovered(&self) -> BTreeSet<Vec<u8>> {
+        self.recovered.iter().cloned().collect()
+    }
+
+    /// How many ancestors were named but not held. Their keys are known, so they can be
+    /// decrypted as soon as they arrive.
+    pub fn missing(&self) -> usize {
+        self.missing
+    }
+}
+
 /// A serialized `Keyhive`.
 #[derive(Clone)]
 pub struct TestArchive {
@@ -421,6 +443,9 @@ pub struct TestContext {
     docs: Vec<TestDocument>,
     /// The digests each instance has already received, so `sync` sends a delta.
     delivered: BTreeMap<TestInstanceId, BTreeSet<[u8; 32]>>,
+    /// Each instance's ciphertext store. Storing what you wrote or received is the
+    /// application's role, and causal decryption reads back out of it.
+    stores: BTreeMap<TestInstanceId, ContentStore>,
 }
 
 impl TestContext {
@@ -442,6 +467,7 @@ impl TestContext {
             names,
             docs: Vec::new(),
             delivered: BTreeMap::new(),
+            stores: BTreeMap::new(),
             csprng: StdRng::seed_from_u64(seed),
             seed,
         }
@@ -760,6 +786,73 @@ impl TestContext {
         })
     }
 
+    /// Write `content` in an envelope listing the ancestors and carrying the keys to open
+    /// them. Simulates what an application would do.
+    pub async fn encrypt_in_envelope(
+        &mut self,
+        who: &TestIndividual,
+        doc: &TestDocument,
+        after: &[TestEncryptedContent],
+        content: &[u8],
+    ) -> Result<TestEncryptedContent> {
+        let mut ancestors = std::collections::HashMap::new();
+        for pred in after {
+            let key = self.derived_key(who, pred).await?.ok_or_else(|| {
+                format!(
+                    "{:?} cannot derive the key for an ancestor, so cannot name it",
+                    who.name
+                )
+            })?;
+            ancestors.insert(pred.inner.content_ref, key.0);
+        }
+        let envelope = Envelope {
+            plaintext: content.to_vec(),
+            ancestors,
+        };
+        let bytes = bincode::serialize(&envelope)
+            .map_err(|e| TestError::Other(format!("could not serialize an envelope: {e}")))?;
+
+        let out = self.encrypt_after(who, doc, after, &bytes).await?;
+        self.deliver_content(who, &out).await?;
+        Ok(out)
+    }
+
+    /// Give `to` a copy of the content, simulating how an application would behave.
+    pub async fn deliver_content(
+        &mut self,
+        to: &TestIndividual,
+        ct: &TestEncryptedContent,
+    ) -> Result<()> {
+        self.stores
+            .get(&to.instance)
+            .ok_or_else(|| format!("{:?} is not in this TestContext", to.name))?
+            .insert(Arc::new(ct.inner.clone()))
+            .await;
+        Ok(())
+    }
+
+    /// Walk back from `ct` through the ancestors it lists, decrypting what `who` holds.
+    ///
+    /// Reports what it recovered and what it could not find.
+    pub async fn causal_decrypt(
+        &self,
+        who: &TestIndividual,
+        ct: &TestEncryptedContent,
+    ) -> Result<TestCausalDecryption> {
+        let handle = self
+            .get_document_by_id(who, ct.doc, "that document")
+            .await?;
+        let state = self
+            .hive(who)?
+            .try_causal_decrypt_content(handle, &ct.inner)
+            .await
+            .map_err(|e| TestError::Other(e.to_string()))?;
+        Ok(TestCausalDecryption {
+            recovered: state.complete.into_iter().map(|(_, p)| p).collect(),
+            missing: state.next.len(),
+        })
+    }
+
     /// Encrypt. Returns the application secret the content went under.
     pub async fn encrypt_keyed(
         &mut self,
@@ -870,17 +963,18 @@ impl TestContext {
             .get(&archive.identity)
             .ok_or("that archive's identity was not created by this TestContext")?
             .clone();
+        let store = ContentStore::new();
         let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::try_from_archive(
             &archive.inner,
             signer,
-            MemoryCiphertextStore::new(),
+            store.clone(),
             NoListener,
             Arc::new(Mutex::new(StdRng::seed_from_u64(self.csprng.gen()))),
         )
         .await
         .map_err(|e| TestError::Other(e.to_string()))?;
 
-        self.register_instance(hive, name).await
+        self.register_instance(hive, store, name).await
     }
 
     /// Merge an archive into a live instance. Returns how many events remain pending.
@@ -1119,19 +1213,25 @@ impl TestContext {
         rng: StdRng,
         name: &str,
     ) -> Result<TestIndividual> {
+        let store = ContentStore::new();
         let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
             signer,
-            MemoryCiphertextStore::new(),
+            store.clone(),
             NoListener,
             rng,
         )
         .await?;
 
-        self.register_instance(hive, name).await
+        self.register_instance(hive, store, name).await
     }
 
     /// Register a new instance and swap contact cards with every other instance.
-    async fn register_instance(&mut self, hive: Hive, name: &str) -> Result<TestIndividual> {
+    async fn register_instance(
+        &mut self,
+        hive: Hive,
+        store: ContentStore,
+        name: &str,
+    ) -> Result<TestIndividual> {
         let card = hive.contact_card().await?;
         for other in self.hives.values() {
             other.receive_contact_card(&card).await?;
@@ -1143,6 +1243,7 @@ impl TestContext {
         let instance = TestInstanceId(self.next_instance);
         self.next_instance += 1;
         self.hives.insert(instance, hive);
+        self.stores.insert(instance, store);
         let handle = TestIndividual {
             identity,
             instance,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -605,7 +605,7 @@ impl TestContext {
     ///
     /// Signed by the issuer. Returns an error if the issuer may not do this.
     pub async fn delegate(
-        &mut self,
+        &self,
         issuer: &TestIndividual,
         audience: &impl TestAgent,
         membered: &impl TestMembered,
@@ -632,7 +632,7 @@ impl TestContext {
     /// Members `audience` had admitted keep their access, because their delegations are
     /// re-issued under the issuer.
     pub async fn revoke(
-        &mut self,
+        &self,
         issuer: &TestIndividual,
         audience: &impl TestAgent,
         membered: &impl TestMembered,
@@ -642,7 +642,7 @@ impl TestContext {
 
     /// `issuer` removes `audience`, and everyone whose only way in was through them.
     pub async fn revoke_cascading(
-        &mut self,
+        &self,
         issuer: &TestIndividual,
         audience: &impl TestAgent,
         membered: &impl TestMembered,
@@ -651,7 +651,7 @@ impl TestContext {
     }
 
     async fn revoke_inner(
-        &mut self,
+        &self,
         issuer: &TestIndividual,
         audience: &impl TestAgent,
         membered: &impl TestMembered,
@@ -707,14 +707,7 @@ impl TestContext {
 
         Ok(raw
             .into_iter()
-            .map(|(id, (_, access))| {
-                let name = self
-                    .names
-                    .get(&id)
-                    .map(|n| n.to_string())
-                    .unwrap_or_else(|| format!("<{id}>"));
-                (name, access)
-            })
+            .map(|(id, (_, access))| (self.name_of(id, &id.to_string()).to_string(), access))
             .collect())
     }
 
@@ -838,7 +831,7 @@ impl TestContext {
     }
 
     pub async fn encrypt(
-        &mut self,
+        &self,
         who: &TestIndividual,
         doc: &TestDocument,
         content: &[u8],
@@ -848,7 +841,7 @@ impl TestContext {
 
     /// Encrypt content that follows `after` in the document's content DAG.
     pub async fn encrypt_after(
-        &mut self,
+        &self,
         who: &TestIndividual,
         doc: &TestDocument,
         after: &[TestEncryptedContent],
@@ -879,9 +872,9 @@ impl TestContext {
     }
 
     /// Write `content` in an envelope listing the ancestors and carrying the keys to open
-    /// them. Simulates what an application would do.
+    /// them. Simulates what an application would do. Returns the encrypted content.
     pub async fn encrypt_in_envelope(
-        &mut self,
+        &self,
         who: &TestIndividual,
         doc: &TestDocument,
         after: &[TestEncryptedContent],
@@ -911,7 +904,7 @@ impl TestContext {
 
     /// Give `to` a copy of the content, simulating how an application would behave.
     pub async fn deliver_content(
-        &mut self,
+        &self,
         to: &TestIndividual,
         ct: &TestEncryptedContent,
     ) -> Result<()> {
@@ -947,7 +940,7 @@ impl TestContext {
 
     /// Encrypt. Returns the application secret the content went under.
     pub async fn encrypt_keyed(
-        &mut self,
+        &self,
         who: &TestIndividual,
         doc: &TestDocument,
         content: &[u8],
@@ -971,7 +964,7 @@ impl TestContext {
     ///
     /// Returns the share key the rotation introduced.
     pub async fn force_pcs_update(
-        &mut self,
+        &self,
         who: &TestIndividual,
         doc: &TestDocument,
     ) -> Result<TestShareKey> {
@@ -985,14 +978,14 @@ impl TestContext {
     }
 
     /// Add a prekey. Returns the key that was added.
-    pub async fn expand_prekeys(&mut self, who: &TestIndividual) -> Result<TestShareKey> {
+    pub async fn expand_prekeys(&self, who: &TestIndividual) -> Result<TestShareKey> {
         let op = self.hive(who)?.expand_prekeys().await?;
         Ok(TestShareKey(op.payload().share_key))
     }
 
     /// Replace `old` with a fresh key. Returns the key that replaced it.
     pub async fn rotate_prekey(
-        &mut self,
+        &self,
         who: &TestIndividual,
         old: &TestShareKey,
     ) -> Result<TestShareKey> {

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -30,7 +30,7 @@ use keyhive_crypto::{
 use nonempty::nonempty;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
+    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, HashMap},
     hash::{Hash, Hasher},
     sync::Arc,
 };
@@ -64,8 +64,9 @@ pub enum TestError {
     #[error("no authority over that resource")]
     NoAuthority,
 
-    /// The individual has not yet received the required events.
-    #[error("{individual:?} does not know about {subject:?}. Sync first.")]
+    /// The individual has not yet received the required events. Also returned when they
+    /// have no access to the subject and so were never sent it.
+    #[error("{individual:?} has not received {subject:?}. Sync first, or check they have access.")]
     NotSynced { individual: String, subject: String },
 
     /// Two things in one context cannot share a name.
@@ -421,11 +422,13 @@ impl TestDocument {
     }
 }
 
+/// Anything a delegation can be addressed to: an individual, a group, a document, or public.
 pub trait TestAgent {
     fn agent_id(&self) -> Identifier;
     fn name(&self) -> &str;
 }
 
+/// Anything that can have members: a group or a document.
 pub trait TestMembered: TestAgent {
     #[doc(hidden)]
     fn as_membered(&self) -> TestMemberedRef<'_>;
@@ -442,7 +445,6 @@ pub enum TestMemberedRef<'a> {
 }
 
 impl TestAgent for TestIndividual {
-    /// A keyhive identity's id.
     fn agent_id(&self) -> Identifier {
         self.identity.into()
     }
@@ -538,7 +540,6 @@ impl TestContext {
     ///
     /// Every individual learns every other individual's contact card.
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
-        self.claim_name(name)?;
         let mut hive_rng = StdRng::seed_from_u64(self.csprng.gen());
         let signer = MemorySigner::generate(&mut hive_rng);
         let handle = self.add_instance(signer.clone(), hive_rng, name).await?;
@@ -554,7 +555,6 @@ impl TestContext {
         of: &TestIndividual,
         name: &str,
     ) -> Result<TestIndividual> {
-        self.claim_name(name)?;
         let signer = self
             .signers
             .get(&of.identity)
@@ -626,7 +626,7 @@ impl TestContext {
         Ok(handle)
     }
 
-    /// `issuer` delegates `can` over `resource` to `audience`.
+    /// `issuer` delegates `can` over `membered` to `audience`.
     ///
     /// Signed by the issuer. Returns an error if the issuer may not do this.
     pub async fn delegate(
@@ -645,14 +645,15 @@ impl TestContext {
         let update = hive.add_member(aud, &res, can, &relevant).await?;
         Ok(TestDelegation {
             digest: *update.delegation.digest().raw.as_bytes(),
-            issuer: issuer.name.clone(),
+            // The identity's name, not this instance's.
+            issuer: self.name_of(issuer.identity.into()),
             audience: self.name_of(audience.agent_id()),
             subject: self.name_of(membered.agent_id()),
             can,
         })
     }
 
-    /// `issuer` removes `audience`'s membership in `resource`, keeping everyone else.
+    /// `issuer` removes `audience`'s membership in `membered`, keeping everyone else.
     ///
     /// Members `audience` had admitted keep their access, because their delegations are
     /// re-issued under the issuer.
@@ -744,13 +745,10 @@ impl TestContext {
         who: &impl TestAgent,
     ) -> Result<BTreeMap<String, Access>> {
         let hive = self.hive(observer)?;
-        let raw = if observer.agent_id() == who.agent_id() {
-            hive.reachable_docs().await
-        } else {
-            let aud = self.get_agent(observer, who.agent_id(), who.name()).await?;
-            hive.docs_reachable_by_agent(&aud).await
-        };
-        Ok(raw
+        let aud = self.get_agent(observer, who.agent_id(), who.name()).await?;
+        Ok(hive
+            .docs_reachable_by_agent(&aud)
+            .await
             .into_iter()
             .map(|(id, ability)| (self.name_of(id.into()).to_string(), ability.can()))
             .collect())
@@ -876,6 +874,8 @@ impl TestContext {
             .map(|(_, key)| TestSymmetricKey(key)))
     }
 
+    /// Decrypt with a key the test obtained some other way, rather than with one derived
+    /// through the graph.
     pub fn decrypt_with_key(
         &self,
         ct: &TestEncryptedContent,
@@ -926,7 +926,7 @@ impl TestContext {
     }
 
     /// Write `content` in an envelope listing the ancestors and carrying the keys to open
-    /// them. Simulates what an application would do. Returns the encrypted content.
+    /// them. Simulates what an application would do.
     pub async fn encrypt_in_envelope(
         &self,
         who: &TestIndividual,
@@ -934,14 +934,9 @@ impl TestContext {
         after: &[&TestEncryptedContent],
         content: &[u8],
     ) -> Result<TestEncryptedContent> {
-        let mut ancestors = std::collections::HashMap::with_capacity(after.len());
+        let mut ancestors = HashMap::with_capacity(after.len());
         for pred in after {
-            let key = self.derived_key(who, pred).await?.ok_or_else(|| {
-                format!(
-                    "{:?} cannot derive the key for an ancestor, so cannot name it",
-                    who.name
-                )
-            })?;
+            let key = self.derived_key(who, pred).await?.ok_or(TestError::NoKey)?;
             ancestors.insert(pred.inner.content_ref, key.0);
         }
         let envelope = Envelope {
@@ -998,6 +993,8 @@ impl TestContext {
     /// `Keyhive::try_causal_decrypt_content` takes a single entrypoint. A reader holding
     /// several heads walks from all of them together, and a shared ancestor should be read
     /// once rather than once per head.
+    ///
+    /// The recovered set includes the entrypoints themselves, unlike `causal_decrypt`.
     pub async fn causal_decrypt_from(
         &self,
         who: &TestIndividual,
@@ -1005,10 +1002,7 @@ impl TestContext {
     ) -> Result<TestCausalDecryption> {
         let mut to_walk = Vec::new();
         for ct in entrypoints {
-            let key = self
-                .derived_key(who, ct)
-                .await?
-                .ok_or("the reader cannot derive the key for one of the entrypoints")?;
+            let key = self.derived_key(who, ct).await?.ok_or(TestError::NoKey)?;
             to_walk.push((Arc::new(ct.inner.clone()), key.0));
         }
         let store = self
@@ -1028,7 +1022,7 @@ impl TestContext {
         })
     }
 
-    /// Encrypt. Returns the application secret the content went under.
+    /// Encrypt content. Returns the content and the application secret it went under.
     pub async fn encrypt_keyed(
         &self,
         who: &TestIndividual,
@@ -1050,9 +1044,7 @@ impl TestContext {
         ))
     }
 
-    /// Force PCS update on `doc`.
-    ///
-    /// Returns the share key the rotation introduced.
+    /// Force PCS update on `doc`. Returns the share key the rotation introduced.
     pub async fn force_pcs_update(
         &self,
         who: &TestIndividual,
@@ -1168,7 +1160,7 @@ impl TestContext {
 
     /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
     ///
-    /// Events `to` has already received are not sent again.
+    /// Everything `to` is entitled to, including events it already holds.
     pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
         let events = self.static_events_for_agent(from, to).await?;
         self.deliver(to, events).await
@@ -1221,7 +1213,7 @@ impl TestContext {
         to: &TestIndividual,
         batch: usize,
     ) -> Result<usize> {
-        assert!(batch > 0, "a batch size of zero is not a valid chunk size");
+        assert!(batch > 0, "batch must be at least 1");
         let events = self.static_events_for_agent(from, to).await?;
         let mut pending = 0;
         for chunk in events.chunks(batch) {
@@ -1230,7 +1222,11 @@ impl TestContext {
         Ok(pending)
     }
 
-    /// Sends everything in an order decided by `seed`, so a failing order can be replayed.
+    /// Sends everything in an order decided by `seed`.
+    ///
+    /// The same seed permutes the same set of events the same way. It does not reproduce an
+    /// order across runs: `TestContext::new` seeds itself from `OsRng`, so the identities,
+    /// and therefore the digests sorted on here, differ every run.
     pub async fn sync_shuffled(
         &mut self,
         from: &TestIndividual,
@@ -1238,6 +1234,9 @@ impl TestContext {
         seed: u64,
     ) -> Result<usize> {
         let mut events = self.static_events_for_agent(from, to).await?;
+        // `static_events_for_agent` comes out of a `HashMap`, whose order varies per process.
+        // Without this the seed would permute a different starting order every run.
+        events.sort_unstable_by_key(|(digest, _)| *digest);
         events.shuffle(&mut StdRng::seed_from_u64(seed));
         self.deliver(to, events).await
     }
@@ -1259,7 +1258,10 @@ impl TestContext {
             .collect())
     }
 
-    /// How many events the last `sync*` call delivered.
+    /// How many events the last delivery carried.
+    ///
+    /// `sync_in_batches` and `sync_all_unsent` deliver more than once, so after those this
+    /// is the final batch or the final pair's delta rather than the call's total.
     pub fn events_last_delivered(&self) -> usize {
         self.last_delivery
     }
@@ -1290,8 +1292,10 @@ impl TestContext {
             + s.pending_revoked) as usize)
     }
 
-    /// Sends every pair of individuals the events they have not been sent until a round
-    /// changes nothing.
+    /// Sends every individual what every other has not yet sent them, repeating until a
+    /// round changes nothing.
+    ///
+    /// Returns an error if the state has not settled after eight rounds.
     pub async fn sync_all_unsent(&mut self) -> Result<()> {
         const MAX_ROUNDS: usize = 8;
         let everyone: Vec<TestIndividual> = self.handles.values().cloned().collect();
@@ -1449,6 +1453,7 @@ impl TestContext {
         store: ContentStore,
         name: &str,
     ) -> Result<TestIndividual> {
+        self.claim_name(name)?;
         let card = hive.contact_card().await?;
         for other in self.hives.values() {
             other.receive_contact_card(&card).await?;

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -28,7 +28,8 @@ use keyhive_crypto::{
 use nonempty::nonempty;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet},
+    hash::{Hash, Hasher},
     sync::Arc,
 };
 use thiserror::Error;
@@ -935,10 +936,14 @@ impl TestContext {
             + s.pending_revoked) as usize)
     }
 
-    /// Sends events between every pair of individuals.
+    /// Sends events between every pair of individuals, until a round changes nothing.
+    ///
+    /// Events that no instance can apply are left pending.
     pub async fn sync_all(&mut self) -> Result<()> {
+        const MAX_ROUNDS: usize = 8;
         let ids: Vec<TestInstanceId> = self.hives.keys().copied().collect();
-        for _ in 0..3 {
+        for _ in 0..MAX_ROUNDS {
+            let before = self.state_signature().await;
             for from in &ids {
                 for to in &ids {
                     if from != to {
@@ -948,13 +953,27 @@ impl TestContext {
                     }
                 }
             }
+            if self.state_signature().await == before {
+                return Ok(());
+            }
         }
-        Ok(())
+        Err(format!("sync_all did not settle in {MAX_ROUNDS} rounds").into())
     }
 
     /////////////////////
     // Internal details
     /////////////////////
+
+    /// What every instance holds and what it is still waiting on. Two rounds of syncing
+    /// that leave this unchanged have moved nothing, and no further round can.
+    async fn state_signature(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        for hive in self.hives.values() {
+            hive.stats().await.hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
     async fn static_events_for_agent(
         &self,
         from: &TestIndividual,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -6,6 +6,7 @@ use dupe::Dupe;
 use futures::lock::Mutex;
 use keyhive_core::{
     access::Access,
+    event::static_event::StaticEvent,
     keyhive::{EncryptContentError, Keyhive},
     listener::no_listener::NoListener,
     principal::{
@@ -23,6 +24,7 @@ use keyhive_crypto::{
     signed::SigningError, signer::memory::MemorySigner, symmetric_key::SymmetricKey,
 };
 use nonempty::nonempty;
+use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 use std::{collections::BTreeMap, sync::Arc};
 
 type Hive = Keyhive<
@@ -32,7 +34,7 @@ type Hive = Keyhive<
     Vec<u8>,
     MemoryCiphertextStore<[u8; 32], Vec<u8>>,
     NoListener,
-    rand::rngs::OsRng,
+    StdRng,
 >;
 
 pub type Result<T> = std::result::Result<T, TestError>;
@@ -261,6 +263,36 @@ impl TestEncryptedContent {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct TestStaticEvent {
+    kind: TestEventKind,
+}
+
+impl TestStaticEvent {
+    pub fn kind(&self) -> TestEventKind {
+        self.kind
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TestEventKind {
+    PrekeysExpanded,
+    PrekeyRotated,
+    CgkaOperation,
+    Delegated,
+    Revoked,
+}
+
+fn kind_of(event: &StaticEvent<[u8; 32]>) -> TestEventKind {
+    match event {
+        StaticEvent::PrekeysExpanded(_) => TestEventKind::PrekeysExpanded,
+        StaticEvent::PrekeyRotated(_) => TestEventKind::PrekeyRotated,
+        StaticEvent::CgkaOperation(_) => TestEventKind::CgkaOperation,
+        StaticEvent::Delegated(_) => TestEventKind::Delegated,
+        StaticEvent::Revoked(_) => TestEventKind::Revoked,
+    }
+}
+
 impl TestIndividual {
     pub fn name(&self) -> &str {
         &self.name
@@ -342,18 +374,34 @@ impl TestMembered for TestDocument {
 pub struct TestContext {
     hives: BTreeMap<IndividualId, Hive>,
     names: BTreeMap<Identifier, Arc<str>>,
+    csprng: StdRng,
+    seed: u64,
     docs: Vec<TestDocument>,
 }
 
 impl TestContext {
+    /// A context, recording a seed for replayability
     pub async fn new() -> Self {
+        Self::with_seed(rand::rngs::OsRng.gen()).await
+    }
+
+    /// A context whose key material follows from `seed` so a failure can be
+    /// replayed.
+    pub async fn with_seed(seed: u64) -> Self {
         let mut names = BTreeMap::new();
         names.insert(Public.id(), PUBLIC_NAME.into());
         TestContext {
             hives: BTreeMap::new(),
             names,
             docs: Vec::new(),
+            csprng: StdRng::seed_from_u64(seed),
+            seed,
         }
+    }
+
+    /// The seed this context was built from. Report it when a test fails.
+    pub fn seed(&self) -> u64 {
+        self.seed
     }
 
     pub fn public(&self) -> TestPublic {
@@ -364,12 +412,13 @@ impl TestContext {
     //
     // Every individual learns every other individual's contact card.
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
-        let signer = MemorySigner::generate(&mut rand::rngs::OsRng);
+        let mut hive_rng = StdRng::seed_from_u64(self.csprng.gen());
+        let signer = MemorySigner::generate(&mut hive_rng);
         let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
             signer,
             MemoryCiphertextStore::new(),
             NoListener,
-            rand::rngs::OsRng,
+            hive_rng,
         )
         .await?;
 
@@ -621,13 +670,77 @@ impl TestContext {
 
     /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
     pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
-        let to_agent = self.get_agent(from, to.id.into(), &to.name).await?;
-        let events = self.hive(from)?.static_events_for_agent(&to_agent).await;
-        let pending = self
-            .hive(to)?
-            .ingest_unsorted_static_events(events.into_values().collect())
-            .await;
-        Ok(pending.len())
+        let events = self.static_events_for_agent(from, to).await?;
+        self.deliver(to, events).await
+    }
+
+    /// Sends everything except one kind of event, to make a dependency visible.
+    pub async fn sync_without(
+        &mut self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+        kind: TestEventKind,
+    ) -> Result<usize> {
+        let events: Vec<_> = self
+            .static_events_for_agent(from, to)
+            .await?
+            .into_iter()
+            .filter(|e| kind_of(e) != kind)
+            .collect();
+        self.deliver(to, events).await
+    }
+
+    /// Sends everything `batch` events at a time, ingesting each batch before the next.
+    pub async fn sync_in_batches(
+        &mut self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+        batch: usize,
+    ) -> Result<usize> {
+        assert!(batch > 0, "a batch of zero events would never terminate");
+        let events = self.static_events_for_agent(from, to).await?;
+        let mut pending = 0;
+        for chunk in events.chunks(batch) {
+            pending = self.deliver(to, chunk.to_vec()).await?;
+        }
+        Ok(pending)
+    }
+
+    /// Sends everything in an order decided by `seed`, so a failing order can be replayed.
+    pub async fn sync_shuffled(
+        &mut self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+        seed: u64,
+    ) -> Result<usize> {
+        let mut events = self.static_events_for_agent(from, to).await?;
+        events.shuffle(&mut StdRng::seed_from_u64(seed));
+        self.deliver(to, events).await
+    }
+
+    /// What `from` would send `to`, without sending it. This is what `to`'s memberships
+    /// entitle it to hear about.
+    pub async fn static_events_for(
+        &self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+    ) -> Result<Vec<TestStaticEvent>> {
+        Ok(self
+            .static_events_for_agent(from, to)
+            .await?
+            .iter()
+            .map(|e| TestStaticEvent { kind: kind_of(e) })
+            .collect())
+    }
+
+    /// How many events `who` has that it cannot yet apply.
+    pub async fn pending_events(&self, who: &TestIndividual) -> Result<usize> {
+        let s = self.hive(who)?.stats().await;
+        Ok((s.pending_prekeys_expanded
+            + s.pending_prekey_rotated
+            + s.pending_cgka_operation
+            + s.pending_delegated
+            + s.pending_revoked) as usize)
     }
 
     /// Sends events between every pair of individuals.
@@ -648,8 +761,35 @@ impl TestContext {
     }
 
     /////////////////////
-    /// Internal details
+    // Internal details
     /////////////////////
+    async fn static_events_for_agent(
+        &self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+    ) -> Result<Vec<StaticEvent<[u8; 32]>>> {
+        let to_agent = self.get_agent(from, to.id.into(), &to.name).await?;
+        Ok(self
+            .hive(from)?
+            .static_events_for_agent(&to_agent)
+            .await
+            .into_values()
+            .collect())
+    }
+
+    /// Deliver events and return a count of how many are still waiting on a dependency.
+    async fn deliver(
+        &self,
+        to: &TestIndividual,
+        events: Vec<StaticEvent<[u8; 32]>>,
+    ) -> Result<usize> {
+        Ok(self
+            .hive(to)?
+            .ingest_unsorted_static_events(events)
+            .await
+            .len())
+    }
+
     fn name_of(&self, id: Identifier, fallback: &str) -> Arc<str> {
         self.names
             .get(&id)

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -911,6 +911,18 @@ impl TestContext {
         self.deliver(to, events).await
     }
 
+    /// Sends `to` everything the public agent may see, like a sync server.
+    pub async fn sync_as_public(
+        &mut self,
+        from: &TestIndividual,
+        to: &TestIndividual,
+    ) -> Result<usize> {
+        let individual = Public.individual();
+        let public = Agent::Individual(individual.id(), Arc::new(Mutex::new(individual)));
+        let events = self.events_for(from, &public).await?;
+        self.deliver(to, events).await
+    }
+
     /// Sends everything except one kind of event, to make a dependency visible.
     pub async fn sync_without(
         &mut self,
@@ -1025,9 +1037,20 @@ impl TestContext {
         to: &TestIndividual,
     ) -> Result<Vec<([u8; 32], StaticEvent<[u8; 32]>)>> {
         let to_agent = self.get_agent(from, to.identity.into(), &to.name).await?;
+        self.events_for(from, &to_agent).await
+    }
+
+    /// Everything `agent`'s memberships entitle it to hear about, each with its digest.
+    ///
+    /// Unlike `static_events_for_agent`, this can be an agent unknown to the `TestContext`.
+    async fn events_for(
+        &self,
+        from: &TestIndividual,
+        agent: &AgentHandle,
+    ) -> Result<Vec<([u8; 32], StaticEvent<[u8; 32]>)>> {
         Ok(self
             .hive(from)?
-            .static_events_for_agent(&to_agent)
+            .static_events_for_agent(agent)
             .await
             .into_iter()
             .map(|(digest, event)| (*digest.raw.as_bytes(), event))

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -4,7 +4,6 @@
 // without this every binary warns about the methods it does not happen to call.
 #![allow(dead_code)]
 
-use dupe::Dupe;
 use futures::lock::Mutex;
 use keyhive_core::{
     access::Access,
@@ -834,7 +833,7 @@ impl TestContext {
         &self,
         who: &TestIndividual,
         doc: &TestDocument,
-        after: &[TestEncryptedContent],
+        after: &[&TestEncryptedContent],
         content: &[u8],
     ) -> Result<TestEncryptedContent> {
         let mut pred_refs = Vec::with_capacity(after.len());
@@ -865,7 +864,7 @@ impl TestContext {
         &self,
         who: &TestIndividual,
         doc: &TestDocument,
-        after: &[TestEncryptedContent],
+        after: &[&TestEncryptedContent],
         content: &[u8],
     ) -> Result<TestEncryptedContent> {
         let mut ancestors = std::collections::HashMap::with_capacity(after.len());

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -69,6 +69,14 @@ pub enum TestError {
     #[error("{individual:?} does not know about {subject:?}. Sync first.")]
     NotSynced { individual: String, subject: String },
 
+    /// A predecessor was named that belongs to a different document.
+    #[error("that content is in {holds:?}, not in {doc:?}")]
+    WrongDocument { holds: String, doc: String },
+
+    /// Prekey secrets belong to one identity and cannot be given to another.
+    #[error("{from:?} and {to:?} are different identities")]
+    DifferentIdentity { from: String, to: String },
+
     /// Anything else, wrapping the underlying error as a `String`.
     #[error("{0}")]
     Other(String),
@@ -191,6 +199,17 @@ pub struct TestDocument {
 pub struct TestEncryptedContent {
     doc: DocumentId,
     inner: beekem::encrypted::EncryptedContent<Vec<u8>, [u8; 32]>,
+}
+
+impl std::fmt::Debug for TestEncryptedContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let r = self.inner.content_ref;
+        write!(
+            f,
+            "TestEncryptedContent({:02x}{:02x}.. in {})",
+            r[0], r[1], self.doc
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -527,11 +546,10 @@ impl TestContext {
         to: &TestIndividual,
     ) -> Result<usize> {
         if from.identity != to.identity {
-            return Err(format!(
-                "{:?} and {:?} are different people; prekey secrets are not transferable",
-                from.name, to.name
-            )
-            .into());
+            return Err(TestError::DifferentIdentity {
+                from: from.name.to_string(),
+                to: to.name.to_string(),
+            });
         }
         let blob = self
             .hive(from)?
@@ -831,11 +849,12 @@ impl TestContext {
         let mut pred_refs = Vec::with_capacity(after.len());
         for pred in after {
             if pred.doc != doc.id {
-                return Err(format!(
-                    "a predecessor belongs to another document, not {:?}",
-                    doc.name
-                )
-                .into());
+                return Err(TestError::WrongDocument {
+                    holds: self
+                        .name_of(pred.doc.into(), "another document")
+                        .to_string(),
+                    doc: doc.name.to_string(),
+                });
             }
             pred_refs.push(pred.inner.content_ref);
         }

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -15,10 +15,13 @@ use keyhive_core::{
         identifier::Identifier,
         individual::{id::IndividualId, ReceivePrekeyOpError},
         membered::Membered,
+        public::Public,
     },
     store::ciphertext::memory::MemoryCiphertextStore,
 };
-use keyhive_crypto::{signed::SigningError, signer::memory::MemorySigner};
+use keyhive_crypto::{
+    signed::SigningError, signer::memory::MemorySigner, symmetric_key::SymmetricKey,
+};
 use nonempty::nonempty;
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -179,9 +182,83 @@ pub struct TestDocument {
 }
 
 /// Encrypted content, with the id for the document it belongs to.
+#[derive(Clone)]
 pub struct TestEncryptedContent {
     doc: DocumentId,
     inner: beekem::encrypted::EncryptedContent<Vec<u8>, [u8; 32]>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TestPublic;
+
+const PUBLIC_NAME: &str = "public";
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TestSymmetricKey(SymmetricKey);
+
+impl std::fmt::Debug for TestSymmetricKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let b = self.0.as_slice();
+        write!(f, "TestSymmetricKey({:02x}{:02x}..)", b[0], b[1])
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TestDelegation {
+    digest: [u8; 32],
+    issuer: Arc<str>,
+    audience: Arc<str>,
+    subject: Arc<str>,
+    can: Access,
+}
+
+impl TestDelegation {
+    /// Who signed it.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Who received the access.
+    pub fn audience(&self) -> &str {
+        &self.audience
+    }
+
+    /// The group or document the access is over.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// How much access it conveys before attenuation.
+    pub fn can(&self) -> Access {
+        self.can
+    }
+}
+
+impl std::fmt::Debug for TestDelegation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}-{:?}->{} over {} ({:02x}{:02x}{:02x}{:02x})",
+            self.issuer,
+            self.can,
+            self.audience,
+            self.subject,
+            self.digest[0],
+            self.digest[1],
+            self.digest[2],
+            self.digest[3],
+        )
+    }
+}
+
+impl TestEncryptedContent {
+    /// The same content with one bit of the ciphertext flipped.
+    pub fn with_a_flipped_bit(&self) -> Self {
+        let mut copy = self.clone();
+        let last = copy.inner.ciphertext.len() - 1;
+        copy.inner.ciphertext[last] ^= 1;
+        copy
+    }
 }
 
 impl TestIndividual {
@@ -241,6 +318,15 @@ impl TestAgent for TestDocument {
     }
 }
 
+impl TestAgent for TestPublic {
+    fn agent_id(&self) -> Identifier {
+        Public.id()
+    }
+    fn name(&self) -> &str {
+        PUBLIC_NAME
+    }
+}
+
 impl TestMembered for TestGroup {
     fn as_membered(&self) -> TestMemberedRef<'_> {
         TestMemberedRef::Group(self)
@@ -261,16 +347,22 @@ pub struct TestContext {
 
 impl TestContext {
     pub async fn new() -> Self {
+        let mut names = BTreeMap::new();
+        names.insert(Public.id(), PUBLIC_NAME.into());
         TestContext {
             hives: BTreeMap::new(),
-            names: BTreeMap::new(),
+            names,
             docs: Vec::new(),
         }
     }
 
-    /// Create a keyhive identity.
-    ///
-    /// Every individual learns every other individual's contact card.
+    pub fn public(&self) -> TestPublic {
+        TestPublic
+    }
+
+    // Create a keyhive identity.
+    //
+    // Every individual learns every other individual's contact card.
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
         let signer = MemorySigner::generate(&mut rand::rngs::OsRng);
         let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
@@ -333,15 +425,21 @@ impl TestContext {
         audience: &impl TestAgent,
         membered: &impl TestMembered,
         can: Access,
-    ) -> Result<()> {
+    ) -> Result<TestDelegation> {
         let hive = self.hive(issuer)?;
         let aud = self
             .get_agent(issuer, audience.agent_id(), audience.name())
             .await?;
         let res = self.get_membered(issuer, membered).await?;
         let relevant = self.other_relevant_docs(issuer, membered).await;
-        hive.add_member(aud, &res, can, &relevant).await?;
-        Ok(())
+        let update = hive.add_member(aud, &res, can, &relevant).await?;
+        Ok(TestDelegation {
+            digest: *update.delegation.digest().raw.as_bytes(),
+            issuer: issuer.name.clone(),
+            audience: self.name_of(audience.agent_id(), audience.name()),
+            subject: self.name_of(membered.agent_id(), membered.name()),
+            can,
+        })
     }
 
     /// `issuer` removes `audience`'s membership in `resource`.
@@ -427,6 +525,60 @@ impl TestContext {
             .is_ok())
     }
 
+    /// The higher of `who`'s own access and public's access.
+    pub async fn best_access(
+        &self,
+        who: &impl TestAgent,
+        doc: &TestDocument,
+    ) -> Result<Option<Access>> {
+        let observer = self.individual_by_id(doc.owner)?;
+        let handle = self.get_membered(&observer, doc).await?;
+        let members = self.hive(&observer)?.reachable_members(handle).await;
+        let direct = members.get(&who.agent_id()).map(|(_, a)| *a);
+        let public = members.get(&Public.id()).map(|(_, a)| *a);
+        Ok(match (direct, public) {
+            (Some(d), Some(p)) => Some(d.max(p)),
+            (Some(d), None) => Some(d),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
+        })
+    }
+
+    /// Whether `who` has received the events needed to learn about `what`.
+    ///
+    /// `effective_access` returns `None` both for no access and for never having heard of
+    /// the subject. This can distinguish those cases.
+    pub async fn has_received(&self, who: &TestIndividual, what: &impl TestAgent) -> Result<bool> {
+        Ok(self.hive(who)?.get_agent(what.agent_id()).await.is_some())
+    }
+
+    /// The application secret `who` derives for this content, or `None` if they cannot.
+    pub async fn derived_key(
+        &self,
+        who: &TestIndividual,
+        ct: &TestEncryptedContent,
+    ) -> Result<Option<TestSymmetricKey>> {
+        let Ok(handle) = self.get_document_by_id(who, ct.doc).await else {
+            return Ok(None);
+        };
+        Ok(self
+            .hive(who)?
+            .try_decrypt_content_keyed(handle, &ct.inner)
+            .await
+            .ok()
+            .map(|(_, key)| TestSymmetricKey(key)))
+    }
+
+    pub fn decrypt_with_key(
+        &self,
+        ct: &TestEncryptedContent,
+        key: &TestSymmetricKey,
+    ) -> Result<Vec<u8>> {
+        ct.inner
+            .try_decrypt(key.0)
+            .map_err(|e| TestError::Other(format!("decryption with the given key failed: {e}")))
+    }
+
     pub async fn encrypt(
         &mut self,
         who: &TestIndividual,
@@ -443,6 +595,28 @@ impl TestContext {
             doc: doc.id,
             inner: out.encrypted_content().clone(),
         })
+    }
+
+    /// Encrypt. Returns the application secret the content went under.
+    pub async fn encrypt_keyed(
+        &mut self,
+        who: &TestIndividual,
+        doc: &TestDocument,
+        content: &[u8],
+    ) -> Result<(TestEncryptedContent, TestSymmetricKey)> {
+        let handle = self.get_document(who, doc).await?;
+        let content_ref: [u8; 32] = blake3::hash(content).into();
+        let (out, key) = self
+            .hive(who)?
+            .try_encrypt_content_keyed(handle, &content_ref, &vec![], content)
+            .await?;
+        Ok((
+            TestEncryptedContent {
+                doc: doc.id,
+                inner: out.encrypted_content().clone(),
+            },
+            TestSymmetricKey(key),
+        ))
     }
 
     /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
@@ -476,6 +650,13 @@ impl TestContext {
     /////////////////////
     /// Internal details
     /////////////////////
+    fn name_of(&self, id: Identifier, fallback: &str) -> Arc<str> {
+        self.names
+            .get(&id)
+            .cloned()
+            .unwrap_or_else(|| fallback.into())
+    }
+
     fn hive(&self, who: &TestIndividual) -> Result<&Hive> {
         self.hives
             .get(&who.id)
@@ -561,12 +742,7 @@ impl TestContext {
     }
 
     /// `add_member`'s `other_relevant_docs` argument: documents whose key state is
-    /// affected, **excluding the resource itself**.
-    ///
-    /// The exclusion is essential and not visible from the signature. `add_member` locks
-    /// the resource and then locks each document in this list; `futures::lock::Mutex` is
-    /// not reentrant, so passing the resource here makes the task hang, with no panic and
-    /// no timeout.
+    /// affected, excluding the resource itself.
     #[allow(clippy::type_complexity)]
     async fn other_relevant_docs(
         &self,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -129,35 +129,23 @@ impl From<RevokeMemberError> for TestError {
     }
 }
 
-impl From<SigningError> for TestError {
-    fn from(e: SigningError) -> Self {
-        TestError::Other(e.to_string())
-    }
+macro_rules! other_from {
+    ($($t:ty),+ $(,)?) => {$(
+        impl From<$t> for TestError {
+            fn from(e: $t) -> Self {
+                TestError::Other(e.to_string())
+            }
+        }
+    )+};
 }
 
-impl From<GenerateDocError> for TestError {
-    fn from(e: GenerateDocError) -> Self {
-        TestError::Other(e.to_string())
-    }
-}
-
-impl From<EncryptContentError> for TestError {
-    fn from(e: EncryptContentError) -> Self {
-        TestError::Other(e.to_string())
-    }
-}
-
-impl From<DecryptError> for TestError {
-    fn from(e: DecryptError) -> Self {
-        TestError::Other(e.to_string())
-    }
-}
-
-impl From<ReceivePrekeyOpError> for TestError {
-    fn from(e: ReceivePrekeyOpError) -> Self {
-        TestError::Other(e.to_string())
-    }
-}
+other_from!(
+    SigningError,
+    GenerateDocError,
+    EncryptContentError,
+    DecryptError,
+    ReceivePrekeyOpError,
+);
 
 impl From<String> for TestError {
     fn from(m: String) -> Self {
@@ -414,6 +402,10 @@ pub trait TestAgent {
 pub trait TestMembered: TestAgent {
     #[doc(hidden)]
     fn as_membered(&self) -> TestMemberedRef<'_>;
+
+    /// The instance that created it, which is the one whose view is authoritative.
+    #[doc(hidden)]
+    fn owner(&self) -> TestInstanceId;
 }
 
 #[doc(hidden)]
@@ -461,10 +453,16 @@ impl TestMembered for TestGroup {
     fn as_membered(&self) -> TestMemberedRef<'_> {
         TestMemberedRef::Group(self)
     }
+    fn owner(&self) -> TestInstanceId {
+        self.owner
+    }
 }
 impl TestMembered for TestDocument {
     fn as_membered(&self) -> TestMemberedRef<'_> {
         TestMemberedRef::Doc(self)
+    }
+    fn owner(&self) -> TestInstanceId {
+        self.owner
     }
 }
 
@@ -621,8 +619,8 @@ impl TestContext {
         Ok(TestDelegation {
             digest: *update.delegation.digest().raw.as_bytes(),
             issuer: issuer.name.clone(),
-            audience: self.name_of(audience.agent_id(), audience.name()),
-            subject: self.name_of(membered.agent_id(), membered.name()),
+            audience: self.name_of(audience.agent_id()),
+            subject: self.name_of(membered.agent_id()),
             can,
         })
     }
@@ -697,17 +695,13 @@ impl TestContext {
         &self,
         membered: &impl TestMembered,
     ) -> Result<BTreeMap<String, Access>> {
-        let owner = match membered.as_membered() {
-            TestMemberedRef::Group(g) => g.owner,
-            TestMemberedRef::Doc(d) => d.owner,
-        };
-        let observer = self.individual_by_instance(owner)?;
+        let observer = self.individual_by_instance(membered.owner())?;
         let handle = self.get_membered(&observer, membered).await?;
         let raw = self.hive(&observer)?.reachable_members(handle).await;
 
         Ok(raw
             .into_iter()
-            .map(|(id, (_, access))| (self.name_of(id, &id.to_string()).to_string(), access))
+            .map(|(id, (_, access))| (self.name_of(id).to_string(), access))
             .collect())
     }
 
@@ -719,18 +713,14 @@ impl TestContext {
         &self,
         membered: &impl TestMembered,
     ) -> Result<BTreeMap<String, Access>> {
-        let owner = match membered.as_membered() {
-            TestMemberedRef::Group(g) => g.owner,
-            TestMemberedRef::Doc(d) => d.owner,
-        };
-        let observer = self.individual_by_instance(owner)?;
+        let observer = self.individual_by_instance(membered.owner())?;
         let raw = match self.get_membered(&observer, membered).await? {
             Membered::Group(_, group) => group.lock().await.revoked_members(),
             Membered::Document(_, doc) => doc.lock().await.revoked_members(),
         };
         Ok(raw
             .into_iter()
-            .map(|(id, (_, access))| (self.name_of(id, &id.to_string()).to_string(), access))
+            .map(|(id, (_, access))| (self.name_of(id).to_string(), access))
             .collect())
     }
 
@@ -741,15 +731,15 @@ impl TestContext {
         membered: &impl TestMembered,
     ) -> Result<Vec<TestDelegation>> {
         let handle = self.get_membered(observer, membered).await?;
-        let subject = self.name_of(membered.agent_id(), membered.name());
+        let subject = self.name_of(membered.agent_id());
         let mut out = vec![];
         for signed in handle.members().await.values().flat_map(|d| d.iter()) {
             let issuer = Identifier::from(signed.issuer());
             let audience = signed.payload().delegate().id();
             out.push(TestDelegation {
                 digest: *signed.digest().raw.as_bytes(),
-                issuer: self.name_of(issuer, &issuer.to_string()),
-                audience: self.name_of(audience, &audience.to_string()),
+                issuer: self.name_of(issuer),
+                audience: self.name_of(audience),
                 subject: subject.clone(),
                 can: signed.payload().can(),
             });
@@ -851,9 +841,7 @@ impl TestContext {
         for pred in after {
             if pred.doc != doc.id {
                 return Err(TestError::WrongDocument {
-                    holds: self
-                        .name_of(pred.doc.into(), "another document")
-                        .to_string(),
+                    holds: self.name_of(pred.doc.into()).to_string(),
                     doc: doc.name.to_string(),
                 });
             }
@@ -880,7 +868,7 @@ impl TestContext {
         after: &[TestEncryptedContent],
         content: &[u8],
     ) -> Result<TestEncryptedContent> {
-        let mut ancestors = std::collections::HashMap::new();
+        let mut ancestors = std::collections::HashMap::with_capacity(after.len());
         for pred in after {
             let key = self.derived_key(who, pred).await?.ok_or_else(|| {
                 format!(
@@ -1189,8 +1177,8 @@ impl TestContext {
     pub async fn sync_all_unsent(&mut self) -> Result<()> {
         const MAX_ROUNDS: usize = 8;
         let everyone: Vec<TestIndividual> = self.handles.values().cloned().collect();
+        let mut before = self.state_signature().await;
         for _ in 0..MAX_ROUNDS {
-            let before = self.state_signature().await;
             for from in &everyone {
                 for to in &everyone {
                     if from.instance != to.instance {
@@ -1198,9 +1186,11 @@ impl TestContext {
                     }
                 }
             }
-            if self.state_signature().await == before {
+            let after = self.state_signature().await;
+            if after == before {
                 return Ok(());
             }
+            before = after;
         }
         Err(format!("sync_all_unsent did not settle in {MAX_ROUNDS} rounds").into())
     }
@@ -1280,11 +1270,12 @@ impl TestContext {
         Ok(())
     }
 
-    fn name_of(&self, id: Identifier, fallback: &str) -> Arc<str> {
+    /// The name this context knows `id` by, or the id itself if it knows none.
+    fn name_of(&self, id: Identifier) -> Arc<str> {
         self.names
             .get(&id)
             .cloned()
-            .unwrap_or_else(|| fallback.into())
+            .unwrap_or_else(|| id.to_string().into())
     }
 
     fn hive(&self, who: &TestIndividual) -> Result<&Hive> {
@@ -1438,7 +1429,7 @@ impl TestContext {
                 continue;
             }
             if let Ok(h) = self.get_document(observer, d).await {
-                out.push(h.dupe());
+                out.push(h);
             }
         }
         out

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -597,16 +597,40 @@ impl TestContext {
         })
     }
 
-    /// `issuer` removes `audience`'s membership in `resource`.
+    /// `issuer` removes `audience`'s membership in `resource`, keeping everyone else.
+    ///
+    /// Members `audience` had admitted keep their access, because their delegations are
+    /// re-issued under the issuer.
     pub async fn revoke(
         &mut self,
         issuer: &TestIndividual,
         audience: &impl TestAgent,
         membered: &impl TestMembered,
     ) -> Result<()> {
+        self.revoke_inner(issuer, audience, membered, true).await
+    }
+
+    /// `issuer` removes `audience`, and everyone whose only way in was through them.
+    pub async fn revoke_cascading(
+        &mut self,
+        issuer: &TestIndividual,
+        audience: &impl TestAgent,
+        membered: &impl TestMembered,
+    ) -> Result<()> {
+        self.revoke_inner(issuer, audience, membered, false).await
+    }
+
+    async fn revoke_inner(
+        &mut self,
+        issuer: &TestIndividual,
+        audience: &impl TestAgent,
+        membered: &impl TestMembered,
+        retain_all_other_members: bool,
+    ) -> Result<()> {
         let hive = self.hive(issuer)?;
         let res = self.get_membered(issuer, membered).await?;
-        hive.revoke_member(audience.agent_id(), true, &res).await?;
+        hive.revoke_member(audience.agent_id(), retain_all_other_members, &res)
+            .await?;
         Ok(())
     }
 

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -252,6 +252,7 @@ impl TestEncryptedContent {
     /// The same content with one bit of the ciphertext flipped.
     pub fn with_a_flipped_bit(&self) -> Self {
         let mut copy = self.clone();
+        assert!(!copy.inner.ciphertext.is_empty(), "nothing to flip");
         let last = copy.inner.ciphertext.len() - 1;
         copy.inner.ciphertext[last] ^= 1;
         copy
@@ -890,7 +891,7 @@ impl TestContext {
         to: &TestIndividual,
         batch: usize,
     ) -> Result<usize> {
-        assert!(batch > 0, "a batch of zero events would never terminate");
+        assert!(batch > 0, "a batch size of zero is not a valid chunk size");
         let events = self.static_events_for_agent(from, to).await?;
         let mut pending = 0;
         for chunk in events.chunks(batch) {

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -462,9 +462,9 @@ impl TestContext {
         TestPublic
     }
 
-    // Create a keyhive identity.
-    //
-    // Every individual learns every other individual's contact card.
+    /// Create a keyhive identity.
+    ///
+    /// Every individual learns every other individual's contact card.
     pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
         let mut hive_rng = StdRng::seed_from_u64(self.csprng.gen());
         let signer = MemorySigner::generate(&mut hive_rng);
@@ -1151,8 +1151,8 @@ impl TestContext {
             })
     }
 
-    /// `add_member`'s `other_relevant_docs` argument: documents whose key state is
-    /// affected, excluding the resource itself.
+    /// `add_member`'s `other_relevant_docs` argument: every document the observer can open,
+    /// excluding the resource itself.
     #[allow(clippy::type_complexity)]
     async fn other_relevant_docs(
         &self,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -1,0 +1,591 @@
+//! A testing facade for `Keyhive`.
+
+#![allow(dead_code)]
+
+use dupe::Dupe;
+use futures::lock::Mutex;
+use keyhive_core::{
+    access::Access,
+    keyhive::{EncryptContentError, Keyhive},
+    listener::no_listener::NoListener,
+    principal::{
+        agent::Agent,
+        document::{id::DocumentId, AddMemberError, DecryptError, Document, GenerateDocError},
+        group::{error::AddError, id::GroupId, AddGroupMemberError, RevokeMemberError},
+        identifier::Identifier,
+        individual::{id::IndividualId, ReceivePrekeyOpError},
+        membered::Membered,
+    },
+    store::ciphertext::memory::MemoryCiphertextStore,
+};
+use keyhive_crypto::{signed::SigningError, signer::memory::MemorySigner};
+use nonempty::nonempty;
+use std::{collections::BTreeMap, sync::Arc};
+
+type Hive = Keyhive<
+    future_form::Sendable,
+    MemorySigner,
+    [u8; 32],
+    Vec<u8>,
+    MemoryCiphertextStore<[u8; 32], Vec<u8>>,
+    NoListener,
+    rand::rngs::OsRng,
+>;
+
+pub type Result<T> = std::result::Result<T, TestError>;
+
+/// Why an operation was refused.
+#[derive(Debug)]
+pub enum TestError {
+    /// The issuer holds some access over the resource, but less than they tried to delegate.
+    Escalation { wanted: Access, held: Access },
+    /// The issuer has no access to the resource.
+    NoAuthority,
+    /// The individual has not yet received the required events.
+    NotSynced { individual: String, subject: String },
+    /// Anything else, wrapping the underlying error as a `String`.
+    Other(String),
+}
+
+impl std::fmt::Display for TestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TestError::Escalation { wanted, held } => {
+                write!(f, "escalation: wanted {wanted}, holds {held}")
+            }
+            TestError::NoAuthority => write!(f, "no authority over that resource"),
+            TestError::NotSynced {
+                individual,
+                subject,
+            } => {
+                write!(
+                    f,
+                    "{individual:?} does not know about {subject:?}. Sync first."
+                )
+            }
+            TestError::Other(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for TestError {}
+
+impl From<AddMemberError> for TestError {
+    fn from(e: AddMemberError) -> Self {
+        match e {
+            AddMemberError::AddMemberError(inner) => inner.into(),
+            other => TestError::Other(other.to_string()),
+        }
+    }
+}
+
+impl From<AddGroupMemberError> for TestError {
+    fn from(e: AddGroupMemberError) -> Self {
+        match e {
+            AddGroupMemberError::AccessEscalation { wanted, have } => {
+                TestError::Escalation { wanted, held: have }
+            }
+            AddGroupMemberError::AddError(AddError::Escelation { claimed, proof }) => {
+                TestError::Escalation {
+                    wanted: claimed,
+                    held: proof,
+                }
+            }
+            AddGroupMemberError::NoProof => TestError::NoAuthority,
+            other => TestError::Other(other.to_string()),
+        }
+    }
+}
+
+impl From<RevokeMemberError> for TestError {
+    fn from(e: RevokeMemberError) -> Self {
+        match e {
+            RevokeMemberError::NoProof => TestError::NoAuthority,
+            RevokeMemberError::AddError(AddError::Escelation { claimed, proof }) => {
+                TestError::Escalation {
+                    wanted: claimed,
+                    held: proof,
+                }
+            }
+            RevokeMemberError::RedelegationError(inner) => inner.into(),
+            other => TestError::Other(other.to_string()),
+        }
+    }
+}
+
+/// Everything else the facade calls reports as `Other`. None of it is a refusal that a
+/// test should be distinguishing.
+impl From<SigningError> for TestError {
+    fn from(e: SigningError) -> Self {
+        TestError::Other(e.to_string())
+    }
+}
+
+impl From<GenerateDocError> for TestError {
+    fn from(e: GenerateDocError) -> Self {
+        TestError::Other(e.to_string())
+    }
+}
+
+impl From<EncryptContentError> for TestError {
+    fn from(e: EncryptContentError) -> Self {
+        TestError::Other(e.to_string())
+    }
+}
+
+impl From<DecryptError> for TestError {
+    fn from(e: DecryptError) -> Self {
+        TestError::Other(e.to_string())
+    }
+}
+
+impl From<ReceivePrekeyOpError> for TestError {
+    fn from(e: ReceivePrekeyOpError) -> Self {
+        TestError::Other(e.to_string())
+    }
+}
+
+impl From<String> for TestError {
+    fn from(m: String) -> Self {
+        TestError::Other(m)
+    }
+}
+
+impl From<&str> for TestError {
+    fn from(m: &str) -> Self {
+        TestError::Other(m.to_string())
+    }
+}
+
+/// A keyhive identity with their own `Keyhive` instance and signing key.
+#[derive(Clone, Debug)]
+pub struct TestIndividual {
+    id: IndividualId,
+    name: Arc<str>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestGroup {
+    id: GroupId,
+    name: Arc<str>,
+    owner: IndividualId,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestDocument {
+    id: DocumentId,
+    name: Arc<str>,
+    owner: IndividualId,
+}
+
+/// Encrypted content, with the id for the document it belongs to.
+pub struct TestEncryptedContent {
+    doc: DocumentId,
+    inner: beekem::encrypted::EncryptedContent<Vec<u8>, [u8; 32]>,
+}
+
+impl TestIndividual {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+impl TestGroup {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+impl TestDocument {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub trait TestAgent {
+    fn agent_id(&self) -> Identifier;
+    fn name(&self) -> &str;
+}
+
+pub trait TestMembered: TestAgent {
+    #[doc(hidden)]
+    fn as_membered(&self) -> TestMemberedRef<'_>;
+}
+
+#[doc(hidden)]
+pub enum TestMemberedRef<'a> {
+    Group(&'a TestGroup),
+    Doc(&'a TestDocument),
+}
+
+impl TestAgent for TestIndividual {
+    fn agent_id(&self) -> Identifier {
+        self.id.into()
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+impl TestAgent for TestGroup {
+    fn agent_id(&self) -> Identifier {
+        self.id.into()
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+impl TestAgent for TestDocument {
+    fn agent_id(&self) -> Identifier {
+        self.id.into()
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl TestMembered for TestGroup {
+    fn as_membered(&self) -> TestMemberedRef<'_> {
+        TestMemberedRef::Group(self)
+    }
+}
+impl TestMembered for TestDocument {
+    fn as_membered(&self) -> TestMemberedRef<'_> {
+        TestMemberedRef::Doc(self)
+    }
+}
+
+/// A set of individuals, groups and documents, with one `Keyhive` instance per individual.
+pub struct TestContext {
+    hives: BTreeMap<IndividualId, Hive>,
+    names: BTreeMap<Identifier, Arc<str>>,
+    docs: Vec<TestDocument>,
+}
+
+impl TestContext {
+    pub async fn new() -> Self {
+        TestContext {
+            hives: BTreeMap::new(),
+            names: BTreeMap::new(),
+            docs: Vec::new(),
+        }
+    }
+
+    /// Create a keyhive identity.
+    ///
+    /// Every individual learns every other individual's contact card.
+    pub async fn individual(&mut self, name: &str) -> Result<TestIndividual> {
+        let signer = MemorySigner::generate(&mut rand::rngs::OsRng);
+        let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::generate(
+            signer,
+            MemoryCiphertextStore::new(),
+            NoListener,
+            rand::rngs::OsRng,
+        )
+        .await?;
+
+        let card = hive.contact_card().await?;
+        for other in self.hives.values() {
+            other.receive_contact_card(&card).await?;
+            hive.receive_contact_card(&other.contact_card().await?)
+                .await?;
+        }
+
+        let id = hive.id();
+        let name: Arc<str> = name.into();
+        self.names.insert(id.into(), name.clone());
+        self.hives.insert(id, hive);
+        Ok(TestIndividual { id, name })
+    }
+
+    pub async fn group(&mut self, owner: &TestIndividual, name: &str) -> Result<TestGroup> {
+        let g = self.hive(owner)?.generate_group(vec![]).await?;
+        let id = { g.lock().await.group_id() };
+        let name: Arc<str> = name.into();
+        self.names.insert(id.into(), name.clone());
+        Ok(TestGroup {
+            id,
+            name,
+            owner: owner.id,
+        })
+    }
+
+    pub async fn doc(&mut self, owner: &TestIndividual, name: &str) -> Result<TestDocument> {
+        let d = self
+            .hive(owner)?
+            .generate_doc(vec![], nonempty![[0u8; 32]])
+            .await?;
+        let id = { d.lock().await.doc_id() };
+        let name: Arc<str> = name.into();
+        self.names.insert(id.into(), name.clone());
+        let handle = TestDocument {
+            id,
+            name,
+            owner: owner.id,
+        };
+        self.docs.push(handle.clone());
+        Ok(handle)
+    }
+
+    /// `issuer` delegates `can` over `resource` to `audience`.
+    ///
+    /// Signed by the issuer. Returns an error if the issuer may not do this.
+    pub async fn delegate(
+        &mut self,
+        issuer: &TestIndividual,
+        audience: &impl TestAgent,
+        membered: &impl TestMembered,
+        can: Access,
+    ) -> Result<()> {
+        let hive = self.hive(issuer)?;
+        let aud = self
+            .get_agent(issuer, audience.agent_id(), audience.name())
+            .await?;
+        let res = self.get_membered(issuer, membered).await?;
+        let relevant = self.other_relevant_docs(issuer, membered).await;
+        hive.add_member(aud, &res, can, &relevant).await?;
+        Ok(())
+    }
+
+    /// `issuer` removes `audience`'s membership in `resource`.
+    pub async fn revoke(
+        &mut self,
+        issuer: &TestIndividual,
+        audience: &impl TestAgent,
+        membered: &impl TestMembered,
+    ) -> Result<()> {
+        let hive = self.hive(issuer)?;
+        let res = self.get_membered(issuer, membered).await?;
+        hive.revoke_member(audience.agent_id(), true, &res).await?;
+        Ok(())
+    }
+
+    /// The access level keyhive claims `who` has over `doc`, according to the
+    /// document owner's instance. `None` means no access.
+    pub async fn effective_access(
+        &self,
+        who: &impl TestAgent,
+        doc: &TestDocument,
+    ) -> Result<Option<Access>> {
+        let observer = self.individual_by_id(doc.owner)?;
+        self.effective_access_seen_by(&observer, who, doc).await
+    }
+
+    /// The access level keyhive claims `who` has over `doc`, according to
+    /// `observer`'s instance. Use this to check that two individuals agree.
+    pub async fn effective_access_seen_by(
+        &self,
+        observer: &TestIndividual,
+        who: &impl TestAgent,
+        doc: &TestDocument,
+    ) -> Result<Option<Access>> {
+        let hive = self.hive(observer)?;
+        let agent = self.get_agent(observer, who.agent_id(), who.name()).await?;
+        Ok(hive
+            .docs_reachable_by_agent(&agent)
+            .await
+            .get(&doc.id)
+            .map(|a| a.can()))
+    }
+
+    /// Everyone who can reach `membered`, including through nested groups.
+    pub async fn transitive_members_of(
+        &self,
+        membered: &impl TestMembered,
+    ) -> Result<BTreeMap<String, Access>> {
+        let owner = match membered.as_membered() {
+            TestMemberedRef::Group(g) => g.owner,
+            TestMemberedRef::Doc(d) => d.owner,
+        };
+        let observer = self.individual_by_id(owner)?;
+        let handle = self.get_membered(&observer, membered).await?;
+        let raw = self.hive(&observer)?.reachable_members(handle).await;
+
+        Ok(raw
+            .into_iter()
+            .map(|(id, (_, access))| {
+                let name = self
+                    .names
+                    .get(&id)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| format!("<{id}>"));
+                (name, access)
+            })
+            .collect())
+    }
+
+    /// Whether `who` can actually decrypt the encrypted content.
+    pub async fn can_decrypt(
+        &self,
+        who: &TestIndividual,
+        ct: &TestEncryptedContent,
+    ) -> Result<bool> {
+        let Ok(handle) = self.get_document_by_id(who, ct.doc).await else {
+            return Ok(false);
+        };
+        Ok(self
+            .hive(who)?
+            .try_decrypt_content(handle, &ct.inner)
+            .await
+            .is_ok())
+    }
+
+    pub async fn encrypt(
+        &mut self,
+        who: &TestIndividual,
+        doc: &TestDocument,
+        content: &[u8],
+    ) -> Result<TestEncryptedContent> {
+        let handle = self.get_document(who, doc).await?;
+        let content_ref: [u8; 32] = blake3::hash(content).into();
+        let out = self
+            .hive(who)?
+            .try_encrypt_content(handle, &content_ref, &vec![], content)
+            .await?;
+        Ok(TestEncryptedContent {
+            doc: doc.id,
+            inner: out.encrypted_content().clone(),
+        })
+    }
+
+    /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
+    pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
+        let to_agent = self.get_agent(from, to.id.into(), &to.name).await?;
+        let events = self.hive(from)?.static_events_for_agent(&to_agent).await;
+        let pending = self
+            .hive(to)?
+            .ingest_unsorted_static_events(events.into_values().collect())
+            .await;
+        Ok(pending.len())
+    }
+
+    /// Sends events between every pair of individuals.
+    pub async fn sync_all(&mut self) -> Result<()> {
+        let ids: Vec<IndividualId> = self.hives.keys().copied().collect();
+        for _ in 0..3 {
+            for from in &ids {
+                for to in &ids {
+                    if from != to {
+                        let a = self.individual_by_id(*from)?;
+                        let b = self.individual_by_id(*to)?;
+                        self.sync(&a, &b).await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /////////////////////
+    /// Internal details
+    /////////////////////
+    fn hive(&self, who: &TestIndividual) -> Result<&Hive> {
+        self.hives
+            .get(&who.id)
+            .ok_or_else(|| format!("{:?} is not in this TestContext", who.name).into())
+    }
+
+    fn individual_by_id(&self, id: IndividualId) -> Result<TestIndividual> {
+        let name = self
+            .names
+            .get(&id.into())
+            .ok_or("unknown actor id")?
+            .clone();
+        Ok(TestIndividual { id, name })
+    }
+
+    async fn get_agent(
+        &self,
+        observer: &TestIndividual,
+        id: Identifier,
+        name: &str,
+    ) -> Result<Agent<future_form::Sendable, MemorySigner, [u8; 32], NoListener>> {
+        self.hive(observer)?
+            .get_agent(id)
+            .await
+            .ok_or_else(|| TestError::NotSynced {
+                individual: observer.name.to_string(),
+                subject: name.to_string(),
+            })
+    }
+
+    async fn get_membered(
+        &self,
+        observer: &TestIndividual,
+        membered: &impl TestMembered,
+    ) -> Result<Membered<future_form::Sendable, MemorySigner, [u8; 32], NoListener>> {
+        match membered.as_membered() {
+            TestMemberedRef::Doc(d) => {
+                let h = self.get_document(observer, d).await?;
+                Ok(Membered::Document(d.id, h))
+            }
+            TestMemberedRef::Group(g) => {
+                let h = self.hive(observer)?.get_group(g.id).await.ok_or_else(|| {
+                    TestError::NotSynced {
+                        individual: observer.name.to_string(),
+                        subject: g.name.to_string(),
+                    }
+                })?;
+                Ok(Membered::Group(g.id, h))
+            }
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn get_document(
+        &self,
+        observer: &TestIndividual,
+        doc: &TestDocument,
+    ) -> Result<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>>
+    {
+        self.hive(observer)?
+            .get_document(doc.id)
+            .await
+            .ok_or_else(|| TestError::NotSynced {
+                individual: observer.name.to_string(),
+                subject: doc.name.to_string(),
+            })
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn get_document_by_id(
+        &self,
+        observer: &TestIndividual,
+        id: DocumentId,
+    ) -> Result<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>>
+    {
+        self.hive(observer)?
+            .get_document(id)
+            .await
+            .ok_or_else(|| TestError::NotSynced {
+                individual: observer.name.to_string(),
+                subject: format!("{id}"),
+            })
+    }
+
+    /// `add_member`'s `other_relevant_docs` argument: documents whose key state is
+    /// affected, **excluding the resource itself**.
+    ///
+    /// The exclusion is essential and not visible from the signature. `add_member` locks
+    /// the resource and then locks each document in this list; `futures::lock::Mutex` is
+    /// not reentrant, so passing the resource here makes the task hang, with no panic and
+    /// no timeout.
+    #[allow(clippy::type_complexity)]
+    async fn other_relevant_docs(
+        &self,
+        observer: &TestIndividual,
+        membered: &impl TestMembered,
+    ) -> Vec<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>> {
+        let exclude = match membered.as_membered() {
+            TestMemberedRef::Doc(d) => Some(d.id),
+            TestMemberedRef::Group(_) => None,
+        };
+        let mut out = vec![];
+        for d in &self.docs {
+            if Some(d.id) == exclude {
+                continue;
+            }
+            if let Ok(h) = self.get_document(observer, d).await {
+                out.push(h.dupe());
+            }
+        }
+        out
+    }
+}

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -795,6 +795,23 @@ impl TestContext {
         ))
     }
 
+    /// Force PCS update on `doc`.
+    ///
+    /// Returns the share key the rotation introduced.
+    pub async fn force_pcs_update(
+        &mut self,
+        who: &TestIndividual,
+        doc: &TestDocument,
+    ) -> Result<TestShareKey> {
+        let handle = self.get_document(who, doc).await?;
+        let (_op, new_key, _secret) = self
+            .hive(who)?
+            .force_pcs_update(handle)
+            .await
+            .map_err(|e| TestError::Other(e.to_string()))?;
+        Ok(TestShareKey(new_key))
+    }
+
     /// Add a prekey. Returns the key that was added.
     pub async fn expand_prekeys(&mut self, who: &TestIndividual) -> Result<TestShareKey> {
         let op = self.hive(who)?.expand_prekeys().await?;

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -1,5 +1,7 @@
 //! A testing facade for `Keyhive`.
 
+// Each integration test binary compiles the whole facade and uses a subset of it, so
+// without this every binary warns about the methods it does not happen to call.
 #![allow(dead_code)]
 
 use dupe::Dupe;
@@ -308,6 +310,11 @@ impl TestCausalDecryption {
         self.recovered.iter().cloned().collect()
     }
 
+    /// How many pieces of content the walk decrypted, counting repeats.
+    pub fn recovered_count(&self) -> usize {
+        self.recovered.len()
+    }
+
     /// How many ancestors were listed but not held. Their keys are known, so they can be
     /// decrypted as soon as they arrive.
     pub fn missing(&self) -> usize {
@@ -448,8 +455,10 @@ pub struct TestContext {
     names: BTreeMap<Identifier, Arc<str>>,
     csprng: StdRng,
     docs: Vec<TestDocument>,
-    /// The digests each instance has already received, so `sync` sends a delta.
+    /// The digests each instance has already received, so `sync_all_unsent` sends a delta.
     delivered: BTreeMap<TestInstanceId, BTreeSet<[u8; 32]>>,
+    /// How many events were last delivered.
+    last_delivery: usize,
     /// Each instance's ciphertext store. Storing what you wrote or received is the
     /// application's role, and causal decryption reads back out of it.
     stores: BTreeMap<TestInstanceId, ContentStore>,
@@ -467,6 +476,7 @@ impl TestContext {
             names,
             docs: Vec::new(),
             delivered: BTreeMap::new(),
+            last_delivery: 0,
             stores: BTreeMap::new(),
             csprng: StdRng::from_rng(rand::rngs::OsRng).expect("OsRng cannot fail"),
         }
@@ -1050,6 +1060,12 @@ impl TestContext {
     ///
     /// Events `to` has already received are not sent again.
     pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
+        let events = self.static_events_for_agent(from, to).await?;
+        self.deliver(to, events).await
+    }
+
+    /// Sends `from`'s events to `to`, skipping any this context has already delivered.
+    async fn sync_unsent(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
         let known = self.delivered.get(&to.instance);
         let events: Vec<_> = self
             .static_events_for_agent(from, to)
@@ -1133,6 +1149,11 @@ impl TestContext {
             .collect())
     }
 
+    /// How many events the last `sync*` call delivered.
+    pub fn events_last_delivered(&self) -> usize {
+        self.last_delivery
+    }
+
     /// How many events `who` has that it cannot yet apply.
     pub async fn pending_events(&self, who: &TestIndividual) -> Result<usize> {
         let s = self.hive(who)?.stats().await;
@@ -1143,10 +1164,9 @@ impl TestContext {
             + s.pending_revoked) as usize)
     }
 
-    /// Sends events between every pair of individuals, until a round changes nothing.
-    ///
-    /// Events that no instance can apply are left pending.
-    pub async fn sync_all(&mut self) -> Result<()> {
+    /// Sends every pair of individuals the events they have not been sent until a round
+    /// changes nothing.
+    pub async fn sync_all_unsent(&mut self) -> Result<()> {
         const MAX_ROUNDS: usize = 8;
         let everyone: Vec<TestIndividual> = self.handles.values().cloned().collect();
         for _ in 0..MAX_ROUNDS {
@@ -1154,7 +1174,7 @@ impl TestContext {
             for from in &everyone {
                 for to in &everyone {
                     if from.instance != to.instance {
-                        self.sync(from, to).await?;
+                        self.sync_unsent(from, to).await?;
                     }
                 }
             }
@@ -1162,7 +1182,7 @@ impl TestContext {
                 return Ok(());
             }
         }
-        Err(format!("sync_all did not settle in {MAX_ROUNDS} rounds").into())
+        Err(format!("sync_all_unsent did not settle in {MAX_ROUNDS} rounds").into())
     }
 
     /////////////////////
@@ -1215,6 +1235,7 @@ impl TestContext {
         events: Vec<([u8; 32], StaticEvent<[u8; 32]>)>,
     ) -> Result<usize> {
         let (digests, events): (Vec<_>, Vec<_>) = events.into_iter().unzip();
+        self.last_delivery = events.len();
         let pending = self
             .hive(to)?
             .ingest_unsorted_static_events(events)

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -6,6 +6,7 @@ use dupe::Dupe;
 use futures::lock::Mutex;
 use keyhive_core::{
     access::Access,
+    archive::Archive,
     event::static_event::StaticEvent,
     keyhive::{EncryptContentError, Keyhive},
     listener::no_listener::NoListener,
@@ -14,14 +15,15 @@ use keyhive_core::{
         document::{id::DocumentId, AddMemberError, DecryptError, Document, GenerateDocError},
         group::{error::AddError, id::GroupId, AddGroupMemberError, RevokeMemberError},
         identifier::Identifier,
-        individual::{id::IndividualId, ReceivePrekeyOpError},
+        individual::{id::IndividualId, op::KeyOp, Individual, ReceivePrekeyOpError},
         membered::Membered,
         public::Public,
     },
     store::ciphertext::memory::MemoryCiphertextStore,
 };
 use keyhive_crypto::{
-    signed::SigningError, signer::memory::MemorySigner, symmetric_key::SymmetricKey,
+    share_key::ShareKey, signed::SigningError, signer::memory::MemorySigner,
+    symmetric_key::SymmetricKey,
 };
 use nonempty::nonempty;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
@@ -264,6 +266,43 @@ impl TestEncryptedContent {
         copy.inner.ciphertext[last] ^= 1;
         copy
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TestShareKey(ShareKey);
+
+impl std::fmt::Debug for TestShareKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let b = self.0.to_bytes();
+        write!(f, "TestShareKey({:02x}{:02x}..)", b[0], b[1])
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TestPrekeyOp {
+    Added {
+        new: TestShareKey,
+    },
+    Rotated {
+        old: TestShareKey,
+        new: TestShareKey,
+    },
+}
+
+impl TestPrekeyOp {
+    /// The key this op introduced.
+    pub fn new_key(&self) -> TestShareKey {
+        match self {
+            TestPrekeyOp::Added { new } | TestPrekeyOp::Rotated { new, .. } => *new,
+        }
+    }
+}
+
+/// A serialized `Keyhive`.
+#[derive(Clone)]
+pub struct TestArchive {
+    identity: IndividualId,
+    inner: Archive<[u8; 32]>,
 }
 
 #[derive(Clone, Debug)]
@@ -711,6 +750,110 @@ impl TestContext {
         ))
     }
 
+    /// Add a prekey. Returns the key that was added.
+    pub async fn expand_prekeys(&mut self, who: &TestIndividual) -> Result<TestShareKey> {
+        let op = self.hive(who)?.expand_prekeys().await?;
+        Ok(TestShareKey(op.payload().share_key))
+    }
+
+    /// Replace `old` with a fresh key. Returns the key that replaced it.
+    pub async fn rotate_prekey(
+        &mut self,
+        who: &TestIndividual,
+        old: &TestShareKey,
+    ) -> Result<TestShareKey> {
+        let op = self.hive(who)?.rotate_prekey(old.0).await?;
+        Ok(TestShareKey(op.payload().new))
+    }
+
+    /// Every prekey op `observer` holds for `of`.
+    pub async fn prekey_ops(
+        &self,
+        observer: &TestIndividual,
+        of: &TestIndividual,
+    ) -> Result<Vec<TestPrekeyOp>> {
+        let indie = self.get_individual(observer, of).await?;
+        let locked = indie.lock().await;
+        Ok(locked
+            .prekey_ops()
+            .values()
+            .map(|op| match op.as_ref() {
+                KeyOp::Add(add) => TestPrekeyOp::Added {
+                    new: TestShareKey(add.payload().share_key),
+                },
+                KeyOp::Rotate(rot) => TestPrekeyOp::Rotated {
+                    old: TestShareKey(rot.payload().old),
+                    new: TestShareKey(rot.payload().new),
+                },
+            })
+            .collect())
+    }
+
+    /// Serialize `who`'s instance.
+    pub async fn archive(&self, who: &TestIndividual) -> Result<TestArchive> {
+        Ok(TestArchive {
+            identity: who.identity,
+            inner: self.hive(who)?.into_archive().await,
+        })
+    }
+
+    /// Rebuild an instance from an archive, as a new instance of the same identity.
+    ///
+    /// The restored instance gets a fresh ciphertext store. It can compute keys but
+    /// holds no stored ciphertexts of its own.
+    pub async fn rebuild_from_archive(
+        &mut self,
+        archive: &TestArchive,
+        name: &str,
+    ) -> Result<TestIndividual> {
+        let signer = self
+            .signers
+            .get(&archive.identity)
+            .ok_or("that archive's identity was not created by this TestContext")?
+            .clone();
+        let hive = Keyhive::<future_form::Sendable, _, _, _, _, _, _>::try_from_archive(
+            &archive.inner,
+            signer,
+            MemoryCiphertextStore::new(),
+            NoListener,
+            Arc::new(Mutex::new(StdRng::seed_from_u64(self.csprng.gen()))),
+        )
+        .await
+        .map_err(|e| TestError::Other(e.to_string()))?;
+
+        let identity = hive.id();
+        let instance = TestInstanceId(self.next_instance);
+        self.next_instance += 1;
+        let card = hive.contact_card().await?;
+        for other in self.hives.values() {
+            other.receive_contact_card(&card).await?;
+            hive.receive_contact_card(&other.contact_card().await?)
+                .await?;
+        }
+        self.hives.insert(instance, hive);
+        let handle = TestIndividual {
+            identity,
+            instance,
+            name: name.into(),
+        };
+        self.handles.insert(instance, handle.clone());
+        Ok(handle)
+    }
+
+    /// Merge an archive into a live instance. Returns how many events remain pending.
+    pub async fn ingest_archive(
+        &mut self,
+        into: &TestIndividual,
+        archive: &TestArchive,
+    ) -> Result<usize> {
+        Ok(self
+            .hive(into)?
+            .ingest_archive(archive.inner.clone())
+            .await
+            .map_err(|e| TestError::Other(e.to_string()))?
+            .len())
+    }
+
     /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
     pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
         let events = self.static_events_for_agent(from, to).await?;
@@ -851,6 +994,21 @@ impl TestContext {
             .get(&instance)
             .cloned()
             .ok_or_else(|| "unknown instance".into())
+    }
+
+    /// `observer`'s copy of what it knows about the person `of`.
+    async fn get_individual(
+        &self,
+        observer: &TestIndividual,
+        of: &TestIndividual,
+    ) -> Result<Arc<Mutex<Individual>>> {
+        self.hive(observer)?
+            .get_individual(of.identity)
+            .await
+            .ok_or_else(|| TestError::NotSynced {
+                individual: observer.name.to_string(),
+                subject: of.name.to_string(),
+            })
     }
 
     async fn add_instance(

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -742,6 +742,37 @@ impl TestContext {
         })
     }
 
+    /// Encrypt content that follows `after` in the document's content DAG.
+    pub async fn encrypt_after(
+        &mut self,
+        who: &TestIndividual,
+        doc: &TestDocument,
+        after: &[TestEncryptedContent],
+        content: &[u8],
+    ) -> Result<TestEncryptedContent> {
+        let mut pred_refs = Vec::with_capacity(after.len());
+        for pred in after {
+            if pred.doc != doc.id {
+                return Err(format!(
+                    "a predecessor belongs to another document, not {:?}",
+                    doc.name
+                )
+                .into());
+            }
+            pred_refs.push(pred.inner.content_ref);
+        }
+        let handle = self.get_document(who, doc).await?;
+        let content_ref: [u8; 32] = blake3::hash(content).into();
+        let out = self
+            .hive(who)?
+            .try_encrypt_content(handle, &content_ref, &pred_refs, content)
+            .await?;
+        Ok(TestEncryptedContent {
+            doc: doc.id,
+            inner: out.encrypted_content().clone(),
+        })
+    }
+
     /// Encrypt. Returns the application secret the content went under.
     pub async fn encrypt_keyed(
         &mut self,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -27,7 +27,10 @@ use keyhive_crypto::{
 };
 use nonempty::nonempty;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 type Hive = Keyhive<
     future_form::Sendable,
@@ -766,7 +769,18 @@ impl TestContext {
         Ok(TestShareKey(op.payload().new))
     }
 
-    /// Every prekey op `observer` holds for `of`.
+    /// The prekeys `observer` holds for `of`.
+    pub async fn prekeys(
+        &self,
+        observer: &TestIndividual,
+        of: &TestIndividual,
+    ) -> Result<BTreeSet<TestShareKey>> {
+        let indie = self.get_individual(observer, of).await?;
+        let locked = indie.lock().await;
+        Ok(locked.prekeys().iter().copied().map(TestShareKey).collect())
+    }
+
+    /// The prekey ops `observer` holds for `of`.
     pub async fn prekey_ops(
         &self,
         observer: &TestIndividual,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -439,7 +439,6 @@ pub struct TestContext {
     next_instance: u32,
     names: BTreeMap<Identifier, Arc<str>>,
     csprng: StdRng,
-    seed: u64,
     docs: Vec<TestDocument>,
     /// The digests each instance has already received, so `sync` sends a delta.
     delivered: BTreeMap<TestInstanceId, BTreeSet<[u8; 32]>>,
@@ -449,14 +448,7 @@ pub struct TestContext {
 }
 
 impl TestContext {
-    /// A context, recording a seed for replayability.
     pub async fn new() -> Self {
-        Self::with_seed(rand::rngs::OsRng.gen()).await
-    }
-
-    /// A context whose key material follows from `seed` so a failure can be
-    /// replayed.
-    pub async fn with_seed(seed: u64) -> Self {
         let mut names = BTreeMap::new();
         names.insert(Public.id(), PUBLIC_NAME.into());
         TestContext {
@@ -468,14 +460,8 @@ impl TestContext {
             docs: Vec::new(),
             delivered: BTreeMap::new(),
             stores: BTreeMap::new(),
-            csprng: StdRng::seed_from_u64(seed),
-            seed,
+            csprng: StdRng::from_rng(rand::rngs::OsRng).expect("OsRng cannot fail"),
         }
-    }
-
-    /// The seed this context was built from. Report it when a test fails.
-    pub fn seed(&self) -> u64 {
-        self.seed
     }
 
     pub fn public(&self) -> TestPublic {

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -44,6 +44,10 @@ type Hive = Keyhive<
     StdRng,
 >;
 
+type AgentHandle = Agent<future_form::Sendable, MemorySigner, [u8; 32], NoListener>;
+type MemberedHandle = Membered<future_form::Sendable, MemorySigner, [u8; 32], NoListener>;
+type DocHandle = Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>;
+
 pub type Result<T> = std::result::Result<T, TestError>;
 
 /// Why an operation was refused.
@@ -663,14 +667,7 @@ impl TestContext {
         who: &TestIndividual,
         ct: &TestEncryptedContent,
     ) -> Result<bool> {
-        let Ok(handle) = self.get_document_by_id(who, ct.doc).await else {
-            return Ok(false);
-        };
-        Ok(self
-            .hive(who)?
-            .try_decrypt_content(handle, &ct.inner)
-            .await
-            .is_ok())
+        Ok(self.derived_key(who, ct).await?.is_some())
     }
 
     /// The higher of `who`'s own access and public's access.
@@ -684,12 +681,8 @@ impl TestContext {
         let members = self.hive(&observer)?.reachable_members(handle).await;
         let direct = members.get(&who.agent_id()).map(|(_, a)| *a);
         let public = members.get(&Public.id()).map(|(_, a)| *a);
-        Ok(match (direct, public) {
-            (Some(d), Some(p)) => Some(d.max(p)),
-            (Some(d), None) => Some(d),
-            (None, Some(p)) => Some(p),
-            (None, None) => None,
-        })
+        // None sorts below every Some, so this is "the better of the two, if either".
+        Ok(direct.max(public))
     }
 
     /// Whether `who` has received the events needed to learn about `what`.
@@ -706,7 +699,7 @@ impl TestContext {
         who: &TestIndividual,
         ct: &TestEncryptedContent,
     ) -> Result<Option<TestSymmetricKey>> {
-        let Ok(handle) = self.get_document_by_id(who, ct.doc).await else {
+        let Ok(handle) = self.get_document_by_id(who, ct.doc, "that document").await else {
             return Ok(None);
         };
         Ok(self
@@ -733,16 +726,7 @@ impl TestContext {
         doc: &TestDocument,
         content: &[u8],
     ) -> Result<TestEncryptedContent> {
-        let handle = self.get_document(who, doc).await?;
-        let content_ref: [u8; 32] = blake3::hash(content).into();
-        let out = self
-            .hive(who)?
-            .try_encrypt_content(handle, &content_ref, &vec![], content)
-            .await?;
-        Ok(TestEncryptedContent {
-            doc: doc.id,
-            inner: out.encrypted_content().clone(),
-        })
+        Ok(self.encrypt_keyed(who, doc, content).await?.0)
     }
 
     /// Encrypt content that follows `after` in the document's content DAG.
@@ -903,11 +887,11 @@ impl TestContext {
     pub async fn ingest_archive(
         &mut self,
         into: &TestIndividual,
-        archive: &TestArchive,
+        archive: TestArchive,
     ) -> Result<usize> {
         Ok(self
             .hive(into)?
-            .ingest_archive(archive.inner.clone())
+            .ingest_archive(archive.inner)
             .await
             .map_err(|e| TestError::Other(e.to_string()))?
             .len())
@@ -1003,15 +987,13 @@ impl TestContext {
     /// Events that no instance can apply are left pending.
     pub async fn sync_all(&mut self) -> Result<()> {
         const MAX_ROUNDS: usize = 8;
-        let ids: Vec<TestInstanceId> = self.hives.keys().copied().collect();
+        let everyone: Vec<TestIndividual> = self.handles.values().cloned().collect();
         for _ in 0..MAX_ROUNDS {
             let before = self.state_signature().await;
-            for from in &ids {
-                for to in &ids {
-                    if from != to {
-                        let a = self.individual_by_instance(*from)?;
-                        let b = self.individual_by_instance(*to)?;
-                        self.sync(&a, &b).await?;
+            for from in &everyone {
+                for to in &everyone {
+                    if from.instance != to.instance {
+                        self.sync(from, to).await?;
                     }
                 }
             }
@@ -1152,7 +1134,7 @@ impl TestContext {
         observer: &TestIndividual,
         id: Identifier,
         name: &str,
-    ) -> Result<Agent<future_form::Sendable, MemorySigner, [u8; 32], NoListener>> {
+    ) -> Result<AgentHandle> {
         self.hive(observer)?
             .get_agent(id)
             .await
@@ -1166,7 +1148,7 @@ impl TestContext {
         &self,
         observer: &TestIndividual,
         membered: &impl TestMembered,
-    ) -> Result<Membered<future_form::Sendable, MemorySigner, [u8; 32], NoListener>> {
+    ) -> Result<MemberedHandle> {
         match membered.as_membered() {
             TestMemberedRef::Doc(d) => {
                 let h = self.get_document(observer, d).await?;
@@ -1184,46 +1166,36 @@ impl TestContext {
         }
     }
 
-    #[allow(clippy::type_complexity)]
     async fn get_document(
         &self,
         observer: &TestIndividual,
         doc: &TestDocument,
-    ) -> Result<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>>
-    {
-        self.hive(observer)?
-            .get_document(doc.id)
-            .await
-            .ok_or_else(|| TestError::NotSynced {
-                individual: observer.name.to_string(),
-                subject: doc.name.to_string(),
-            })
+    ) -> Result<DocHandle> {
+        self.get_document_by_id(observer, doc.id, doc.name()).await
     }
 
-    #[allow(clippy::type_complexity)]
     async fn get_document_by_id(
         &self,
         observer: &TestIndividual,
         id: DocumentId,
-    ) -> Result<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>>
-    {
+        name: &str,
+    ) -> Result<DocHandle> {
         self.hive(observer)?
             .get_document(id)
             .await
             .ok_or_else(|| TestError::NotSynced {
                 individual: observer.name.to_string(),
-                subject: format!("{id}"),
+                subject: name.to_string(),
             })
     }
 
     /// `add_member`'s `other_relevant_docs` argument: every document the observer can open,
     /// excluding the resource itself.
-    #[allow(clippy::type_complexity)]
     async fn other_relevant_docs(
         &self,
         observer: &TestIndividual,
         membered: &impl TestMembered,
-    ) -> Vec<Arc<Mutex<Document<future_form::Sendable, MemorySigner, [u8; 32], NoListener>>>> {
+    ) -> Vec<DocHandle> {
         let exclude = match membered.as_membered() {
             TestMemberedRef::Doc(d) => Some(d.id),
             TestMemberedRef::Group(_) => None,

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -843,23 +843,7 @@ impl TestContext {
         .await
         .map_err(|e| TestError::Other(e.to_string()))?;
 
-        let identity = hive.id();
-        let instance = TestInstanceId(self.next_instance);
-        self.next_instance += 1;
-        let card = hive.contact_card().await?;
-        for other in self.hives.values() {
-            other.receive_contact_card(&card).await?;
-            hive.receive_contact_card(&other.contact_card().await?)
-                .await?;
-        }
-        self.hives.insert(instance, hive);
-        let handle = TestIndividual {
-            identity,
-            instance,
-            name: name.into(),
-        };
-        self.handles.insert(instance, handle.clone());
-        Ok(handle)
+        self.register_instance(hive, name).await
     }
 
     /// Merge an archive into a live instance. Returns how many events remain pending.
@@ -1047,6 +1031,11 @@ impl TestContext {
         )
         .await?;
 
+        self.register_instance(hive, name).await
+    }
+
+    /// Register a new instance and swap contact cards with every other instance.
+    async fn register_instance(&mut self, hive: Hive, name: &str) -> Result<TestIndividual> {
         let card = hive.contact_card().await?;
         for other in self.hives.values() {
             other.receive_contact_card(&card).await?;

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -735,14 +735,21 @@ impl TestContext {
             .collect())
     }
 
-    /// Which documents `who` reaches and at what level.
+    /// The documents `who` reaches, as `observer` sees it, and at what level.
     ///
-    /// A document delegated to Public is not included.
+    /// A document delegated to Public is not included unless it's passed as `who`.
     pub async fn documents_reachable_by(
         &self,
-        who: &TestIndividual,
+        observer: &TestIndividual,
+        who: &impl TestAgent,
     ) -> Result<BTreeMap<String, Access>> {
-        let raw = self.hive(who)?.reachable_docs().await;
+        let hive = self.hive(observer)?;
+        let raw = if observer.agent_id() == who.agent_id() {
+            hive.reachable_docs().await
+        } else {
+            let aud = self.get_agent(observer, who.agent_id(), who.name()).await?;
+            hive.docs_reachable_by_agent(&aud).await
+        };
         Ok(raw
             .into_iter()
             .map(|(id, ability)| (self.name_of(id.into()).to_string(), ability.can()))

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -308,7 +308,7 @@ impl TestCausalDecryption {
         self.recovered.iter().cloned().collect()
     }
 
-    /// How many ancestors were named but not held. Their keys are known, so they can be
+    /// How many ancestors were listed but not held. Their keys are known, so they can be
     /// decrypted as soon as they arrive.
     pub fn missing(&self) -> usize {
         self.missing

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -21,7 +21,7 @@ use keyhive_core::{
         membered::Membered,
         public::Public,
     },
-    store::ciphertext::memory::MemoryCiphertextStore,
+    store::ciphertext::{memory::MemoryCiphertextStore, CiphertextStoreExt},
 };
 use keyhive_crypto::{
     share_key::ShareKey, signed::SigningError, signer::memory::MemorySigner,
@@ -79,6 +79,14 @@ pub enum TestError {
     /// Prekey secrets belong to one identity and cannot be given to another.
     #[error("{from:?} and {to:?} are different identities")]
     DifferentIdentity { from: String, to: String },
+
+    /// The reader holds no secret key that derives this content's key.
+    #[error("no secret key for that content")]
+    NoKey,
+
+    /// A key was derived but the ciphertext did not authenticate under it.
+    #[error("the ciphertext did not authenticate")]
+    CiphertextRejected,
 
     /// Anything else, wrapping the underlying error as a `String`.
     #[error("{0}")]
@@ -142,9 +150,20 @@ other_from!(
     SigningError,
     GenerateDocError,
     EncryptContentError,
-    DecryptError,
     ReceivePrekeyOpError,
 );
+
+impl From<DecryptError> for TestError {
+    fn from(e: DecryptError) -> Self {
+        match e {
+            DecryptError::KeyNotFound => TestError::NoKey,
+            DecryptError::DecryptionFailed(_) | DecryptError::SivMismatch => {
+                TestError::CiphertextRejected
+            }
+            other => TestError::Other(other.to_string()),
+        }
+    }
+}
 
 impl From<String> for TestError {
     fn from(m: String) -> Self {
@@ -311,6 +330,7 @@ impl TestPrekeyOp {
 #[derive(Clone, Debug)]
 pub struct TestCausalDecryption {
     recovered: Vec<Vec<u8>>,
+    recovered_keys: BTreeMap<[u8; 32], SymmetricKey>,
     missing: BTreeMap<[u8; 32], SymmetricKey>,
 }
 
@@ -337,6 +357,19 @@ impl TestCausalDecryption {
             .get(&ct.inner.content_ref)
             .copied()
             .map(TestSymmetricKey)
+    }
+
+    /// The key the walk used to read a piece of content, if it read it.
+    pub fn key_for_recovered(&self, ct: &TestEncryptedContent) -> Option<TestSymmetricKey> {
+        self.recovered_keys
+            .get(&ct.inner.content_ref)
+            .copied()
+            .map(TestSymmetricKey)
+    }
+
+    /// How many distinct pieces of content the walk holds a key for.
+    pub fn recovered_key_count(&self) -> usize {
+        self.recovered_keys.len()
     }
 }
 
@@ -921,6 +954,42 @@ impl TestContext {
             .map_err(|e| TestError::Other(e.to_string()))?;
         Ok(TestCausalDecryption {
             recovered: state.complete.into_iter().map(|(_, p)| p).collect(),
+            recovered_keys: state.keys.into_iter().collect(),
+            missing: state.next.into_iter().collect(),
+        })
+    }
+
+    /// Walk back from more than one entrypoint at once.
+    ///
+    /// `Keyhive::try_causal_decrypt_content` takes a single entrypoint. A reader holding
+    /// several heads walks from all of them together, and a shared ancestor should be read
+    /// once rather than once per head.
+    pub async fn causal_decrypt_from(
+        &self,
+        who: &TestIndividual,
+        entrypoints: &[&TestEncryptedContent],
+    ) -> Result<TestCausalDecryption> {
+        let mut to_walk = Vec::new();
+        for ct in entrypoints {
+            let key = self
+                .derived_key(who, ct)
+                .await?
+                .ok_or("the reader cannot derive the key for one of the entrypoints")?;
+            to_walk.push((Arc::new(ct.inner.clone()), key.0));
+        }
+        let store = self
+            .stores
+            .get(&who.instance)
+            .ok_or_else(|| format!("{:?} is not in this TestContext", who.name))?;
+        let state = CiphertextStoreExt::<future_form::Sendable, _, _>::try_causal_decrypt(
+            store,
+            &mut to_walk,
+        )
+        .await
+        .map_err(|e| TestError::Other(e.to_string()))?;
+        Ok(TestCausalDecryption {
+            recovered: state.complete.into_iter().map(|(_, p)| p).collect(),
+            recovered_keys: state.keys.into_iter().collect(),
             missing: state.next.into_iter().collect(),
         })
     }
@@ -1159,6 +1228,22 @@ impl TestContext {
     /// How many events the last `sync*` call delivered.
     pub fn events_last_delivered(&self) -> usize {
         self.last_delivery
+    }
+
+    /// How many events of one kind `who` has that it cannot yet apply.
+    pub async fn pending_events_of_kind(
+        &self,
+        who: &TestIndividual,
+        kind: TestEventKind,
+    ) -> Result<usize> {
+        let s = self.hive(who)?.stats().await;
+        Ok(match kind {
+            TestEventKind::PrekeysExpanded => s.pending_prekeys_expanded,
+            TestEventKind::PrekeyRotated => s.pending_prekey_rotated,
+            TestEventKind::CgkaOperation => s.pending_cgka_operation,
+            TestEventKind::Delegated => s.pending_delegated,
+            TestEventKind::Revoked => s.pending_revoked,
+        } as usize)
     }
 
     /// How many events `who` has that it cannot yet apply.

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -415,6 +415,8 @@ pub struct TestContext {
     csprng: StdRng,
     seed: u64,
     docs: Vec<TestDocument>,
+    /// The digests each instance has already received, so `sync` sends a delta.
+    delivered: BTreeMap<TestInstanceId, BTreeSet<[u8; 32]>>,
 }
 
 impl TestContext {
@@ -435,6 +437,7 @@ impl TestContext {
             next_instance: 0,
             names,
             docs: Vec::new(),
+            delivered: BTreeMap::new(),
             csprng: StdRng::seed_from_u64(seed),
             seed,
         }
@@ -911,8 +914,16 @@ impl TestContext {
     }
 
     /// Sends `from`'s events to `to`. Returns how many events `to` could not yet apply.
+    ///
+    /// Events `to` has already received are not sent again.
     pub async fn sync(&mut self, from: &TestIndividual, to: &TestIndividual) -> Result<usize> {
-        let events = self.static_events_for_agent(from, to).await?;
+        let known = self.delivered.get(&to.instance);
+        let events: Vec<_> = self
+            .static_events_for_agent(from, to)
+            .await?
+            .into_iter()
+            .filter(|(digest, _)| known.is_none_or(|seen| !seen.contains(digest)))
+            .collect();
         self.deliver(to, events).await
     }
 
@@ -927,7 +938,7 @@ impl TestContext {
             .static_events_for_agent(from, to)
             .await?
             .into_iter()
-            .filter(|e| kind_of(e) != kind)
+            .filter(|(_, event)| kind_of(event) != kind)
             .collect();
         self.deliver(to, events).await
     }
@@ -971,7 +982,9 @@ impl TestContext {
             .static_events_for_agent(from, to)
             .await?
             .iter()
-            .map(|e| TestStaticEvent { kind: kind_of(e) })
+            .map(|(_, event)| TestStaticEvent {
+                kind: kind_of(event),
+            })
             .collect())
     }
 
@@ -1023,31 +1036,41 @@ impl TestContext {
         hasher.finish()
     }
 
+    /// Everything `to`'s memberships entitle it to hear about, each with its digest.
     async fn static_events_for_agent(
         &self,
         from: &TestIndividual,
         to: &TestIndividual,
-    ) -> Result<Vec<StaticEvent<[u8; 32]>>> {
+    ) -> Result<Vec<([u8; 32], StaticEvent<[u8; 32]>)>> {
         let to_agent = self.get_agent(from, to.identity.into(), &to.name).await?;
         Ok(self
             .hive(from)?
             .static_events_for_agent(&to_agent)
             .await
-            .into_values()
+            .into_iter()
+            .map(|(digest, event)| (*digest.raw.as_bytes(), event))
             .collect())
     }
 
     /// Deliver events and return a count of how many are still waiting on a dependency.
+    ///
+    /// Records what `to` received so `sync` does not send it again.
     async fn deliver(
-        &self,
+        &mut self,
         to: &TestIndividual,
-        events: Vec<StaticEvent<[u8; 32]>>,
+        events: Vec<([u8; 32], StaticEvent<[u8; 32]>)>,
     ) -> Result<usize> {
-        Ok(self
+        let (digests, events): (Vec<_>, Vec<_>) = events.into_iter().unzip();
+        let pending = self
             .hive(to)?
             .ingest_unsorted_static_events(events)
             .await
-            .len())
+            .len();
+        self.delivered
+            .entry(to.instance)
+            .or_default()
+            .extend(digests);
+        Ok(pending)
     }
 
     fn name_of(&self, id: Identifier, fallback: &str) -> Arc<str> {

--- a/keyhive_core/tests/facade/mod.rs
+++ b/keyhive_core/tests/facade/mod.rs
@@ -31,6 +31,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
+use thiserror::Error;
 
 type Hive = Keyhive<
     future_form::Sendable,
@@ -45,40 +46,24 @@ type Hive = Keyhive<
 pub type Result<T> = std::result::Result<T, TestError>;
 
 /// Why an operation was refused.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TestError {
     /// The issuer holds some access over the resource, but less than they tried to delegate.
+    #[error("escalation: wanted {wanted}, holds {held}")]
     Escalation { wanted: Access, held: Access },
+
     /// The issuer has no access to the resource.
+    #[error("no authority over that resource")]
     NoAuthority,
+
     /// The individual has not yet received the required events.
+    #[error("{individual:?} does not know about {subject:?}. Sync first.")]
     NotSynced { individual: String, subject: String },
+
     /// Anything else, wrapping the underlying error as a `String`.
+    #[error("{0}")]
     Other(String),
 }
-
-impl std::fmt::Display for TestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TestError::Escalation { wanted, held } => {
-                write!(f, "escalation: wanted {wanted}, holds {held}")
-            }
-            TestError::NoAuthority => write!(f, "no authority over that resource"),
-            TestError::NotSynced {
-                individual,
-                subject,
-            } => {
-                write!(
-                    f,
-                    "{individual:?} does not know about {subject:?}. Sync first."
-                )
-            }
-            TestError::Other(m) => write!(f, "{m}"),
-        }
-    }
-}
-
-impl std::error::Error for TestError {}
 
 impl From<AddMemberError> for TestError {
     fn from(e: AddMemberError) -> Self {

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -1,6 +1,6 @@
 mod facade;
 
-use facade::{Result, TestContext, TestError};
+use facade::{Result, TestContext, TestError, TestEventKind};
 use keyhive_core::access::Access::{Admin, Read};
 
 #[tokio::test]
@@ -102,6 +102,12 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
     assert!(
         stuck > 0,
         "the sibling's key-agreement events should be waiting, not discarded"
+    );
+    assert_eq!(
+        ctx.pending_events_of_kind(sibling, TestEventKind::CgkaOperation)
+            .await?,
+        stuck,
+        "everything waiting on the sibling is key agreement, not something else"
     );
     assert_eq!(
         ctx.pending_events(invited).await?,

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -1,0 +1,136 @@
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::{Admin, Read};
+
+#[tokio::test]
+async fn two_instances_of_one_identity_are_one_member() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let bob = ctx.individual("bob").await?;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let design_doc = ctx.doc(&bob, "design_doc").await?;
+
+    ctx.delegate(&bob, &alice, &design_doc, Read).await?;
+
+    let members = ctx.transitive_members_of(&design_doc).await?;
+    assert_eq!(members.get("alice"), Some(&Read));
+    assert_eq!(
+        members.get("alice-worker"),
+        None,
+        "the graph knows the identity, not the device"
+    );
+    assert_eq!(
+        ctx.effective_access(&alice_worker, &design_doc).await?,
+        Some(Read),
+        "a delegation to one instance is a delegation to the identity"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn either_instance_signs_as_the_identity() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.sync_all().await?;
+
+    ctx.delegate(&alice_worker, &carol, &design_doc, Admin)
+        .await?;
+
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice_worker, &carol, &design_doc)
+            .await?,
+        Some(Admin)
+    );
+
+    // Instances are separate replicas, so the first one learns of the delegation by sync like
+    // anyone else.
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice, &carol, &design_doc)
+            .await?,
+        None,
+        "the first instance doesn't know about the delegation yet"
+    );
+    ctx.sync_all().await?;
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice, &carol, &design_doc)
+            .await?,
+        Some(Admin),
+        "the first instance honours what the second signed"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let bob = ctx.individual("bob").await?;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let design_doc = ctx.doc(&bob, "design_doc").await?;
+
+    ctx.delegate(&bob, &alice, &design_doc, Read).await?;
+    let ct = ctx
+        .encrypt(&bob, &design_doc, b"invitation content")
+        .await?;
+    ctx.sync_all().await?;
+
+    // Both instances know the document and both are members.
+    assert!(ctx.has_received(&alice_worker, &design_doc).await?);
+    assert_eq!(
+        ctx.effective_access(&alice_worker, &design_doc).await?,
+        Some(Read)
+    );
+
+    // Exactly one of them holds the secret key.
+    let (invited, sibling) = if ctx.can_decrypt(&alice, &ct).await? {
+        (&alice, &alice_worker)
+    } else {
+        (&alice_worker, &alice)
+    };
+    assert!(
+        !ctx.can_decrypt(sibling, &ct).await?,
+        "only one instance was invited, so only one can read (seed {:#x})",
+        ctx.seed()
+    );
+
+    let stuck = ctx.pending_events(sibling).await?;
+    assert!(
+        stuck > 0,
+        "the sibling's key-agreement events should be waiting, not discarded"
+    );
+    assert_eq!(
+        ctx.pending_events(invited).await?,
+        0,
+        "the invited instance has nothing waiting"
+    );
+
+    let drained = ctx.share_prekey_secrets(invited, sibling).await?;
+
+    assert_eq!(
+        drained, stuck,
+        "importing the secrets drained exactly those"
+    );
+    assert_eq!(ctx.pending_events(sibling).await?, 0);
+    assert!(
+        ctx.can_decrypt(sibling, &ct).await?,
+        "and now the sibling can read it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn prekey_secrets_do_not_cross_between_identities() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+
+    assert!(
+        ctx.share_prekey_secrets(&alice, &bob).await.is_err(),
+        "alice and bob are different people"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -125,6 +125,142 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
 }
 
 #[tokio::test]
+async fn two_instances_creating_documents_independently_converge() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let reader = ctx.individual("reader").await?;
+
+    // Each instance holds the other's prekey secrets, like two clients sharing storage.
+    ctx.share_prekey_secrets(&alice, &alice_worker).await?;
+    ctx.share_prekey_secrets(&alice_worker, &alice).await?;
+
+    // Neither instance knows about the other's document when it makes it.
+    let from_alice = ctx.doc(&alice, "notes").await?;
+    ctx.delegate(&alice, &ctx.public(), &from_alice, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &from_alice).await?;
+
+    let from_worker = ctx.doc(&alice_worker, "design_doc").await?;
+    ctx.delegate(&alice_worker, &ctx.public(), &from_worker, Read)
+        .await?;
+    ctx.force_pcs_update(&alice_worker, &from_worker).await?;
+
+    ctx.sync(&alice, &alice_worker).await?;
+    ctx.sync(&alice_worker, &alice).await?;
+
+    assert!(
+        ctx.has_received(&alice, &from_worker).await?,
+        "alice learned about the document the worker made"
+    );
+    assert!(
+        ctx.has_received(&alice_worker, &from_alice).await?,
+        "and the worker about alice's"
+    );
+    assert_eq!(ctx.pending_events(&alice).await?, 0);
+    assert_eq!(
+        ctx.pending_events(&alice_worker).await?,
+        0,
+        "neither instance was left holding an event it could not place"
+    );
+
+    let alice_wrote = ctx.encrypt(&alice, &from_alice, b"from alice").await?;
+    let worker_wrote = ctx
+        .encrypt(&alice_worker, &from_worker, b"from the worker")
+        .await?;
+
+    ctx.sync_as_public(&alice, &reader).await?;
+    ctx.sync_as_public(&alice_worker, &reader).await?;
+
+    assert!(ctx.can_decrypt(&reader, &alice_wrote).await?);
+    assert!(
+        ctx.can_decrypt(&reader, &worker_wrote).await?,
+        "one reader, two instances, both documents"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revocation_and_a_redelegation_reach_the_other_instance() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let reader = ctx.individual("reader").await?;
+    ctx.share_prekey_secrets(&alice, &alice_worker).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    // When revoking and re-delegating, the second delegation cannot be applied until the
+    // revocation has been.
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.revoke(&alice, &ctx.public(), &design_doc).await?;
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+
+    ctx.sync(&alice, &alice_worker).await?;
+    assert_eq!(
+        ctx.pending_events(&alice_worker).await?,
+        0,
+        "the worker applied the revocation and the delegation that followed it"
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&alice_worker, &ctx.public(), &design_doc)
+            .await?,
+        Some(Read),
+        "and ended on the re-delegation rather than the revocation"
+    );
+
+    let worker_wrote = ctx
+        .encrypt(&alice_worker, &design_doc, b"after the re-delegation")
+        .await?;
+    ctx.sync_as_public(&alice, &reader).await?;
+    ctx.sync_as_public(&alice_worker, &reader).await?;
+
+    assert!(
+        ctx.can_decrypt(&reader, &worker_wrote).await?,
+        "the document is public again, so the reader reads what the worker wrote"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_peer_cannot_read_an_instance_it_has_not_heard_from() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+    let bob = ctx.individual("bob").await?;
+    ctx.share_prekey_secrets(&alice, &alice_worker).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync(&alice, &alice_worker).await?;
+
+    let worker_wrote = ctx
+        .encrypt(&alice_worker, &design_doc, b"written on the worker")
+        .await?;
+
+    // Everything alice has, which is everything except the worker's write.
+    ctx.sync(&alice, &bob).await?;
+    assert!(
+        ctx.has_received(&bob, &design_doc).await?,
+        "bob has the document itself"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &worker_wrote).await?,
+        "but not the key agreement the worker's write went under"
+    );
+
+    ctx.sync(&alice_worker, &bob).await?;
+    assert!(
+        ctx.can_decrypt(&bob, &worker_wrote).await?,
+        "the second round completes it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn prekey_secrets_do_not_cross_between_identities() -> Result<()> {
     let mut ctx = TestContext::with_seed(0xa11ce).await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -5,7 +5,7 @@ use keyhive_core::access::Access::{Admin, Read};
 
 #[tokio::test]
 async fn two_instances_of_one_identity_are_one_member() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let bob = ctx.individual("bob").await?;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
@@ -30,7 +30,7 @@ async fn two_instances_of_one_identity_are_one_member() -> Result<()> {
 
 #[tokio::test]
 async fn either_instance_signs_as_the_identity() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
     let carol = ctx.individual("carol").await?;
@@ -66,7 +66,7 @@ async fn either_instance_signs_as_the_identity() -> Result<()> {
 
 #[tokio::test]
 async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let bob = ctx.individual("bob").await?;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
@@ -90,8 +90,7 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
     let worker_can = ctx.can_decrypt(&alice_worker, &ct).await?;
     assert!(
         alice_can ^ worker_can,
-        "only one instance was invited, so only one can read (seed {:#x})",
-        ctx.seed()
+        "only one instance was invited, so only one can read"
     );
     let (invited, sibling) = if alice_can {
         (&alice, &alice_worker)
@@ -126,7 +125,7 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
 
 #[tokio::test]
 async fn two_instances_creating_documents_independently_converge() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
     let reader = ctx.individual("reader").await?;
@@ -182,7 +181,7 @@ async fn two_instances_creating_documents_independently_converge() -> Result<()>
 
 #[tokio::test]
 async fn a_revocation_and_a_redelegation_reach_the_other_instance() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
     let reader = ctx.individual("reader").await?;
@@ -227,7 +226,7 @@ async fn a_revocation_and_a_redelegation_reach_the_other_instance() -> Result<()
 
 #[tokio::test]
 async fn a_peer_cannot_read_an_instance_it_has_not_heard_from() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
     let bob = ctx.individual("bob").await?;
@@ -262,7 +261,7 @@ async fn a_peer_cannot_read_an_instance_it_has_not_heard_from() -> Result<()> {
 
 #[tokio::test]
 async fn prekey_secrets_do_not_cross_between_identities() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xa11ce).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
 

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -35,7 +35,7 @@ async fn either_instance_signs_as_the_identity() -> Result<()> {
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
     let carol = ctx.individual("carol").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     ctx.delegate(&alice_worker, &carol, &design_doc, Admin)
         .await?;
@@ -54,7 +54,7 @@ async fn either_instance_signs_as_the_identity() -> Result<()> {
         None,
         "the first instance doesn't know about the delegation yet"
     );
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert_eq!(
         ctx.effective_access_seen_by(&alice, &carol, &design_doc)
             .await?,
@@ -76,7 +76,7 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
     let ct = ctx
         .encrypt(&bob, &design_doc, b"invitation content")
         .await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     // Both instances know the document and both are members.
     assert!(ctx.has_received(&alice_worker, &design_doc).await?);

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -86,16 +86,18 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
     );
 
     // Exactly one of them holds the secret key.
-    let (invited, sibling) = if ctx.can_decrypt(&alice, &ct).await? {
+    let alice_can = ctx.can_decrypt(&alice, &ct).await?;
+    let worker_can = ctx.can_decrypt(&alice_worker, &ct).await?;
+    assert!(
+        alice_can ^ worker_can,
+        "only one instance was invited, so only one can read (seed {:#x})",
+        ctx.seed()
+    );
+    let (invited, sibling) = if alice_can {
         (&alice, &alice_worker)
     } else {
         (&alice_worker, &alice)
     };
-    assert!(
-        !ctx.can_decrypt(sibling, &ct).await?,
-        "only one instance was invited, so only one can read (seed {:#x})",
-        ctx.seed()
-    );
 
     let stuck = ctx.pending_events(sibling).await?;
     assert!(

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -1,6 +1,6 @@
 mod facade;
 
-use facade::{Result, TestContext};
+use facade::{Result, TestContext, TestError};
 use keyhive_core::access::Access::{Admin, Read};
 
 #[tokio::test]
@@ -286,9 +286,12 @@ async fn prekey_secrets_do_not_cross_between_identities() -> Result<()> {
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
 
-    assert!(
-        ctx.share_prekey_secrets(&alice, &bob).await.is_err(),
-        "alice and bob are different people"
-    );
+    match ctx.share_prekey_secrets(&alice, &bob).await {
+        Err(TestError::DifferentIdentity { from, to }) => {
+            assert_eq!(from, "alice");
+            assert_eq!(to, "bob");
+        }
+        other => panic!("prekey secrets are not transferable between identities, got {other:?}"),
+    }
     Ok(())
 }

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -171,10 +171,19 @@ async fn two_instances_creating_documents_independently_converge() -> Result<()>
     ctx.sync_as_public(&alice, &reader).await?;
     ctx.sync_as_public(&alice_worker, &reader).await?;
 
-    assert!(ctx.can_decrypt(&reader, &alice_wrote).await?);
-    assert!(
-        ctx.can_decrypt(&reader, &worker_wrote).await?,
+    assert_eq!(
+        ctx.read(&reader, &alice_wrote).await?,
+        b"from alice".to_vec()
+    );
+    assert_eq!(
+        ctx.read(&reader, &worker_wrote).await?,
+        b"from the worker".to_vec(),
         "one reader, two instances, both documents"
+    );
+    assert_eq!(
+        ctx.pending_events(&reader).await?,
+        0,
+        "and nothing it was sent is stuck"
     );
     Ok(())
 }
@@ -217,9 +226,15 @@ async fn a_revocation_and_a_redelegation_reach_the_other_instance() -> Result<()
     ctx.sync_as_public(&alice, &reader).await?;
     ctx.sync_as_public(&alice_worker, &reader).await?;
 
-    assert!(
-        ctx.can_decrypt(&reader, &worker_wrote).await?,
+    assert_eq!(
+        ctx.read(&reader, &worker_wrote).await?,
+        b"after the re-delegation".to_vec(),
         "the document is public again, so the reader reads what the worker wrote"
+    );
+    assert_eq!(
+        ctx.pending_events(&reader).await?,
+        0,
+        "and nothing it was sent is stuck"
     );
     Ok(())
 }
@@ -252,9 +267,15 @@ async fn a_peer_cannot_read_an_instance_it_has_not_heard_from() -> Result<()> {
     );
 
     ctx.sync(&alice_worker, &bob).await?;
-    assert!(
-        ctx.can_decrypt(&bob, &worker_wrote).await?,
+    assert_eq!(
+        ctx.read(&bob, &worker_wrote).await?,
+        b"written on the worker".to_vec(),
         "the second round completes it"
+    );
+    assert_eq!(
+        ctx.pending_events(&bob).await?,
+        0,
+        "with nothing left over from the first round"
     );
     Ok(())
 }

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -45,7 +45,7 @@ async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<(
     //       - Group inner:
     //         - dave (individual)
     //         - eve (individual)
-    //     - frank (direct individual member AND also in inner)
+    //     - frank, a direct member of design_doc and also a member of inner
     //
     // Revoke outer from design_doc -> carol, dave, and eve should be removed from
     // design_doc's key group. bob and alice should remain (direct members). frank
@@ -614,7 +614,7 @@ async fn revoking_a_link_in_a_longer_cycle_removes_access() -> Result<()> {
 #[tokio::test]
 async fn breaking_a_cycle_from_both_sides_terminates() -> Result<()> {
     // first -> second -> third -> first indirect cycle. first in design_doc. bob in
-    // third. Revoke second from first AND first from third -> cycle broken. Only
+    // third. Revoke second from first AND first from third, so the cycle breaks. Only
     // first is still in design_doc directly. second and third lose access.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -16,7 +16,7 @@ async fn readers_after_writing(
     cast: &[&TestIndividual],
 ) -> Result<BTreeSet<String>> {
     let ct = ctx.encrypt(author, doc, content).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     let mut readers = BTreeSet::new();
     for who in cast {
         if ctx.can_decrypt(who, &ct).await? {
@@ -585,10 +585,10 @@ async fn revoking_a_member_keeps_the_members_they_admitted() -> Result<()> {
     ctx.delegate(&alice, &engineering, &design_doc, Read)
         .await?;
     ctx.delegate(&alice, &carol, &engineering, Admin).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     // Dan is in the group because carol put him there.
     ctx.delegate(&carol, &dan, &engineering, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
@@ -619,9 +619,9 @@ async fn a_cascading_revocation_removes_the_members_they_admitted() -> Result<()
     ctx.delegate(&alice, &engineering, &design_doc, Read)
         .await?;
     ctx.delegate(&alice, &carol, &engineering, Admin).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     ctx.delegate(&carol, &dan, &engineering, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     ctx.revoke_cascading(&alice, &carol, &engineering).await?;
 

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -1,7 +1,7 @@
 mod facade;
 
 use facade::{Result, TestContext, TestDocument, TestIndividual};
-use keyhive_core::access::Access::{Admin, Read};
+use keyhive_core::access::Access::{Admin, Edit, Read};
 use std::collections::BTreeSet;
 
 /// Write new content and report which of `cast` can read it.
@@ -629,6 +629,110 @@ async fn a_cascading_revocation_removes_the_members_they_admitted() -> Result<()
         readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
         named(&["alice"]),
         "dan was only ever in the group because of carol's delegation"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revoked_member_is_listed_with_what_they_lost() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &bob, &engineering, Edit).await?;
+    ctx.delegate(&alice, &carol, &engineering, Read).await?;
+
+    assert!(
+        ctx.revoked_members_of(&engineering).await?.is_empty(),
+        "nobody has been revoked yet"
+    );
+
+    ctx.revoke(&alice, &bob, &engineering).await?;
+
+    assert_eq!(
+        ctx.revoked_members_of(&engineering).await?.get("bob"),
+        Some(&Edit),
+        "bob is listed at the level his delegation had conveyed"
+    );
+    assert_eq!(
+        ctx.revoked_members_of(&engineering).await?.get("carol"),
+        None,
+        "and carol, who is still a member, is not listed"
+    );
+    assert_eq!(
+        ctx.transitive_members_of(&engineering).await?.get("bob"),
+        None,
+        "the two lists do not overlap"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_member_who_was_revoked_and_admitted_again_is_not_listed() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &bob, &engineering, Edit).await?;
+    ctx.revoke(&alice, &bob, &engineering).await?;
+    assert_eq!(
+        ctx.revoked_members_of(&engineering).await?.get("bob"),
+        Some(&Edit)
+    );
+
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+
+    assert_eq!(
+        ctx.revoked_members_of(&engineering).await?.get("bob"),
+        None,
+        "he is a member again, so he is not a revoked member"
+    );
+    assert_eq!(
+        ctx.transitive_members_of(&engineering).await?.get("bob"),
+        Some(&Read),
+        "at the level he was admitted at the second time"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revoked_member_is_listed_at_the_best_level_they_held() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+
+    // Two delegations to the same person, at different levels.
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &bob, &engineering, Admin).await?;
+
+    ctx.revoke(&alice, &bob, &engineering).await?;
+
+    assert_eq!(
+        ctx.revoked_members_of(&engineering).await?.get("bob"),
+        Some(&Admin),
+        "the level reported is the best one he lost, not whichever revocation came first"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_revoked_member_of_a_document_is_listed_too() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+    ctx.revoke(&alice, &bob, &design_doc).await?;
+
+    assert_eq!(
+        ctx.revoked_members_of(&design_doc).await?.get("bob"),
+        Some(&Edit),
+        "a document answers this the same way a group does"
     );
     Ok(())
 }

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -1,7 +1,7 @@
 mod facade;
 
 use facade::{Result, TestContext, TestDocument, TestIndividual};
-use keyhive_core::access::Access::Read;
+use keyhive_core::access::Access::{Admin, Read};
 use std::collections::BTreeSet;
 
 /// Write new content and report which of `cast` can read it.
@@ -568,6 +568,67 @@ async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()>
         readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
         named(&["alice", "bob"]),
         "second is still a member and holds first, so bob comes back round"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_member_keeps_the_members_they_admitted() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let carol = ctx.individual("carol").await?;
+    let dan = ctx.individual("dan").await?;
+    let cast = [&alice, &carol, &dan];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &carol, &engineering, Admin).await?;
+    ctx.sync_all().await?;
+    // Dan is in the group because carol put him there.
+    ctx.delegate(&carol, &dan, &engineering, Read).await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "carol", "dan"])
+    );
+
+    ctx.revoke(&alice, &carol, &engineering).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "dan"]),
+        "dan's delegation is re-issued rather than dropped with carol's"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "a cascading revocation keeps members admitted by the one it removes"]
+async fn a_cascading_revocation_removes_the_members_they_admitted() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let carol = ctx.individual("carol").await?;
+    let dan = ctx.individual("dan").await?;
+    let cast = [&alice, &carol, &dan];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &carol, &engineering, Admin).await?;
+    ctx.sync_all().await?;
+    ctx.delegate(&carol, &dan, &engineering, Read).await?;
+    ctx.sync_all().await?;
+
+    ctx.revoke_cascading(&alice, &carol, &engineering).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "dan was only ever in the group because of carol's delegation"
     );
     Ok(())
 }

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -684,13 +684,14 @@ async fn a_revoked_member_is_listed_with_what_they_lost() -> Result<()> {
 
     ctx.revoke(&alice, &bob, &engineering).await?;
 
+    let revoked = ctx.revoked_members_of(&engineering).await?;
     assert_eq!(
-        ctx.revoked_members_of(&engineering).await?.get("bob"),
+        revoked.get("bob"),
         Some(&Edit),
         "bob is listed at the level his delegation had conveyed"
     );
     assert_eq!(
-        ctx.revoked_members_of(&engineering).await?.get("carol"),
+        revoked.get("carol"),
         None,
         "and carol, who is still a member, is not listed"
     );

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -32,6 +32,25 @@ fn named(who: &[&str]) -> BTreeSet<String> {
 
 #[tokio::test]
 async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<()> {
+    // Revoking a group from a document removes the correct individuals from the
+    // document's key group, including nested group members, without removing
+    // individuals who are still reachable via other paths (direct membership).
+    //
+    // Setup:
+    //   design_doc has members:
+    //     - alice (owner/active)
+    //     - bob (direct individual member)
+    //     - Group outer:
+    //       - carol (individual)
+    //       - Group inner:
+    //         - dave (individual)
+    //         - eve (individual)
+    //     - frank (direct individual member AND also in inner)
+    //
+    // Revoke outer from design_doc -> carol, dave, and eve should be removed from
+    // design_doc's key group. bob and alice should remain (direct members). frank
+    // should remain because he is still a direct member of design_doc even though
+    // he was also in inner.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -41,7 +60,6 @@ async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<(
     let frank = ctx.individual("frank").await?;
     let cast = [&alice, &bob, &carol, &dave, &eve, &frank];
 
-    // inner = {dave, eve, frank}, outer = {carol, inner}
     let inner = ctx.group(&alice, "inner").await?;
     let outer = ctx.group(&alice, "outer").await?;
     for who in [&dave, &eve, &frank] {
@@ -50,7 +68,6 @@ async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<(
     ctx.delegate(&alice, &carol, &outer, Read).await?;
     ctx.delegate(&alice, &inner, &outer, Read).await?;
 
-    // The document holds bob directly, outer, and frank directly.
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
     ctx.delegate(&alice, &outer, &design_doc, Read).await?;
@@ -74,6 +91,28 @@ async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<(
 
 #[tokio::test]
 async fn revoking_a_subgroup_removes_only_the_members_it_brought() -> Result<()> {
+    // Revoking a sub-group from a parent group correctly removes the sub-group's
+    // individuals from the key groups of documents that contain the parent group,
+    // without removing individuals still reachable via other paths.
+    //
+    // Setup:
+    //   Group outer:
+    //     - alice (owner, auto-added by generate_group)
+    //     - carol (individual)
+    //     - Group inner:
+    //       - alice (owner, auto-added)
+    //       - dave (individual)
+    //       - eve (individual)
+    //       - frank (individual)
+    //
+    //   design_doc has members:
+    //     - alice (owner/active)
+    //     - bob (direct individual)
+    //     - outer
+    //     - frank (direct individual)
+    //
+    // Revoke inner from outer -> dave and eve should be removed from design_doc's
+    // key group. alice, bob, carol, and frank should remain.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -102,7 +141,6 @@ async fn revoking_a_subgroup_removes_only_the_members_it_brought() -> Result<()>
         "everyone reaches the document to begin with"
     );
 
-    // The same graph as above, revoked one level further in.
     ctx.revoke(&alice, &inner, &outer).await?;
 
     assert_eq!(
@@ -115,6 +153,10 @@ async fn revoking_a_subgroup_removes_only_the_members_it_brought() -> Result<()>
 
 #[tokio::test]
 async fn a_change_in_a_group_that_holds_a_document_leaves_the_document_alone() -> Result<()> {
+    // Revoking a sub-group from a group should not affect the key group of a doc
+    // that is a member of that group. Adding design_doc to engineering grants
+    // design_doc access to engineering, not engineering's members access to
+    // design_doc.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -124,8 +166,6 @@ async fn a_change_in_a_group_that_holds_a_document_leaves_the_document_alone() -
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
 
-    // The document is a member of engineering, so engineering reaches the document and not
-    // the other way round.
     let staff = ctx.group(&alice, "staff").await?;
     let engineering = ctx.group(&alice, "engineering").await?;
     ctx.delegate(&alice, &dave, &staff, Read).await?;
@@ -152,6 +192,10 @@ async fn a_change_in_a_group_that_holds_a_document_leaves_the_document_alone() -
 
 #[tokio::test]
 async fn adding_a_member_to_a_group_reaches_the_documents_it_holds() -> Result<()> {
+    // Adding an individual to a group should propagate key group adds to docs
+    // that contain the group as a member. If engineering is a member of
+    // design_doc, then adding bob to engineering should add bob to design_doc's
+    // key group.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -180,12 +224,13 @@ async fn adding_a_member_to_a_group_reaches_the_documents_it_holds() -> Result<(
 
 #[tokio::test]
 async fn adding_a_member_deep_in_a_chain_reaches_the_document() -> Result<()> {
+    // innermost in middle in outermost in design_doc. Adding bob to innermost
+    // should propagate to design_doc's key group.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let cast = [&alice, &bob];
 
-    // innermost in middle in outermost in the document.
     let innermost = ctx.group(&alice, "innermost").await?;
     let middle = ctx.group(&alice, "middle").await?;
     let outermost = ctx.group(&alice, "outermost").await?;
@@ -207,6 +252,8 @@ async fn adding_a_member_deep_in_a_chain_reaches_the_document() -> Result<()> {
 
 #[tokio::test]
 async fn adding_a_member_to_a_group_reaches_every_document_it_holds() -> Result<()> {
+    // engineering is a member of both design_doc and notes. Adding bob to
+    // engineering should add bob to both of their key groups.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -235,12 +282,14 @@ async fn adding_a_member_to_a_group_reaches_every_document_it_holds() -> Result<
 
 #[tokio::test]
 async fn a_member_with_a_second_route_survives_a_revocation() -> Result<()> {
+    // readers is a member of both left and right, both in design_doc. bob is in
+    // readers. Revoke readers from left -> bob should still be in design_doc's key
+    // group (reachable via right).
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let cast = [&alice, &bob];
 
-    // bob is in readers, which is in both left and right, both of which the document holds.
     let readers = ctx.group(&alice, "readers").await?;
     let left = ctx.group(&alice, "left").await?;
     let right = ctx.group(&alice, "right").await?;
@@ -270,6 +319,8 @@ async fn a_member_with_a_second_route_survives_a_revocation() -> Result<()> {
 
 #[tokio::test]
 async fn revoking_one_route_leaves_the_other_document_alone() -> Result<()> {
+    // readers in left in design_doc, and readers in right in notes. bob in readers.
+    // Revoke readers from left -> bob loses design_doc, keeps notes.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -311,6 +362,8 @@ async fn revoking_one_route_leaves_the_other_document_alone() -> Result<()> {
 
 #[tokio::test]
 async fn revoking_a_group_from_one_document_leaves_the_other() -> Result<()> {
+    // engineering in design_doc and notes. bob in engineering. Revoke engineering
+    // from design_doc -> bob loses design_doc, keeps notes.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -347,6 +400,9 @@ async fn revoking_a_group_from_one_document_leaves_the_other() -> Result<()> {
 
 #[tokio::test]
 async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
+    // readers in engineering in design_doc, and also readers directly in
+    // design_doc. bob in readers. Revoke readers from engineering -> bob still in
+    // design_doc's key group (readers is a direct member of design_doc).
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -357,7 +413,6 @@ async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
     ctx.delegate(&alice, &bob, &readers, Read).await?;
     let readers_in_engineering = ctx.delegate(&alice, &readers, &engineering, Read).await?;
 
-    // The document holds engineering, and readers as well.
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &engineering, &design_doc, Read)
         .await?;
@@ -381,6 +436,9 @@ async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
 
 #[tokio::test]
 async fn revoking_a_link_removes_everyone_below_it() -> Result<()> {
+    // innermost in middle in outermost in design_doc. bob in innermost. Revoke
+    // middle from outermost -> bob (and middle, innermost's members) should be
+    // removed from design_doc's key group.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -401,7 +459,6 @@ async fn revoking_a_link_removes_everyone_below_it() -> Result<()> {
         named(&["alice", "bob"])
     );
 
-    // Cut the middle of the chain, two levels above bob.
     ctx.revoke(&alice, &middle, &outermost).await?;
 
     assert_eq!(
@@ -414,12 +471,14 @@ async fn revoking_a_link_removes_everyone_below_it() -> Result<()> {
 
 #[tokio::test]
 async fn a_cycle_does_not_stop_an_addition_reaching_the_document() -> Result<()> {
+    // first contains second, second contains first (direct cycle). first is in
+    // design_doc. bob in second -> bob should be in design_doc's key group
+    // (reachable via second -> first -> design_doc).
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let cast = [&alice, &bob];
 
-    // Each group holds the other.
     let first = ctx.group(&alice, "first").await?;
     let second = ctx.group(&alice, "second").await?;
     ctx.delegate(&alice, &second, &first, Read).await?;
@@ -440,6 +499,11 @@ async fn a_cycle_does_not_stop_an_addition_reaching_the_document() -> Result<()>
 
 #[tokio::test]
 async fn revoking_a_link_in_a_cycle_removes_access() -> Result<()> {
+    // first <-> second cycle, first in design_doc. bob in second. Revoke second
+    // from first -> bob should be removed. The doc reaches down through first, and
+    // first no longer contains second after revocation. second still containing
+    // first doesn't help: that means first's members can access second, not that
+    // second can access design_doc.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -471,12 +535,16 @@ async fn revoking_a_link_in_a_cycle_removes_access() -> Result<()> {
 
 #[tokio::test]
 async fn revoking_a_link_in_a_longer_cycle_removes_access() -> Result<()> {
+    // first -> second -> third -> first indirect cycle. first in design_doc. bob in
+    // third. Revoke second from first -> bob loses access. The doc reaches down
+    // through first, and first no longer contains second. The remaining cycle edges
+    // (second -> third -> first) don't help: the doc only reaches down through
+    // first.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let cast = [&alice, &bob];
 
-    // first holds second holds third holds first.
     let first = ctx.group(&alice, "first").await?;
     let second = ctx.group(&alice, "second").await?;
     let third = ctx.group(&alice, "third").await?;
@@ -505,6 +573,9 @@ async fn revoking_a_link_in_a_longer_cycle_removes_access() -> Result<()> {
 
 #[tokio::test]
 async fn breaking_a_cycle_from_both_sides_terminates() -> Result<()> {
+    // first -> second -> third -> first indirect cycle. first in design_doc. bob in
+    // third. Revoke second from first AND first from third -> cycle broken. Only
+    // first is still in design_doc directly. second and third lose access.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -526,7 +597,6 @@ async fn breaking_a_cycle_from_both_sides_terminates() -> Result<()> {
         named(&["alice", "bob"])
     );
 
-    // Two revocations, each removing one edge of the cycle.
     ctx.revoke(&alice, &second, &first).await?;
     ctx.revoke(&alice, &first, &third).await?;
 
@@ -540,6 +610,10 @@ async fn breaking_a_cycle_from_both_sides_terminates() -> Result<()> {
 
 #[tokio::test]
 async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()> {
+    // first <-> second cycle, both are direct members of design_doc. bob in first.
+    // Revoke first from design_doc -> second is still a direct member of
+    // design_doc, and second contains first, so bob is still reachable via
+    // design_doc -> second -> first. bob should stay in design_doc's key group.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
@@ -551,7 +625,6 @@ async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()>
     ctx.delegate(&alice, &first, &second, Read).await?;
     ctx.delegate(&alice, &bob, &first, Read).await?;
 
-    // The document holds both halves of the cycle.
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     let first_in_doc = ctx.delegate(&alice, &first, &design_doc, Read).await?;
     ctx.delegate(&alice, &second, &design_doc, Read).await?;

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -606,6 +606,39 @@ async fn revoking_a_member_keeps_the_members_they_admitted() -> Result<()> {
 }
 
 #[tokio::test]
+async fn a_cascading_revocation_removes_the_member_it_names() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &carol];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &carol, &engineering, Admin).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "carol"])
+    );
+
+    ctx.revoke_cascading(&alice, &carol, &engineering).await?;
+
+    assert_eq!(
+        ctx.transitive_members_of(&engineering).await?.get("carol"),
+        None,
+        "carol is out of the group"
+    );
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "and out of the document the group holds"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 #[ignore = "a cascading revocation keeps members admitted by the one it removes"]
 async fn a_cascading_revocation_removes_the_members_they_admitted() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -1,0 +1,573 @@
+mod facade;
+
+use facade::{Result, TestContext, TestDocument, TestIndividual};
+use keyhive_core::access::Access::Read;
+use std::collections::BTreeSet;
+
+/// Write new content and report which of `cast` can read it.
+///
+/// Reading content written after a change is the behaviour behind "is this individual in
+/// the document's key group?", which is what these tests are about.
+async fn readers_after_writing(
+    ctx: &mut TestContext,
+    author: &TestIndividual,
+    doc: &TestDocument,
+    content: &[u8],
+    cast: &[&TestIndividual],
+) -> Result<BTreeSet<String>> {
+    let ct = ctx.encrypt(author, doc, content).await?;
+    ctx.sync_all().await?;
+    let mut readers = BTreeSet::new();
+    for who in cast {
+        if ctx.can_decrypt(who, &ct).await? {
+            readers.insert(who.name().to_string());
+        }
+    }
+    Ok(readers)
+}
+
+fn named(who: &[&str]) -> BTreeSet<String> {
+    who.iter().map(|n| n.to_string()).collect()
+}
+
+#[tokio::test]
+async fn revoking_a_group_from_a_document_removes_only_its_members() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let dave = ctx.individual("dave").await?;
+    let eve = ctx.individual("eve").await?;
+    let frank = ctx.individual("frank").await?;
+    let cast = [&alice, &bob, &carol, &dave, &eve, &frank];
+
+    // inner = {dave, eve, frank}, outer = {carol, inner}
+    let inner = ctx.group(&alice, "inner").await?;
+    let outer = ctx.group(&alice, "outer").await?;
+    for who in [&dave, &eve, &frank] {
+        ctx.delegate(&alice, who, &inner, Read).await?;
+    }
+    ctx.delegate(&alice, &carol, &outer, Read).await?;
+    ctx.delegate(&alice, &inner, &outer, Read).await?;
+
+    // The document holds bob directly, outer, and frank directly.
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.delegate(&alice, &outer, &design_doc, Read).await?;
+    ctx.delegate(&alice, &frank, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob", "carol", "dave", "eve", "frank"]),
+        "everyone reaches the document to begin with"
+    );
+
+    ctx.revoke(&alice, &outer, &design_doc).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob", "frank"]),
+        "carol, dave and eve had only the group route; frank also has a direct one"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_subgroup_removes_only_the_members_it_brought() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let dave = ctx.individual("dave").await?;
+    let eve = ctx.individual("eve").await?;
+    let frank = ctx.individual("frank").await?;
+    let cast = [&alice, &bob, &carol, &dave, &eve, &frank];
+
+    let inner = ctx.group(&alice, "inner").await?;
+    let outer = ctx.group(&alice, "outer").await?;
+    for who in [&dave, &eve, &frank] {
+        ctx.delegate(&alice, who, &inner, Read).await?;
+    }
+    ctx.delegate(&alice, &carol, &outer, Read).await?;
+    ctx.delegate(&alice, &inner, &outer, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.delegate(&alice, &outer, &design_doc, Read).await?;
+    ctx.delegate(&alice, &frank, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob", "carol", "dave", "eve", "frank"]),
+        "everyone reaches the document to begin with"
+    );
+
+    // The same graph as above, revoked one level further in.
+    ctx.revoke(&alice, &inner, &outer).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob", "carol", "frank"]),
+        "dave and eve came in through inner; carol was outer's own member"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_change_in_a_group_that_holds_a_document_leaves_the_document_alone() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let dave = ctx.individual("dave").await?;
+    let cast = [&alice, &bob, &dave];
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+
+    // The document is a member of engineering, so engineering reaches the document and not
+    // the other way round.
+    let staff = ctx.group(&alice, "staff").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &dave, &staff, Read).await?;
+    ctx.delegate(&alice, &design_doc, &engineering, Read)
+        .await?;
+    ctx.delegate(&alice, &staff, &engineering, Read).await?;
+
+    let before = readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?;
+    assert_eq!(
+        before,
+        named(&["alice", "bob"]),
+        "dave reaches engineering, which the document is a member of, so not the document"
+    );
+
+    ctx.revoke(&alice, &staff, &engineering).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        before,
+        "a revocation one level above the document does not touch its members"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn adding_a_member_to_a_group_reaches_the_documents_it_holds() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice"]),
+        "bob is in nothing yet"
+    );
+
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "joining the group joined the document's key group"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn adding_a_member_deep_in_a_chain_reaches_the_document() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    // innermost in middle in outermost in the document.
+    let innermost = ctx.group(&alice, "innermost").await?;
+    let middle = ctx.group(&alice, "middle").await?;
+    let outermost = ctx.group(&alice, "outermost").await?;
+    ctx.delegate(&alice, &innermost, &middle, Read).await?;
+    ctx.delegate(&alice, &middle, &outermost, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &outermost, &design_doc, Read).await?;
+
+    ctx.delegate(&alice, &bob, &innermost, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "three groups deep still reaches the document"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn adding_a_member_to_a_group_reaches_every_document_it_holds() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let notes = ctx.doc(&alice, "notes").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &engineering, &notes, Read).await?;
+
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"one", &cast).await?,
+        named(&["alice", "bob"])
+    );
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &notes, b"two", &cast).await?,
+        named(&["alice", "bob"]),
+        "one addition, every document the group holds"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_member_with_a_second_route_survives_a_revocation() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    // bob is in readers, which is in both left and right, both of which the document holds.
+    let readers = ctx.group(&alice, "readers").await?;
+    let left = ctx.group(&alice, "left").await?;
+    let right = ctx.group(&alice, "right").await?;
+    ctx.delegate(&alice, &bob, &readers, Read).await?;
+    let readers_in_left = ctx.delegate(&alice, &readers, &left, Read).await?;
+    ctx.delegate(&alice, &readers, &right, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &left, &design_doc, Read).await?;
+    ctx.delegate(&alice, &right, &design_doc, Read).await?;
+
+    ctx.revoke(&alice, &readers, &left).await?;
+    assert!(
+        !ctx.delegations_for(&alice, &left)
+            .await?
+            .contains(&readers_in_left),
+        "the route that was cut is really gone, so the test turns on the other one"
+    );
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "one of bob's two routes was cut, and the other still stands"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_one_route_leaves_the_other_document_alone() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let readers = ctx.group(&alice, "readers").await?;
+    ctx.delegate(&alice, &bob, &readers, Read).await?;
+
+    let left = ctx.group(&alice, "left").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &readers, &left, Read).await?;
+    ctx.delegate(&alice, &left, &design_doc, Read).await?;
+
+    let right = ctx.group(&alice, "right").await?;
+    let notes = ctx.doc(&alice, "notes").await?;
+    ctx.delegate(&alice, &readers, &right, Read).await?;
+    ctx.delegate(&alice, &right, &notes, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches design_doc to begin with"
+    );
+
+    ctx.revoke(&alice, &readers, &left).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"one", &cast).await?,
+        named(&["alice"]),
+        "bob lost the route to design_doc"
+    );
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &notes, b"two", &cast).await?,
+        named(&["alice", "bob"]),
+        "and kept the one to notes, which went through a different group"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_group_from_one_document_leaves_the_other() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let notes = ctx.doc(&alice, "notes").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &engineering, &notes, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches design_doc to begin with"
+    );
+
+    ctx.revoke(&alice, &engineering, &design_doc).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"one", &cast).await?,
+        named(&["alice"])
+    );
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &notes, b"two", &cast).await?,
+        named(&["alice", "bob"]),
+        "the same group still holds the other document"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let readers = ctx.group(&alice, "readers").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &bob, &readers, Read).await?;
+    let readers_in_engineering = ctx.delegate(&alice, &readers, &engineering, Read).await?;
+
+    // The document holds engineering, and readers as well.
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Read)
+        .await?;
+    ctx.delegate(&alice, &readers, &design_doc, Read).await?;
+
+    ctx.revoke(&alice, &readers, &engineering).await?;
+    assert!(
+        !ctx.delegations_for(&alice, &engineering)
+            .await?
+            .contains(&readers_in_engineering),
+        "readers really did lose its membership in engineering"
+    );
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "readers is still a member of the document in its own right"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_link_removes_everyone_below_it() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let innermost = ctx.group(&alice, "innermost").await?;
+    let middle = ctx.group(&alice, "middle").await?;
+    let outermost = ctx.group(&alice, "outermost").await?;
+    ctx.delegate(&alice, &bob, &innermost, Read).await?;
+    ctx.delegate(&alice, &innermost, &middle, Read).await?;
+    ctx.delegate(&alice, &middle, &outermost, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &outermost, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"])
+    );
+
+    // Cut the middle of the chain, two levels above bob.
+    ctx.revoke(&alice, &middle, &outermost).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "everything below the cut goes with it"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_cycle_does_not_stop_an_addition_reaching_the_document() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    // Each group holds the other.
+    let first = ctx.group(&alice, "first").await?;
+    let second = ctx.group(&alice, "second").await?;
+    ctx.delegate(&alice, &second, &first, Read).await?;
+    ctx.delegate(&alice, &first, &second, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &first, &design_doc, Read).await?;
+
+    ctx.delegate(&alice, &bob, &second, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches the document through second, which first holds"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_link_in_a_cycle_removes_access() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let first = ctx.group(&alice, "first").await?;
+    let second = ctx.group(&alice, "second").await?;
+    ctx.delegate(&alice, &second, &first, Read).await?;
+    ctx.delegate(&alice, &first, &second, Read).await?;
+    ctx.delegate(&alice, &bob, &second, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &first, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"])
+    );
+
+    ctx.revoke(&alice, &second, &first).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "the other half of the cycle points away from the document, so it is not a route back"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_a_link_in_a_longer_cycle_removes_access() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    // first holds second holds third holds first.
+    let first = ctx.group(&alice, "first").await?;
+    let second = ctx.group(&alice, "second").await?;
+    let third = ctx.group(&alice, "third").await?;
+    ctx.delegate(&alice, &second, &first, Read).await?;
+    ctx.delegate(&alice, &third, &second, Read).await?;
+    ctx.delegate(&alice, &first, &third, Read).await?;
+    ctx.delegate(&alice, &bob, &third, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &first, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"])
+    );
+
+    ctx.revoke(&alice, &second, &first).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "bob's only route to the document ran through the link that was cut"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn breaking_a_cycle_from_both_sides_terminates() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let first = ctx.group(&alice, "first").await?;
+    let second = ctx.group(&alice, "second").await?;
+    let third = ctx.group(&alice, "third").await?;
+    ctx.delegate(&alice, &second, &first, Read).await?;
+    ctx.delegate(&alice, &third, &second, Read).await?;
+    ctx.delegate(&alice, &first, &third, Read).await?;
+    ctx.delegate(&alice, &bob, &third, Read).await?;
+
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &first, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"])
+    );
+
+    // Two revocations, each removing one edge of the cycle.
+    ctx.revoke(&alice, &second, &first).await?;
+    ctx.revoke(&alice, &first, &third).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice"]),
+        "the cycle can be taken apart edge by edge without hanging or keeping bob"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let cast = [&alice, &bob];
+
+    let first = ctx.group(&alice, "first").await?;
+    let second = ctx.group(&alice, "second").await?;
+    ctx.delegate(&alice, &second, &first, Read).await?;
+    ctx.delegate(&alice, &first, &second, Read).await?;
+    ctx.delegate(&alice, &bob, &first, Read).await?;
+
+    // The document holds both halves of the cycle.
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let first_in_doc = ctx.delegate(&alice, &first, &design_doc, Read).await?;
+    ctx.delegate(&alice, &second, &design_doc, Read).await?;
+
+    ctx.revoke(&alice, &first, &design_doc).await?;
+    assert!(
+        !ctx.delegations_for(&alice, &design_doc)
+            .await?
+            .contains(&first_in_doc),
+        "first is no longer a member of the document in its own right"
+    );
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"after", &cast).await?,
+        named(&["alice", "bob"]),
+        "second is still a member and holds first, so bob comes back round"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/membership.rs
+++ b/keyhive_core/tests/membership.rs
@@ -229,7 +229,9 @@ async fn adding_a_member_deep_in_a_chain_reaches_the_document() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let innermost = ctx.group(&alice, "innermost").await?;
     let middle = ctx.group(&alice, "middle").await?;
@@ -239,6 +241,12 @@ async fn adding_a_member_deep_in_a_chain_reaches_the_document() -> Result<()> {
 
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &outermost, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice"]),
+        "bob is in none of the three groups yet"
+    );
 
     ctx.delegate(&alice, &bob, &innermost, Read).await?;
 
@@ -257,7 +265,9 @@ async fn adding_a_member_to_a_group_reaches_every_document_it_holds() -> Result<
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let engineering = ctx.group(&alice, "engineering").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -265,6 +275,12 @@ async fn adding_a_member_to_a_group_reaches_every_document_it_holds() -> Result<
     ctx.delegate(&alice, &engineering, &design_doc, Read)
         .await?;
     ctx.delegate(&alice, &engineering, &notes, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice"]),
+        "bob is in the group holding neither document yet"
+    );
 
     ctx.delegate(&alice, &bob, &engineering, Read).await?;
 
@@ -288,7 +304,9 @@ async fn a_member_with_a_second_route_survives_a_revocation() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let readers = ctx.group(&alice, "readers").await?;
     let left = ctx.group(&alice, "left").await?;
@@ -300,6 +318,12 @@ async fn a_member_with_a_second_route_survives_a_revocation() -> Result<()> {
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &left, &design_doc, Read).await?;
     ctx.delegate(&alice, &right, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches the document by both routes to begin with, and carol by neither"
+    );
 
     ctx.revoke(&alice, &readers, &left).await?;
     assert!(
@@ -406,7 +430,9 @@ async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let readers = ctx.group(&alice, "readers").await?;
     let engineering = ctx.group(&alice, "engineering").await?;
@@ -417,6 +443,12 @@ async fn a_direct_membership_survives_a_revocation_further_up() -> Result<()> {
     ctx.delegate(&alice, &engineering, &design_doc, Read)
         .await?;
     ctx.delegate(&alice, &readers, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches the document by both routes to begin with, and carol by neither"
+    );
 
     ctx.revoke(&alice, &readers, &engineering).await?;
     assert!(
@@ -477,7 +509,9 @@ async fn a_cycle_does_not_stop_an_addition_reaching_the_document() -> Result<()>
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let first = ctx.group(&alice, "first").await?;
     let second = ctx.group(&alice, "second").await?;
@@ -486,6 +520,12 @@ async fn a_cycle_does_not_stop_an_addition_reaching_the_document() -> Result<()>
 
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &first, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice"]),
+        "bob is in neither half of the cycle yet"
+    );
 
     ctx.delegate(&alice, &bob, &second, Read).await?;
 
@@ -617,7 +657,9 @@ async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()>
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
-    let cast = [&alice, &bob];
+    // carol was not delegated anything, so use her to check access did not widen.
+    let carol = ctx.individual("carol").await?;
+    let cast = [&alice, &bob, &carol];
 
     let first = ctx.group(&alice, "first").await?;
     let second = ctx.group(&alice, "second").await?;
@@ -628,6 +670,12 @@ async fn revoking_one_of_two_cyclic_groups_keeps_the_other_route() -> Result<()>
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     let first_in_doc = ctx.delegate(&alice, &first, &design_doc, Read).await?;
     ctx.delegate(&alice, &second, &design_doc, Read).await?;
+
+    assert_eq!(
+        readers_after_writing(&mut ctx, &alice, &design_doc, b"before", &cast).await?,
+        named(&["alice", "bob"]),
+        "bob reaches the document to begin with, and carol does not"
+    );
 
     ctx.revoke(&alice, &first, &design_doc).await?;
     assert!(

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -52,7 +52,7 @@ async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
     ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     let old = ctx.expand_prekeys(&alice).await?;
     let new = ctx.rotate_prekey(&alice, &old).await?;
@@ -63,7 +63,7 @@ async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
         "bob hasn't seen alice's rotation yet"
     );
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         ctx.prekey_ops(&bob, &alice)
@@ -113,7 +113,7 @@ async fn two_concurrent_rotations_of_one_key_both_survive() -> Result<()> {
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
 
     let k1 = ctx.expand_prekeys(&alice).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
     assert!(
         ctx.prekeys(&alice_worker, &alice).await?.contains(&k1),
         "both instances start from the same key"
@@ -124,7 +124,7 @@ async fn two_concurrent_rotations_of_one_key_both_survive() -> Result<()> {
     let from_worker = ctx.rotate_prekey(&alice_worker, &k1).await?;
     assert_ne!(from_first, from_worker);
 
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     for observer in [&alice, &alice_worker] {
         let live = ctx.prekeys(observer, &alice).await?;

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -1,0 +1,75 @@
+mod facade;
+
+use facade::{Result, TestContext, TestPrekeyOp};
+use keyhive_core::access::Access::Read;
+
+#[tokio::test]
+async fn expanding_prekeys_adds_a_distinct_key() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+
+    let before = ctx.prekey_ops(&alice, &alice).await?;
+    let added = ctx.expand_prekeys(&alice).await?;
+    let after = ctx.prekey_ops(&alice, &alice).await?;
+
+    assert_eq!(after.len(), before.len() + 1, "exactly one op was recorded");
+    assert!(
+        !before.iter().any(|op| op.new_key() == added),
+        "the key is new"
+    );
+    assert!(
+        after.contains(&TestPrekeyOp::Added { new: added }),
+        "and it was recorded as an addition"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn rotating_a_prekey_records_what_it_replaced() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+
+    let old = ctx.expand_prekeys(&alice).await?;
+    let new = ctx.rotate_prekey(&alice, &old).await?;
+
+    assert_ne!(new, old, "a rotation produces a different key");
+    let ops = ctx.prekey_ops(&alice, &alice).await?;
+    assert!(
+        ops.contains(&TestPrekeyOp::Rotated { old, new }),
+        "the rotation names both keys"
+    );
+    assert!(
+        ops.contains(&TestPrekeyOp::Added { new: old }),
+        "and the op that introduced the old key is still in the log"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all().await?;
+
+    let old = ctx.expand_prekeys(&alice).await?;
+    let new = ctx.rotate_prekey(&alice, &old).await?;
+    assert!(
+        !ctx.prekey_ops(&bob, &alice)
+            .await?
+            .contains(&TestPrekeyOp::Rotated { old, new }),
+        "bob hasn't seen alice's rotation yet"
+    );
+
+    ctx.sync_all().await?;
+
+    assert!(
+        ctx.prekey_ops(&bob, &alice)
+            .await?
+            .contains(&TestPrekeyOp::Rotated { old, new }),
+        "bob sees alice's rotation"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -73,3 +73,71 @@ async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn rotating_a_prekey_replacing_the_old_one() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+
+    let old = ctx.expand_prekeys(&alice).await?;
+    assert!(ctx.prekeys(&alice, &alice).await?.contains(&old));
+
+    let new = ctx.rotate_prekey(&alice, &old).await?;
+    let live = ctx.prekeys(&alice, &alice).await?;
+
+    assert!(live.contains(&new), "the replacement is live");
+    assert!(!live.contains(&old), "the replaced key is not");
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_rotated_away_intermediate_prekey_does_not_survive() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+
+    let k1 = ctx.expand_prekeys(&alice).await?;
+    let k2 = ctx.rotate_prekey(&alice, &k1).await?;
+    let k3 = ctx.rotate_prekey(&alice, &k2).await?;
+
+    let live = ctx.prekeys(&alice, &alice).await?;
+    assert!(live.contains(&k3), "the last key is live");
+    assert!(!live.contains(&k2), "the intermediate is not");
+    assert!(!live.contains(&k1), "and neither is the original");
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_concurrent_rotations_of_one_key_both_survive() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let alice = ctx.individual("alice").await?;
+    let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
+
+    let k1 = ctx.expand_prekeys(&alice).await?;
+    ctx.sync_all().await?;
+    assert!(
+        ctx.prekeys(&alice_worker, &alice).await?.contains(&k1),
+        "both instances start from the same key"
+    );
+
+    // Neither rotation has heard of the other.
+    let from_first = ctx.rotate_prekey(&alice, &k1).await?;
+    let from_worker = ctx.rotate_prekey(&alice_worker, &k1).await?;
+    assert_ne!(from_first, from_worker);
+
+    ctx.sync_all().await?;
+
+    for observer in [&alice, &alice_worker] {
+        let live = ctx.prekeys(observer, &alice).await?;
+        assert!(
+            live.contains(&from_first) && live.contains(&from_worker),
+            "{} lost one of the two concurrent replacements",
+            observer.name()
+        );
+        assert!(
+            !live.contains(&k1),
+            "{} kept the key both rotations replaced",
+            observer.name()
+        );
+    }
+    Ok(())
+}

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -75,7 +75,7 @@ async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
 }
 
 #[tokio::test]
-async fn rotating_a_prekey_replacing_the_old_one() -> Result<()> {
+async fn rotating_a_prekey_replaces_the_old_one() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
 

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -36,7 +36,7 @@ async fn rotating_a_prekey_records_what_it_replaced() -> Result<()> {
     let ops = ctx.prekey_ops(&alice, &alice).await?;
     assert!(
         ops.contains(&TestPrekeyOp::Rotated { old, new }),
-        "the rotation names both keys"
+        "the rotation records the key it replaced and its replacement"
     );
     assert!(
         ops.contains(&TestPrekeyOp::Added { new: old }),

--- a/keyhive_core/tests/prekeys.rs
+++ b/keyhive_core/tests/prekeys.rs
@@ -5,7 +5,7 @@ use keyhive_core::access::Access::Read;
 
 #[tokio::test]
 async fn expanding_prekeys_adds_a_distinct_key() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
 
     let before = ctx.prekey_ops(&alice, &alice).await?;
@@ -26,7 +26,7 @@ async fn expanding_prekeys_adds_a_distinct_key() -> Result<()> {
 
 #[tokio::test]
 async fn rotating_a_prekey_records_what_it_replaced() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
 
     let old = ctx.expand_prekeys(&alice).await?;
@@ -47,7 +47,7 @@ async fn rotating_a_prekey_records_what_it_replaced() -> Result<()> {
 
 #[tokio::test]
 async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -76,7 +76,7 @@ async fn a_prekey_rotation_reaches_a_peer() -> Result<()> {
 
 #[tokio::test]
 async fn rotating_a_prekey_replacing_the_old_one() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
 
     let old = ctx.expand_prekeys(&alice).await?;
@@ -92,7 +92,7 @@ async fn rotating_a_prekey_replacing_the_old_one() -> Result<()> {
 
 #[tokio::test]
 async fn a_rotated_away_intermediate_prekey_does_not_survive() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
 
     let k1 = ctx.expand_prekeys(&alice).await?;
@@ -108,7 +108,7 @@ async fn a_rotated_away_intermediate_prekey_does_not_survive() -> Result<()> {
 
 #[tokio::test]
 async fn two_concurrent_rotations_of_one_key_both_survive() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x9e0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let alice_worker = ctx.second_instance(&alice, "alice-worker").await?;
 

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -5,23 +5,25 @@ use keyhive_core::access::Access::{Admin, Edit, Read};
 
 #[tokio::test]
 async fn delegating_to_public_records_a_public_delegation() -> Result<()> {
-    let mut ctx = TestContext::new().await;
-    let alice = ctx.individual("alice").await?;
-    let design_doc = ctx.doc(&alice, "design_doc").await?;
-    let public = ctx.public();
+    for level in [Read, Edit, Admin] {
+        let mut ctx = TestContext::new().await;
+        let alice = ctx.individual("alice").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+        let public = ctx.public();
 
-    assert_eq!(ctx.effective_access(&public, &design_doc).await?, None);
-    ctx.delegate(&alice, &public, &design_doc, Read).await?;
+        assert_eq!(ctx.effective_access(&public, &design_doc).await?, None);
+        ctx.delegate(&alice, &public, &design_doc, level).await?;
 
-    assert_eq!(
-        ctx.effective_access(&public, &design_doc).await?,
-        Some(Read)
-    );
-    assert_eq!(
-        ctx.transitive_members_of(&design_doc).await?.get("public"),
-        Some(&Read),
-        "the public delegation should add public as a member"
-    );
+        assert_eq!(
+            ctx.effective_access(&public, &design_doc).await?,
+            Some(level)
+        );
+        assert_eq!(
+            ctx.transitive_members_of(&design_doc).await?.get("public"),
+            Some(&level),
+            "the public delegation should add public as a member"
+        );
+    }
     Ok(())
 }
 
@@ -69,21 +71,6 @@ async fn a_direct_delegation_and_a_public_delegation_take_the_higher() -> Result
         ctx.best_access(&carol, &design_doc).await?,
         Some(Read),
         "carol has only the public delegation"
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn public_has_effective_access_if_delegated() -> Result<()> {
-    let mut ctx = TestContext::new().await;
-    let alice = ctx.individual("alice").await?;
-    let design_doc = ctx.doc(&alice, "design_doc").await?;
-
-    ctx.delegate(&alice, &ctx.public(), &design_doc, Edit)
-        .await?;
-    assert_eq!(
-        ctx.effective_access(&ctx.public(), &design_doc).await?,
-        Some(Edit)
     );
     Ok(())
 }

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -202,7 +202,7 @@ async fn a_public_delegation_does_not_deliver_the_document() -> Result<()> {
     ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
         .await?;
     let ct = ctx.encrypt(&alice, &design_doc, b"announcement").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert!(
         !ctx.has_received(&bob, &design_doc).await?,

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -188,6 +188,16 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
 
     // The events reach bob through the server.
     ctx.sync(&alice, &server).await?;
+    assert_eq!(
+        ctx.pending_events(&server).await?,
+        0,
+        "the server applied everything alice sent it"
+    );
+    assert!(
+        !ctx.static_events_for(&server, &bob).await?.is_empty(),
+        "the server has something to relay, so the assertions below are not on an empty delivery"
+    );
+
     let pending = ctx.sync_as_public(&server, &bob).await?;
 
     assert_eq!(pending, 0, "bob could apply everything the server relayed");

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -4,7 +4,7 @@ use facade::{Result, TestContext};
 use keyhive_core::access::Access::{Admin, Edit, Read};
 
 #[tokio::test]
-async fn granting_to_public_records_a_public_delegation() -> Result<()> {
+async fn delegating_to_public_records_a_public_delegation() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -26,7 +26,7 @@ async fn granting_to_public_records_a_public_delegation() -> Result<()> {
 }
 
 #[tokio::test]
-async fn a_public_grant_raises_best_access_and_not_effective_access() -> Result<()> {
+async fn a_public_delegation_raises_best_access_and_not_effective_access() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -234,7 +234,7 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
     Ok(())
 }
 
-// This is a sanity check for the testing facade
+// This is a sanity check for the testing facade.
 #[tokio::test]
 async fn a_public_delegation_does_not_deliver_the_document() -> Result<()> {
     let mut ctx = TestContext::new().await;

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -1,7 +1,7 @@
 mod facade;
 
 use facade::{Result, TestContext};
-use keyhive_core::access::Access::{Admin, Edit, Read};
+use keyhive_core::access::Access::{Admin, Edit, Read, Relay};
 
 #[tokio::test]
 async fn delegating_to_public_records_a_public_delegation() -> Result<()> {
@@ -71,6 +71,80 @@ async fn a_direct_delegation_and_a_public_delegation_take_the_higher() -> Result
         ctx.best_access(&carol, &design_doc).await?,
         Some(Read),
         "carol has only the public delegation"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_public_reader_reads_what_a_member_wrote() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"announcement").await?;
+
+    ctx.sync_as_public(&alice, &bob).await?;
+
+    assert_eq!(
+        ctx.effective_access(&bob, &design_doc).await?,
+        None,
+        "bob is not a member and never becomes one"
+    );
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "he reads it through the public delegation"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_public_readers_meet_through_the_document() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    ctx.sync_as_public(&alice, &bob).await?;
+    ctx.sync_as_public(&alice, &carol).await?;
+
+    // Neither of them is a member. Both write and read as public.
+    let from_bob = ctx.encrypt(&bob, &design_doc, b"from bob").await?;
+
+    assert!(
+        ctx.can_decrypt(&carol, &from_bob).await?,
+        "carol reads what bob wrote, with neither of them a member"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn another_member_does_not_displace_the_public_reader() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let server = ctx.individual("server").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &server, &design_doc, Relay).await?;
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"relayed").await?;
+
+    let pending = ctx.sync_as_public(&alice, &bob).await?;
+
+    assert_eq!(pending, 0, "bob could apply every event he was sent");
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "the document is public whether or not it has other members"
     );
     Ok(())
 }

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -4,12 +4,13 @@ use facade::{Result, TestContext};
 use keyhive_core::access::Access::{Admin, Edit, Read, Relay};
 
 #[tokio::test]
-async fn delegating_to_public_records_a_public_delegation() -> Result<()> {
+async fn delegating_to_public_creates_a_public_delegation() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let public = ctx.public();
+
     for level in [Read, Edit, Admin] {
-        let mut ctx = TestContext::new().await;
-        let alice = ctx.individual("alice").await?;
-        let design_doc = ctx.doc(&alice, "design_doc").await?;
-        let public = ctx.public();
+        let design_doc = ctx.doc(&alice, &format!("design_doc-{level:?}")).await?;
 
         assert_eq!(ctx.effective_access(&public, &design_doc).await?, None);
         ctx.delegate(&alice, &public, &design_doc, level).await?;

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -1,0 +1,113 @@
+mod facade;
+
+use facade::{Result, TestContext};
+use keyhive_core::access::Access::{Admin, Edit, Read};
+
+#[tokio::test]
+async fn granting_to_public_records_a_public_delegation() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let public = ctx.public();
+
+    assert_eq!(ctx.effective_access(&public, &design_doc).await?, None);
+    ctx.delegate(&alice, &public, &design_doc, Read).await?;
+
+    assert_eq!(
+        ctx.effective_access(&public, &design_doc).await?,
+        Some(Read)
+    );
+    assert_eq!(
+        ctx.transitive_members_of(&design_doc).await?.get("public"),
+        Some(&Read),
+        "the public delegation should add public as a member"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_public_grant_raises_best_access_and_not_effective_access() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let public = ctx.public();
+
+    ctx.delegate(&alice, &public, &design_doc, Read).await?;
+
+    assert_eq!(
+        ctx.effective_access(&bob, &design_doc).await?,
+        None,
+        "nobody delegated anything to bob"
+    );
+    assert_eq!(
+        ctx.best_access(&bob, &design_doc).await?,
+        Some(Read),
+        "the document is public"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_direct_delegation_and_a_public_delegation_take_the_higher() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let public = ctx.public();
+
+    ctx.delegate(&alice, &public, &design_doc, Read).await?;
+    ctx.delegate(&alice, &bob, &design_doc, Admin).await?;
+
+    assert_eq!(
+        ctx.best_access(&bob, &design_doc).await?,
+        Some(Admin),
+        "bob's own delegation is the better one"
+    );
+    assert_eq!(
+        ctx.best_access(&carol, &design_doc).await?,
+        Some(Read),
+        "carol has only the public delegation"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn public_has_effective_access_if_delegated() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Edit)
+        .await?;
+    assert_eq!(
+        ctx.effective_access(&ctx.public(), &design_doc).await?,
+        Some(Edit)
+    );
+    Ok(())
+}
+
+// This is a sanity check for the testing facade
+#[tokio::test]
+async fn a_public_delegation_does_not_deliver_the_document() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"announcement").await?;
+    ctx.sync_all().await?;
+
+    assert!(
+        !ctx.has_received(&bob, &design_doc).await?,
+        "bob was never sent the document"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &ct).await?,
+        "bob can't decrypt a document he doesn't have"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -149,6 +149,44 @@ async fn another_member_does_not_displace_the_public_reader() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let server = ctx.individual("server").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &server, &design_doc, Relay).await?;
+    ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
+        .await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"announcement").await?;
+
+    // The events reach bob through the server.
+    ctx.sync(&alice, &server).await?;
+    let pending = ctx.sync_as_public(&server, &bob).await?;
+
+    assert_eq!(pending, 0, "bob could apply everything the server relayed");
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &bob, &design_doc)
+            .await?,
+        None,
+        "asking about himself does not find the document"
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &ctx.public(), &design_doc)
+            .await?,
+        Some(Read),
+        "asking about public does"
+    );
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "and he can read it"
+    );
+    Ok(())
+}
+
 // This is a sanity check for the testing facade
 #[tokio::test]
 async fn a_public_delegation_does_not_deliver_the_document() -> Result<()> {

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -2,6 +2,7 @@ mod facade;
 
 use facade::{Result, TestContext};
 use keyhive_core::access::Access::{Admin, Edit, Read, Relay};
+use std::collections::BTreeMap;
 
 #[tokio::test]
 async fn delegating_to_public_creates_a_public_delegation() -> Result<()> {
@@ -180,6 +181,11 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
 
+    // A document bob is a direct member of. The reachability assertion below
+    // distinguishes "the public document is excluded" from "bob reaches nothing".
+    let notes = ctx.doc(&alice, "notes").await?;
+    ctx.delegate(&alice, &bob, &notes, Read).await?;
+
     ctx.delegate(&alice, &server, &design_doc, Relay).await?;
     ctx.delegate(&alice, &ctx.public(), &design_doc, Read)
         .await?;
@@ -206,6 +212,13 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
             .await?,
         None,
         "asking about himself does not find the document"
+    );
+    ctx.sync(&alice, &bob).await?;
+    assert_eq!(
+        ctx.documents_reachable_by(&bob).await?,
+        BTreeMap::from([("notes".to_string(), Read)]),
+        "the documents he reaches because of his personal access are notes and only \
+        notes, so the public one is excluded rather than there being nothing to exclude it from"
     );
     assert_eq!(
         ctx.effective_access_seen_by(&bob, &ctx.public(), &design_doc)

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -94,8 +94,9 @@ async fn a_public_reader_reads_what_a_member_wrote() -> Result<()> {
         None,
         "bob is not a member and never becomes one"
     );
-    assert!(
-        ctx.can_decrypt(&bob, &ct).await?,
+    assert_eq!(
+        ctx.read(&bob, &ct).await?,
+        b"announcement".to_vec(),
         "he reads it through the public delegation"
     );
     Ok(())
@@ -118,8 +119,9 @@ async fn two_public_readers_meet_through_the_document() -> Result<()> {
     // Neither of them is a member. Both write and read as public.
     let from_bob = ctx.encrypt(&bob, &design_doc, b"from bob").await?;
 
-    assert!(
-        ctx.can_decrypt(&carol, &from_bob).await?,
+    assert_eq!(
+        ctx.read(&carol, &from_bob).await?,
+        b"from bob".to_vec(),
         "carol reads what bob wrote, with neither of them a member"
     );
     Ok(())
@@ -142,8 +144,9 @@ async fn another_member_does_not_displace_the_public_reader() -> Result<()> {
     let pending = ctx.sync_as_public(&alice, &bob).await?;
 
     assert_eq!(pending, 0, "bob could apply every event he was sent");
-    assert!(
-        ctx.can_decrypt(&bob, &ct).await?,
+    assert_eq!(
+        ctx.read(&bob, &ct).await?,
+        b"relayed".to_vec(),
         "the document is public whether or not it has other members"
     );
     Ok(())
@@ -180,7 +183,11 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
         Some(Read),
         "asking about public does"
     );
-    assert!(ctx.can_decrypt(&bob, &ct).await?, "and he can read it");
+    assert_eq!(
+        ctx.read(&bob, &ct).await?,
+        b"announcement".to_vec(),
+        "and he can read it"
+    );
     Ok(())
 }
 

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -215,7 +215,7 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
     );
     ctx.sync(&alice, &bob).await?;
     assert_eq!(
-        ctx.documents_reachable_by(&bob).await?,
+        ctx.documents_reachable_by(&bob, &bob).await?,
         BTreeMap::from([("notes".to_string(), Read)]),
         "the documents he reaches because of his personal access are notes and only \
         notes, so the public one is excluded rather than there being nothing to exclude it from"

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -180,10 +180,7 @@ async fn a_public_document_is_reachable_as_public_and_not_as_yourself() -> Resul
         Some(Read),
         "asking about public does"
     );
-    assert!(
-        ctx.can_decrypt(&bob, &ct).await?,
-        "and he can read it"
-    );
+    assert!(ctx.can_decrypt(&bob, &ct).await?, "and he can read it");
     Ok(())
 }
 

--- a/keyhive_core/tests/public.rs
+++ b/keyhive_core/tests/public.rs
@@ -105,6 +105,25 @@ async fn a_public_reader_reads_what_a_member_wrote() -> Result<()> {
 
 #[tokio::test]
 async fn two_public_readers_meet_through_the_document() -> Result<()> {
+    // Scenario:
+    // Alice creates a doc and adds Public as a Read member.
+    // A and B are not members of the doc.
+    // A and B receive the doc events via the Public agent (simulating
+    // the sync server checking Public access).
+    // A encrypts content as Public, B decrypts as Public.
+    //
+    // ┌─────────────────────┐
+    // │        Alice        │  (owner)
+    // └─────────────────────┘
+    //            │
+    //            │ Read
+    //            ▼
+    // ┌─────────────────────┐
+    // │       Public        │  (well-known identity)
+    // └─────────────────────┘
+    //
+    // A and B are not members. They receive doc events because Public
+    // has access, and encrypt/decrypt using Public's well-known keys.
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -92,7 +92,7 @@ async fn delivery_order_does_not_change_the_authority_graph() -> Result<()> {
 /// is sent to Dave and does converge, so this is specific to a revocation one level up the
 /// membership chain.
 #[tokio::test]
-#[ignore = "fails on main and on jtfm/cgka-authority: a group revocation is not sent to a peer of the parent document"]
+#[ignore = "a revocation inside a group is not sent to a peer of the parent document. Needs to be fixed"]
 async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()> {
     let mut ctx = TestContext::with_seed(0x5EED).await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -158,6 +158,43 @@ async fn partial_delivery_leaves_events_pending_and_they_apply_later() -> Result
 }
 
 #[tokio::test]
+async fn redelivering_known_events_changes_nothing() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xd11d0).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"written once").await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(ctx.pending_events(&bob).await?, 0);
+    assert!(ctx.can_decrypt(&bob, &ct).await?);
+
+    let pending = ctx.sync_shuffled(&alice, &bob, 0).await?;
+
+    assert_eq!(
+        pending, 0,
+        "an event bob already held would not apply again"
+    );
+    assert_eq!(ctx.pending_events(&bob).await?, 0);
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &bob, &design_doc)
+            .await?,
+        Some(Read),
+        "the second delivery changed what bob believes"
+    );
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "the second delivery caused bob to lose the ability to decrypt"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn withholding_key_agreement_leaves_a_member_who_cannot_read() -> Result<()> {
     let mut ctx = TestContext::with_seed(0xcafe).await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -5,14 +5,14 @@ use keyhive_core::access::Access::{self, Edit, Read};
 
 // Sanity check for seeding tests
 #[tokio::test]
-async fn the_same_seed_produces_the_same_certificates() -> Result<()> {
+async fn the_same_seed_produces_the_same_delegations() -> Result<()> {
     async fn build(seed: u64) -> Result<String> {
         let mut ctx = TestContext::with_seed(seed).await;
         let alice = ctx.individual("alice").await?;
         let bob = ctx.individual("bob").await?;
         let design_doc = ctx.doc(&alice, "design_doc").await?;
-        let cert = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-        Ok(format!("{cert:?}"))
+        let dlg = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+        Ok(format!("{dlg:?}"))
     }
 
     assert_eq!(build(1234).await?, build(1234).await?, "seed 1234 twice");

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -185,7 +185,7 @@ async fn withholding_key_agreement_leaves_a_member_who_cannot_read() -> Result<(
     ctx.sync(&alice, &bob).await?;
     assert!(
         ctx.can_decrypt(&bob, &ct).await?,
-        "the key material completes the grant"
+        "the key material allows him to decrypt"
     );
     Ok(())
 }

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -78,7 +78,7 @@ async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()
     ctx.delegate(&alice, &bob, &engineering, Read).await?;
     ctx.delegate(&alice, &dave, &design_doc, Read).await?;
     ctx.revoke(&alice, &bob, &engineering).await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(
         ctx.effective_access(&bob, &design_doc).await?,
@@ -129,6 +129,35 @@ async fn partial_delivery_leaves_events_pending_and_they_apply_later() -> Result
     Ok(())
 }
 
+// This is a sanity check for the testing facade.
+#[tokio::test]
+async fn the_resending_sync_methods_really_resend() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    ctx.sync_all_unsent().await?;
+
+    let entitled = ctx.static_events_for(&alice, &bob).await?.len();
+    assert!(entitled > 0, "bob is entitled to something to begin with");
+
+    ctx.sync(&alice, &bob).await?;
+    assert_eq!(
+        ctx.events_last_delivered(),
+        entitled,
+        "sync sends everything bob is entitled to, not what he has yet to see"
+    );
+
+    ctx.sync_shuffled(&alice, &bob, 0).await?;
+    assert_eq!(
+        ctx.events_last_delivered(),
+        entitled,
+        "and so does sync_shuffled, which is what the redelivery tests call"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn redelivering_known_events_changes_nothing() -> Result<()> {
     let mut ctx = TestContext::new().await;
@@ -141,10 +170,15 @@ async fn redelivering_known_events_changes_nothing() -> Result<()> {
         .await?;
     ctx.delegate(&alice, &bob, &engineering, Read).await?;
     let ct = ctx.encrypt(&alice, &design_doc, b"written once").await?;
-    ctx.sync_all().await?;
+    ctx.sync_all_unsent().await?;
 
     assert_eq!(ctx.pending_events(&bob).await?, 0);
     assert!(ctx.can_decrypt(&bob, &ct).await?);
+
+    // Bob has all of this already. The point of the test is that it is sent to him
+    // anyway.
+    let to_resend = ctx.static_events_for(&alice, &bob).await?.len();
+    assert!(to_resend > 0, "there is nothing to redeliver");
 
     let pending = ctx.sync_shuffled(&alice, &bob, 0).await?;
 

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -1,0 +1,191 @@
+mod facade;
+
+use facade::{Result, TestContext, TestEventKind};
+use keyhive_core::access::Access::{self, Edit, Read};
+
+// Sanity check for seeding tests
+#[tokio::test]
+async fn the_same_seed_produces_the_same_certificates() -> Result<()> {
+    async fn build(seed: u64) -> Result<String> {
+        let mut ctx = TestContext::with_seed(seed).await;
+        let alice = ctx.individual("alice").await?;
+        let bob = ctx.individual("bob").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+        let cert = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+        Ok(format!("{cert:?}"))
+    }
+
+    assert_eq!(build(1234).await?, build(1234).await?, "seed 1234 twice");
+    assert_ne!(build(1234).await?, build(5678).await?, "different seeds");
+    Ok(())
+}
+
+/// Sanity check for replaying tests with seed.
+#[tokio::test]
+async fn an_unseeded_context_still_reports_its_seed() -> Result<()> {
+    let a = TestContext::new().await;
+    let b = TestContext::new().await;
+    assert_ne!(
+        a.seed(),
+        b.seed(),
+        "new() must not be a fixed seed, or every test shares one identity"
+    );
+
+    let replay = TestContext::with_seed(a.seed()).await;
+    assert_eq!(replay.seed(), a.seed());
+    Ok(())
+}
+
+#[tokio::test]
+async fn delivery_order_does_not_change_the_authority_graph() -> Result<()> {
+    const SEED: u64 = 0xd00d;
+
+    /// Builds the same context every time, delivers it to dave in the order `order` gives,
+    /// and reports what dave then believes about everyone.
+    async fn graph_seen_by_dave(order: u64) -> Result<Vec<(String, Option<Access>)>> {
+        let mut ctx = TestContext::with_seed(SEED).await;
+        let alice = ctx.individual("alice").await?;
+        let bob = ctx.individual("bob").await?;
+        let carol = ctx.individual("carol").await?;
+        let dave = ctx.individual("dave").await?;
+        let design_doc = ctx.doc(&alice, "design_doc").await?;
+        let engineering = ctx.group(&alice, "engineering").await?;
+
+        ctx.delegate(&alice, &engineering, &design_doc, Edit)
+            .await?;
+        ctx.delegate(&alice, &carol, &engineering, Read).await?;
+        ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+        ctx.delegate(&alice, &dave, &design_doc, Read).await?;
+        ctx.revoke(&alice, &bob, &design_doc).await?;
+
+        let pending = ctx.sync_shuffled(&alice, &dave, order).await?;
+        assert_eq!(pending, 0, "order {order} left events unapplied");
+
+        let mut out = vec![];
+        for who in [&bob, &carol, &dave] {
+            out.push((
+                who.name().to_string(),
+                ctx.effective_access_seen_by(&dave, who, &design_doc)
+                    .await?,
+            ));
+        }
+        Ok(out)
+    }
+
+    let first = graph_seen_by_dave(0).await?;
+    for order in 1..8u64 {
+        assert_eq!(
+            graph_seen_by_dave(order).await?,
+            first,
+            "delivery order {order} produced a different graph (seed {SEED:#x})"
+        );
+    }
+    Ok(())
+}
+
+/// Dave holds Read on the document directly. He receives all five `Delegated` events that
+/// describe the group, including the one admitting Bob. He is not sent the `Revoked` event
+/// that cancels it. Nothing is left pending, no error is raised, and further syncing does
+/// not change it. Dave believes Bob is still a member, while Alice and Bob agree he is not.
+///
+/// The same revocation issued directly on the document
+/// is sent to Dave and does converge, so this is specific to a revocation one level up the
+/// membership chain.
+#[tokio::test]
+#[ignore = "fails on main and on jtfm/cgka-authority: a group revocation is not sent to a peer of the parent document"]
+async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0x5EED).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let dave = ctx.individual("dave").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Read).await?;
+    ctx.delegate(&alice, &dave, &design_doc, Read).await?;
+    ctx.revoke(&alice, &bob, &engineering).await?;
+    ctx.sync_all().await?;
+
+    assert_eq!(
+        ctx.effective_access(&bob, &design_doc).await?,
+        None,
+        "alice, who issued the revocation, has it right"
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &bob, &design_doc)
+            .await?,
+        None,
+        "and so does bob, who was sent it"
+    );
+    assert_eq!(
+        ctx.effective_access_seen_by(&dave, &bob, &design_doc)
+            .await?,
+        None,
+        "dave must agree: he holds every delegation that built this graph"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn partial_delivery_leaves_events_pending_and_they_apply_later() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xbeef).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &bob, &engineering, Edit).await?;
+
+    // One event at a time.
+    let pending_at_the_end = ctx.sync_in_batches(&alice, &bob, 1).await?;
+
+    assert_eq!(
+        pending_at_the_end, 0,
+        "every event should have found its place by the last batch"
+    );
+    assert_eq!(ctx.pending_events(&bob).await?, 0);
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &bob, &design_doc)
+            .await?,
+        Some(Edit),
+        "bob converged on the same answer alice has"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn withholding_key_agreement_leaves_a_member_who_cannot_read() -> Result<()> {
+    let mut ctx = TestContext::with_seed(0xcafe).await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+
+    ctx.delegate(&alice, &bob, &design_doc, Read).await?;
+    let ct = ctx.encrypt(&alice, &design_doc, b"needs a key").await?;
+
+    ctx.sync_without(&alice, &bob, TestEventKind::CgkaOperation)
+        .await?;
+
+    assert_eq!(
+        ctx.effective_access_seen_by(&bob, &bob, &design_doc)
+            .await?,
+        Some(Read),
+        "the graph says bob is a reader"
+    );
+    assert!(
+        !ctx.can_decrypt(&bob, &ct).await?,
+        "but he was never given the key material"
+    );
+
+    // Now send the rest.
+    ctx.sync(&alice, &bob).await?;
+    assert!(
+        ctx.can_decrypt(&bob, &ct).await?,
+        "the key material completes the grant"
+    );
+    Ok(())
+}

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -159,6 +159,63 @@ async fn the_resending_sync_methods_really_resend() -> Result<()> {
 }
 
 #[tokio::test]
+async fn a_backlog_that_cannot_apply_does_not_block_new_events() -> Result<()> {
+    let mut ctx = TestContext::new().await;
+    let server = ctx.individual("server").await?;
+    let stranger = ctx.individual("stranger").await?;
+    let alice = ctx.individual("alice").await?;
+
+    // The server is a member of the stranger's document and is sent its key agreement
+    // without the delegations that would let it place them. Nothing later supplies those.
+    let stranger_doc = ctx.doc(&stranger, "stranger_doc").await?;
+    ctx.delegate(&stranger, &server, &stranger_doc, Read)
+        .await?;
+    let friend = ctx.individual("friend").await?;
+    ctx.delegate(&stranger, &friend, &stranger_doc, Read)
+        .await?;
+    // Rotations rather than more members, so the backlog grows without adding identities
+    // that alice would also have to tell the server about.
+    for _ in 0..4 {
+        ctx.force_pcs_update(&stranger, &stranger_doc).await?;
+    }
+    ctx.sync_without(&stranger, &server, TestEventKind::Delegated)
+        .await?;
+
+    let backlog = ctx.pending_events(&server).await?;
+    assert!(backlog > 0, "the server is holding events it cannot apply");
+
+    // Unrelated and entirely valid: alice's own document, which the server may have in full.
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    ctx.delegate(&alice, &server, &design_doc, Read).await?;
+    ctx.force_pcs_update(&alice, &design_doc).await?;
+    let ct = ctx
+        .encrypt(&alice, &design_doc, b"written despite the backlog")
+        .await?;
+
+    // Alice has to send something. If she sent nothing, every assertion below would pass
+    // on an empty delivery.
+    let fresh = ctx.static_events_for(&alice, &server).await?.len();
+    assert!(
+        fresh > 0,
+        "alice has events for the server, so the assertions below are not on an empty delivery"
+    );
+
+    ctx.sync(&alice, &server).await?;
+
+    assert_eq!(
+        ctx.pending_events(&server).await?,
+        backlog,
+        "alice's events applied, and none of them joined the backlog"
+    );
+    assert_eq!(
+        ctx.read(&server, &ct).await?,
+        b"written despite the backlog".to_vec(),
+        "and the server can use what it was sent"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn redelivering_known_events_changes_nothing() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -3,81 +3,53 @@ mod facade;
 use facade::{Result, TestContext, TestEventKind};
 use keyhive_core::access::Access::{self, Edit, Read};
 
-// Sanity check for seeding tests
-#[tokio::test]
-async fn the_same_seed_produces_the_same_delegations() -> Result<()> {
-    async fn build(seed: u64) -> Result<String> {
-        let mut ctx = TestContext::with_seed(seed).await;
-        let alice = ctx.individual("alice").await?;
-        let bob = ctx.individual("bob").await?;
-        let design_doc = ctx.doc(&alice, "design_doc").await?;
-        let dlg = ctx.delegate(&alice, &bob, &design_doc, Read).await?;
-        Ok(format!("{dlg:?}"))
-    }
-
-    assert_eq!(build(1234).await?, build(1234).await?, "seed 1234 twice");
-    assert_ne!(build(1234).await?, build(5678).await?, "different seeds");
-    Ok(())
-}
-
-/// Sanity check for replaying tests with seed.
-#[tokio::test]
-async fn an_unseeded_context_still_reports_its_seed() -> Result<()> {
-    let a = TestContext::new().await;
-    let b = TestContext::new().await;
-    assert_ne!(
-        a.seed(),
-        b.seed(),
-        "new() must not be a fixed seed, or every test shares one identity"
-    );
-
-    let replay = TestContext::with_seed(a.seed()).await;
-    assert_eq!(replay.seed(), a.seed());
-    Ok(())
-}
-
 #[tokio::test]
 async fn delivery_order_does_not_change_the_authority_graph() -> Result<()> {
-    const SEED: u64 = 0xd00d;
+    const ORDERS: u64 = 8;
 
-    /// Builds the same context every time, delivers it to dave in the order `order` gives,
-    /// and reports what dave then believes about everyone.
-    async fn graph_seen_by_dave(order: u64) -> Result<Vec<(String, Option<Access>)>> {
-        let mut ctx = TestContext::with_seed(SEED).await;
-        let alice = ctx.individual("alice").await?;
-        let bob = ctx.individual("bob").await?;
-        let carol = ctx.individual("carol").await?;
-        let dave = ctx.individual("dave").await?;
-        let design_doc = ctx.doc(&alice, "design_doc").await?;
-        let engineering = ctx.group(&alice, "engineering").await?;
+    let mut ctx = TestContext::new().await;
+    let alice = ctx.individual("alice").await?;
+    let bob = ctx.individual("bob").await?;
+    let carol = ctx.individual("carol").await?;
 
-        ctx.delegate(&alice, &engineering, &design_doc, Edit)
-            .await?;
-        ctx.delegate(&alice, &carol, &engineering, Read).await?;
-        ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
-        ctx.delegate(&alice, &dave, &design_doc, Read).await?;
-        ctx.revoke(&alice, &bob, &design_doc).await?;
+    // One observer per delivery order, in one context, so they differ in the order they
+    // were handed the same events and in nothing else.
+    let mut observers = vec![];
+    for i in 0..ORDERS {
+        observers.push(ctx.individual(&format!("observer-{i}")).await?);
+    }
 
-        let pending = ctx.sync_shuffled(&alice, &dave, order).await?;
+    let design_doc = ctx.doc(&alice, "design_doc").await?;
+    let engineering = ctx.group(&alice, "engineering").await?;
+    ctx.delegate(&alice, &engineering, &design_doc, Edit)
+        .await?;
+    ctx.delegate(&alice, &carol, &engineering, Read).await?;
+    ctx.delegate(&alice, &bob, &design_doc, Edit).await?;
+    for observer in &observers {
+        ctx.delegate(&alice, observer, &design_doc, Read).await?;
+    }
+    ctx.revoke(&alice, &bob, &design_doc).await?;
+
+    let mut answers: Vec<Vec<(String, Option<Access>)>> = vec![];
+    for (order, observer) in observers.iter().enumerate() {
+        let pending = ctx.sync_shuffled(&alice, observer, order as u64).await?;
         assert_eq!(pending, 0, "order {order} left events unapplied");
 
-        let mut out = vec![];
-        for who in [&bob, &carol, &dave] {
-            out.push((
+        let mut believes = vec![];
+        for who in [&bob, &carol] {
+            believes.push((
                 who.name().to_string(),
-                ctx.effective_access_seen_by(&dave, who, &design_doc)
+                ctx.effective_access_seen_by(observer, who, &design_doc)
                     .await?,
             ));
         }
-        Ok(out)
+        answers.push(believes);
     }
 
-    let first = graph_seen_by_dave(0).await?;
-    for order in 1..8u64 {
+    for (order, believes) in answers.iter().enumerate().skip(1) {
         assert_eq!(
-            graph_seen_by_dave(order).await?,
-            first,
-            "delivery order {order} produced a different graph (seed {SEED:#x})"
+            believes, &answers[0],
+            "delivery order {order} produced a different graph"
         );
     }
     Ok(())
@@ -94,7 +66,7 @@ async fn delivery_order_does_not_change_the_authority_graph() -> Result<()> {
 #[tokio::test]
 #[ignore = "a revocation inside a group is not sent to a peer of the parent document. Needs to be fixed"]
 async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0x5EED).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let dave = ctx.individual("dave").await?;
@@ -130,7 +102,7 @@ async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()
 
 #[tokio::test]
 async fn partial_delivery_leaves_events_pending_and_they_apply_later() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xbeef).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -159,7 +131,7 @@ async fn partial_delivery_leaves_events_pending_and_they_apply_later() -> Result
 
 #[tokio::test]
 async fn redelivering_known_events_changes_nothing() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xd11d0).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;
@@ -196,7 +168,7 @@ async fn redelivering_known_events_changes_nothing() -> Result<()> {
 
 #[tokio::test]
 async fn withholding_key_agreement_leaves_a_member_who_cannot_read() -> Result<()> {
-    let mut ctx = TestContext::with_seed(0xcafe).await;
+    let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
     let bob = ctx.individual("bob").await?;
     let design_doc = ctx.doc(&alice, "design_doc").await?;

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -177,8 +177,14 @@ async fn redelivering_known_events_changes_nothing() -> Result<()> {
 
     // Bob has all of this already. The point of the test is that it is sent to him
     // anyway.
-    let to_resend = ctx.static_events_for(&alice, &bob).await?.len();
-    assert!(to_resend > 0, "there is nothing to redeliver");
+    let to_resend = ctx.static_events_for(&alice, &bob).await?;
+    assert!(!to_resend.is_empty(), "there is nothing to redeliver");
+    assert!(
+        to_resend
+            .iter()
+            .any(|e| e.kind() == TestEventKind::Delegated),
+        "including the delegations that put bob in the group"
+    );
 
     let pending = ctx.sync_shuffled(&alice, &bob, 0).await?;
 

--- a/keyhive_core/tests/sync.rs
+++ b/keyhive_core/tests/sync.rs
@@ -55,16 +55,13 @@ async fn delivery_order_does_not_change_the_authority_graph() -> Result<()> {
     Ok(())
 }
 
-/// Dave holds Read on the document directly. He receives all five `Delegated` events that
-/// describe the group, including the one admitting Bob. He is not sent the `Revoked` event
-/// that cancels it. Nothing is left pending, no error is raised, and further syncing does
-/// not change it. Dave believes Bob is still a member, while Alice and Bob agree he is not.
+/// A revocation issued inside a group has to reach a peer who holds the parent document
+/// directly, not only the members of the group it was issued in.
 ///
-/// The same revocation issued directly on the document
-/// is sent to Dave and does converge, so this is specific to a revocation one level up the
-/// membership chain.
+/// The same revocation issued on the document itself does reach Dave, so the gap is
+/// specific to a revocation one level up the membership chain.
 #[tokio::test]
-#[ignore = "a revocation inside a group is not sent to a peer of the parent document. Needs to be fixed"]
+#[ignore = "a revocation inside a group is not sent to a peer of the parent document"]
 async fn a_revocation_inside_a_group_reaches_a_peer_of_the_parent() -> Result<()> {
     let mut ctx = TestContext::new().await;
     let alice = ctx.individual("alice").await?;
@@ -192,8 +189,6 @@ async fn a_backlog_that_cannot_apply_does_not_block_new_events() -> Result<()> {
         .encrypt(&alice, &design_doc, b"written despite the backlog")
         .await?;
 
-    // Alice has to send something. If she sent nothing, every assertion below would pass
-    // on an empty delivery.
     let fresh = ctx.static_events_for(&alice, &server).await?.len();
     assert!(
         fresh > 0,


### PR DESCRIPTION
See `keyhive_core/tests/facade/README.md` for the details.

The code in this PR basically falls into 2 categories:

1. The facade API implementation in `keyhive_core/tests/facade/mod.rs` (roughly 1500 lines),
2. New test files where existing keyhive tests have been ported over to use the facade API.

To make reviewing this PR more manageable, I'd say look at the new `README.md`, review the facade implementation, and spot-check the actual tests. 

This PR does not (yet) include deletion of those old tests.