### PR TITLE
Add CGKA Invite ops

### DIFF
--- a/beekem/src/cgka.rs
+++ b/beekem/src/cgka.rs
@@ -12,16 +12,20 @@
 use crate::{
     collections::{Map, Set},
     content_addressed_map::CaMap,
-    encrypted::EncryptedContent,
+    encrypted::{encrypt_secret, EncryptedContent},
     error::CgkaError,
     id::{MemberId, TreeId},
     keys::{NodeKey, ShareKeyMap},
-    operation::{CgkaEpoch, CgkaOperation, CgkaOperationGraph},
+    operation::{CgkaEpoch, CgkaOperation, CgkaOperationGraph, Invitation},
     pcs_key::{ApplicationSecret, PcsKey},
     transact::{Fork, Merge},
     tree::BeeKem,
 };
-use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
 use core::hash::{Hash, Hasher};
 use future_form::FutureForm;
 use keyhive_crypto::{
@@ -66,6 +70,12 @@ pub struct Cgka {
     /// The update operations for each PCS key.
     pcs_key_ops: Map<Digest<PcsKey>, Digest<Signed<CgkaOperation>>>,
 
+    /// The most recent PCS key we know encrypted a piece of content.
+    newest_encrypting_pcs_key: Option<Digest<PcsKey>>,
+
+    /// Invitations for new members.
+    invitations: Map<MemberId, Vec<Invitation>>,
+
     original_member: (MemberId, ShareKey),
     init_add_op: Signed<CgkaOperation>,
 }
@@ -83,6 +93,11 @@ impl Hash for Cgka {
             .keys()
             .map(|k| k.as_slice())
             .collect::<BTreeSet<_>>()
+            .hash(state);
+        self.newest_encrypting_pcs_key.hash(state);
+        self.invitations
+            .iter()
+            .collect::<BTreeMap<_, _>>()
             .hash(state);
         self.original_member.hash(state);
         self.init_add_op.hash(state);
@@ -118,6 +133,8 @@ impl Cgka {
             pending_ops_for_structural_change: false,
             pcs_keys: CaMap::new(),
             pcs_key_ops: Map::new(),
+            newest_encrypting_pcs_key: None,
+            invitations: Map::new(),
             original_member: (owner_id, owner_pk),
             init_add_op: init_add_op.clone(),
         };
@@ -175,18 +192,21 @@ impl Cgka {
             let (pcs_key, update_op) = self
                 .update::<F, S, R>(new_share_key, new_share_secret_key, signer, csprng)
                 .await?;
-            self.insert_pcs_key(&pcs_key, Digest::hash(&update_op));
+            self.record_encrypting_pcs_key(&pcs_key, Digest::hash(&update_op));
             op = Some(update_op);
             pcs_key
         } else {
             let pcs_key = self.pcs_key_from_tree_root()?;
             let pcs_hash = Digest::hash(&pcs_key);
-            if !self.pcs_keys.contains_key(&pcs_hash) {
-                // `has_pcs_key()` above guarantees a single head.
-                debug_assert!(self.ops_graph.has_single_head());
-                if let Some(head) = self.ops_graph.cgka_op_heads.iter().next() {
-                    self.insert_pcs_key(&pcs_key, *head);
-                }
+            // `has_pcs_key()` above guarantees a single head.
+            debug_assert!(self.ops_graph.has_single_head());
+            let op_hash = self
+                .pcs_key_ops
+                .get(&pcs_hash)
+                .copied()
+                .or_else(|| self.ops_graph.cgka_op_heads.iter().next().copied());
+            if let Some(op_hash) = op_hash {
+                self.record_encrypting_pcs_key(&pcs_key, op_hash);
             }
             pcs_key
         };
@@ -216,9 +236,8 @@ impl Cgka {
     ) -> Result<SymmetricKey, CgkaError> {
         let pcs_key =
             self.pcs_key_from_hashes(&encrypted.pcs_key_hash, &encrypted.pcs_update_op_hash)?;
-        if !self.pcs_keys.contains_key(&encrypted.pcs_key_hash) {
-            self.insert_pcs_key(&pcs_key, encrypted.pcs_update_op_hash);
-        }
+        // We can only decrypt with a key that was at some point used to encrypt.
+        self.record_encrypting_pcs_key(&pcs_key, encrypted.pcs_update_op_hash);
         let app_secret = pcs_key.derive_application_secret(
             &encrypted.nonce,
             &encrypted.content_ref,
@@ -235,19 +254,24 @@ impl Cgka {
     }
 
     /// Add member to group.
+    ///
+    /// Returns the add operation and an [`CgkaOperation::Invite`] (if we have
+    /// access to a root secret used to encrypt content). Empty if the member is
+    /// already in the tree.
     #[instrument(skip_all)]
     pub async fn add<F: FutureForm, S: AsyncSigner<F>>(
         &mut self,
         id: MemberId,
         pk: ShareKey,
         signer: &S,
-    ) -> Result<Option<Signed<CgkaOperation>>, CgkaError> {
+    ) -> Result<Vec<Signed<CgkaOperation>>, CgkaError> {
         if self.tree.contains_id(&id) {
-            return Ok(None);
+            return Ok(Vec::new());
         }
         if self.should_replay() {
             self.replay_ops_graph()?;
         }
+        let invitation = self.invitation_for(id, pk);
         let leaf_index = self.tree.push_leaf(id, pk.into());
         let predecessors = Vec::from_iter(self.ops_graph.cgka_op_heads.iter().cloned());
         let add_predecessors = Vec::from_iter(self.ops_graph.add_heads.iter().cloned());
@@ -262,7 +286,25 @@ impl Cgka {
 
         let signed_op = async_signer::try_sign_async::<F, _, _>(signer, op).await?;
         self.ops_graph.add_local_op(&signed_op);
-        Ok(Some(signed_op))
+        let mut ops = alloc::vec![signed_op];
+
+        if let Some(invitation) = invitation {
+            let op = CgkaOperation::Invite {
+                invitation: alloc::boxed::Box::new(invitation),
+                predecessors: Vec::from_iter(self.ops_graph.cgka_op_heads.iter().cloned()),
+                doc_id: self.doc_id,
+            };
+            let signed_op = async_signer::try_sign_async::<F, _, _>(signer, op).await?;
+            self.record_invitation(&signed_op);
+            self.ops_graph.add_local_op(&signed_op);
+            ops.push(signed_op);
+        } else {
+            info!(
+                "no root secret to invite {:?} with; it can only read content written from now on",
+                id
+            );
+        }
+        Ok(ops)
     }
 
     /// Add multiple members to group.
@@ -273,9 +315,98 @@ impl Cgka {
     ) -> Result<Vec<Signed<CgkaOperation>>, CgkaError> {
         let mut ops = Vec::new();
         for m in members {
-            ops.push(self.add::<F, S>(m.0, m.1, signer).await?);
+            ops.extend(self.add::<F, S>(m.0, m.1, signer).await?);
         }
-        Ok(ops.into_iter().flatten().collect())
+        Ok(ops)
+    }
+
+    /// Build an invitation for a member we are adding.
+    ///
+    /// Returns `None` if we don't have access to any root secret that was used
+    /// to encrypt content.
+    #[instrument(skip_all)]
+    fn invitation_for(&self, invitee_id: MemberId, invitee_pk: ShareKey) -> Option<Invitation> {
+        let (root_secret, pcs_key_hash, pcs_update_op_hash) =
+            self.newest_known_encrypting_pcs_key()?;
+        let (inviter_pk, inviter_sk) = self.inviter_key_pair()?;
+        let encrypted = encrypt_secret(
+            self.doc_id.as_bytes(),
+            root_secret.0,
+            &inviter_sk,
+            &invitee_pk,
+        )
+        .ok()?;
+        Some(Invitation {
+            invitee_id,
+            invitee_pk,
+            root_secret: encrypted,
+            inviter_pk,
+            pcs_key_hash,
+            pcs_update_op_hash,
+        })
+    }
+
+    /// The newest root secret we know content is encrypted under, along with
+    /// the two hashes sent with that encrypted content. Returns `None` if we
+    /// don't know of any.
+    fn newest_known_encrypting_pcs_key(
+        &self,
+    ) -> Option<(PcsKey, Digest<PcsKey>, Digest<Signed<CgkaOperation>>)> {
+        if let Some(hash) = self.newest_encrypting_pcs_key {
+            if let (Some(key), Some(op)) = (self.pcs_keys.get(&hash), self.pcs_key_ops.get(&hash)) {
+                return Some((**key, hash, *op));
+            }
+        }
+        self.encrypting_pcs_key_from_our_invitation()
+    }
+
+    /// The root secret from an invitation addressed to us.
+    ///
+    /// If we are inviting another member in turn and do not yet have access
+    /// in the tree to a secret used for encryption, we can encrypt this secret for
+    /// the invitation instead.
+    fn encrypting_pcs_key_from_our_invitation(
+        &self,
+    ) -> Option<(PcsKey, Digest<PcsKey>, Digest<Signed<CgkaOperation>>)> {
+        [self.owner_id, MemberId::public()]
+            .into_iter()
+            .filter_map(|id| self.invitations.get(&id))
+            .flatten()
+            .find_map(|invitation| {
+                let key = self.pcs_key_from_invitation(&invitation.pcs_key_hash)?;
+                Some((key, invitation.pcs_key_hash, invitation.pcs_update_op_hash))
+            })
+    }
+
+    /// A key pair at our own leaf, for the Diffie-Hellman exchange that
+    /// encrypts an invitation.
+    ///
+    /// Falls back to Public's leaf when we are not in the tree ourselves, the
+    /// same way [`Self::update`] does. Returns `None` if neither has access.
+    fn inviter_key_pair(&self) -> Option<(ShareKey, ShareSecretKey)> {
+        let id = if self.tree.contains_id(&self.owner_id) {
+            self.owner_id
+        } else {
+            MemberId::public()
+        };
+        self.tree
+            .node_key_for_id(id)
+            .ok()?
+            .keys()
+            .into_iter()
+            .find_map(|pk| self.owner_sks.get(&pk).map(|sk| (pk, *sk)))
+    }
+
+    /// If there is an invitation, record it for the id it targets.
+    fn record_invitation(&mut self, op: &Signed<CgkaOperation>) {
+        let CgkaOperation::Invite { invitation, .. } = &op.payload else {
+            return;
+        };
+        let invitation = invitation.as_ref();
+        let stored = self.invitations.entry(invitation.invitee_id).or_default();
+        if !stored.contains(invitation) {
+            stored.push(invitation.clone());
+        }
     }
 
     /// Remove member from group.
@@ -387,6 +518,7 @@ impl Cgka {
         if !self.ops_graph.contains_predecessors(&predecessors) {
             return Err(CgkaError::OutOfOrderOperation);
         }
+        self.record_invitation(&op);
         let is_concurrent = !self.ops_graph.heads_contained_in(&predecessors);
         if is_concurrent {
             if self.pending_ops_for_structural_change {
@@ -433,6 +565,7 @@ impl Cgka {
             CgkaOperation::Update { ref new_path, .. } => {
                 self.tree.apply_path(new_path);
             }
+            CgkaOperation::Invite { .. } => self.record_invitation(&op),
         }
         self.ops_graph.add_op(&op, &op.payload.predecessors());
         Ok(())
@@ -446,12 +579,14 @@ impl Cgka {
             if epoch.len() == 1 {
                 self.apply_operation(epoch[0].clone())?;
             } else {
-                // If all operations in this epoch are updates, we can apply them
-                // directly and move on to the next epoch.
-                if epoch
-                    .iter()
-                    .all(|op| matches!(op.payload, CgkaOperation::Update { .. }))
-                {
+                // If no operation in this epoch changes the tree's structure, we can
+                // apply them directly and move on to the next epoch.
+                if epoch.iter().all(|op| {
+                    matches!(
+                        op.payload,
+                        CgkaOperation::Update { .. } | CgkaOperation::Invite { .. }
+                    )
+                }) {
                     for op in epoch.iter() {
                         self.apply_operation(op.clone())?;
                     }
@@ -525,7 +660,44 @@ impl Cgka {
                 }
             }
         }
+        // An invitation may already contain this key, in which case we don't require
+        // a rebuild.
+        if let Some(pcs_key) = self.pcs_key_from_invitation(pcs_key_hash) {
+            self.insert_pcs_key(&pcs_key, *update_op_hash);
+            return Ok(pcs_key);
+        }
         self.derive_pcs_key_for_op(update_op_hash)
+    }
+
+    /// Return this PCS key if we have it in an invitation and `None` otherwise.
+    #[instrument(skip_all)]
+    fn pcs_key_from_invitation(&self, pcs_key_hash: &Digest<PcsKey>) -> Option<PcsKey> {
+        let addressed_to_us = [self.owner_id, MemberId::public()]
+            .into_iter()
+            .filter_map(|id| self.invitations.get(&id))
+            .flatten();
+        for invitation in addressed_to_us {
+            if invitation.pcs_key_hash != *pcs_key_hash {
+                continue;
+            }
+            let Ok(plaintext) = self
+                .owner_sks
+                .try_decrypt_encryption(invitation.inviter_pk, &invitation.root_secret)
+            else {
+                continue;
+            };
+            let Ok(bytes) = <[u8; 32]>::try_from(plaintext) else {
+                continue;
+            };
+            let pcs_key = PcsKey::new(ShareSecretKey::force_from_bytes(bytes));
+            // Before returning, validate that the invitation key actually
+            // corresponds to the hash that was passed in.
+            if Digest::hash(&pcs_key) == *pcs_key_hash {
+                info!("recovered a root secret from an invitation");
+                return Some(pcs_key);
+            }
+        }
+        None
     }
 
     /// Derive [`PcsKey`] for this operation hash.
@@ -606,6 +778,40 @@ impl Cgka {
         self.pcs_keys.insert((*pcs_key).into());
     }
 
+    /// Record a PCS key that was used to encrypt content. If it's the latest
+    /// such key we know of, record it as `newest_encrypting_pcs_key`.
+    fn record_encrypting_pcs_key(
+        &mut self,
+        pcs_key: &PcsKey,
+        op_hash: Digest<Signed<CgkaOperation>>,
+    ) {
+        let hash = Digest::hash(pcs_key);
+        if !self.pcs_keys.contains_key(&hash) {
+            self.insert_pcs_key(pcs_key, op_hash);
+        }
+        if Some(hash) == self.newest_encrypting_pcs_key {
+            return;
+        }
+        if self.is_later_than_newest_encrypting_key(&op_hash) {
+            self.newest_encrypting_pcs_key = Some(hash);
+        }
+    }
+
+    fn is_later_than_newest_encrypting_key(&self, op_hash: &Digest<Signed<CgkaOperation>>) -> bool {
+        let Some(last) = self.newest_encrypting_pcs_key else {
+            return true;
+        };
+        let Some(last_op) = self.pcs_key_ops.get(&last) else {
+            return true;
+        };
+        let Some(last_lamport_ts) = self.ops_graph.lamport_ts_for(last_op) else {
+            return true;
+        };
+        self.ops_graph
+            .lamport_ts_for(op_hash)
+            .is_some_and(|lamport| lamport > last_lamport_ts)
+    }
+
     /// Extend our state with that of the provided [`Cgka`].
     #[instrument(skip_all)]
     fn update_cgka_from(&mut self, other: &Self) {
@@ -618,7 +824,19 @@ impl Cgka {
                 .map(|(hash, key)| (*hash, key.clone())),
         );
         self.pcs_key_ops.extend(other.pcs_key_ops.iter());
+        self.receive_invitations(&other.invitations);
         self.pending_ops_for_structural_change = other.pending_ops_for_structural_change;
+    }
+
+    fn receive_invitations(&mut self, other: &Map<MemberId, Vec<Invitation>>) {
+        for (member, invitations) in other.iter() {
+            let stored = self.invitations.entry(*member).or_default();
+            for invitation in invitations {
+                if !stored.contains(invitation) {
+                    stored.push(invitation.clone());
+                }
+            }
+        }
     }
 }
 
@@ -636,6 +854,16 @@ impl Merge for Cgka {
         self.ops_graph.merge(fork.ops_graph);
         self.pcs_keys.merge(fork.pcs_keys);
         self.pcs_key_ops.extend(fork.pcs_key_ops.iter());
+        self.receive_invitations(&fork.invitations);
+        // The fork may have reached content we did not, so take its newest encrypting
+        // key only if it comes later than ours.
+        if let Some(hash) = fork.newest_encrypting_pcs_key {
+            if let Some(op_hash) = self.pcs_key_ops.get(&hash).copied() {
+                if self.is_later_than_newest_encrypting_key(&op_hash) {
+                    self.newest_encrypting_pcs_key = Some(hash);
+                }
+            }
+        }
         self.replay_ops_graph()
             .expect("two valid graphs should always merge causal consistency");
     }

--- a/beekem/src/operation.rs
+++ b/beekem/src/operation.rs
@@ -3,8 +3,10 @@
 use crate::{
     collections::{Map, Set},
     content_addressed_map::CaMap,
+    encrypted::EncryptedSecret,
     error::CgkaError,
     id::{MemberId, TreeId},
+    pcs_key::PcsKey,
     topsort::TopologicalSort,
     transact::{Fork, Merge},
     tree::PathChange,
@@ -19,7 +21,11 @@ use core::{
     mem,
     ops::Deref,
 };
-use keyhive_crypto::{digest::Digest, share_key::ShareKey, signed::Signed};
+use keyhive_crypto::{
+    digest::Digest,
+    share_key::{ShareKey, ShareSecretKey},
+    signed::Signed,
+};
 use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
 
@@ -50,6 +56,36 @@ impl IntoIterator for CgkaEpoch {
     }
 }
 
+/// When a member is initially added, it has no access to the root secret until
+/// the next PCS update. An invitation gives them a way to decrypt content
+/// immediately by wrapping the latest key used for encrypting content and enough
+/// information to associate that key with that content.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub struct Invitation {
+    /// The invited member.
+    pub invitee_id: MemberId,
+
+    /// The prekey the invited member was added under.
+    pub invitee_pk: ShareKey,
+
+    /// The root secret, encrypted to [`Self::invitee_pk`].
+    pub root_secret: EncryptedSecret<ShareSecretKey>,
+
+    /// The inviter's share key corresponding to the secret key it used
+    /// to encrypt [`Self::root_secret`] via Diffie-Hellman.
+    pub inviter_pk: ShareKey,
+
+    /// Which root secret this is. Used to identify encrypted content associated
+    /// with that secret.
+    pub pcs_key_hash: Digest<PcsKey>,
+
+    /// The update operation that originally produced the root secret. Used to derive
+    /// an application secret from the root secret for decrypting content associated
+    /// with that secret.
+    pub pcs_update_op_hash: Digest<Signed<CgkaOperation>>,
+}
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum CgkaOperation {
@@ -74,6 +110,14 @@ pub enum CgkaOperation {
         predecessors: Vec<Digest<Signed<CgkaOperation>>>,
         doc_id: TreeId,
     },
+    /// Wraps an [`Invitation`] for a new member, allowing them to read content
+    /// before the next PCS update. The only [`CgkaOperation`] that does not
+    /// modify the tree.
+    Invite {
+        invitation: alloc::boxed::Box<Invitation>,
+        predecessors: Vec<Digest<Signed<CgkaOperation>>>,
+        doc_id: TreeId,
+    },
 }
 
 impl CgkaOperation {
@@ -91,11 +135,10 @@ impl CgkaOperation {
     /// The zero or more immediate causal predecessors of this operation.
     pub fn predecessors(&self) -> Set<Digest<Signed<CgkaOperation>>> {
         match self {
-            CgkaOperation::Add { predecessors, .. } => Set::from_iter(predecessors.iter().cloned()),
-            CgkaOperation::Remove { predecessors, .. } => {
-                Set::from_iter(predecessors.iter().cloned())
-            }
-            CgkaOperation::Update { predecessors, .. } => {
+            CgkaOperation::Add { predecessors, .. }
+            | CgkaOperation::Remove { predecessors, .. }
+            | CgkaOperation::Update { predecessors, .. }
+            | CgkaOperation::Invite { predecessors, .. } => {
                 Set::from_iter(predecessors.iter().cloned())
             }
         }
@@ -104,9 +147,10 @@ impl CgkaOperation {
     /// Document/tree id.
     pub fn doc_id(&self) -> &TreeId {
         match self {
-            CgkaOperation::Add { doc_id, .. } => doc_id,
-            CgkaOperation::Remove { doc_id, .. } => doc_id,
-            CgkaOperation::Update { doc_id, .. } => doc_id,
+            CgkaOperation::Add { doc_id, .. }
+            | CgkaOperation::Remove { doc_id, .. }
+            | CgkaOperation::Update { doc_id, .. }
+            | CgkaOperation::Invite { doc_id, .. } => doc_id,
         }
     }
 }
@@ -125,6 +169,10 @@ pub struct CgkaOperationGraph {
     pub cgka_op_heads: Set<Digest<Signed<CgkaOperation>>>,
 
     pub add_heads: Set<Digest<Signed<CgkaOperation>>>,
+
+    /// A Lamport timestamp for each op. An op will always have a larger timestamp
+    /// than its ancestors.
+    cgka_op_lamport_timestamps: Map<Digest<Signed<CgkaOperation>>, u32>,
 }
 
 impl Hash for CgkaOperationGraph {
@@ -145,6 +193,11 @@ impl Hash for CgkaOperationGraph {
             .hash(state);
 
         self.add_heads.iter().collect::<BTreeSet<_>>().hash(state);
+
+        self.cgka_op_lamport_timestamps
+            .iter()
+            .collect::<BTreeMap<_, _>>()
+            .hash(state);
     }
 }
 
@@ -163,6 +216,8 @@ impl Merge for CgkaOperationGraph {
             .extend(fork.cgka_ops_predecessors);
         self.cgka_op_heads.extend(fork.cgka_op_heads);
         self.add_heads.extend(fork.add_heads);
+        self.cgka_op_lamport_timestamps
+            .extend(fork.cgka_op_lamport_timestamps);
     }
 }
 
@@ -173,6 +228,7 @@ impl CgkaOperationGraph {
             cgka_ops_predecessors: Map::new(),
             cgka_op_heads: Set::new(),
             add_heads: Set::new(),
+            cgka_op_lamport_timestamps: Map::new(),
         }
     }
 
@@ -238,7 +294,26 @@ impl CgkaOperationGraph {
         if self.is_add_op(&op_hash) {
             self.add_heads.insert(op_hash);
         }
+        // Causal delivery should guarantee ops are ordered correctly
+        debug_assert!(
+            op_predecessors
+                .iter()
+                .all(|p| self.cgka_op_lamport_timestamps.contains_key(p)),
+            "predecessors should be in the graph before a descendent op"
+        );
+        // The Lamport timestamp is the greatest timestamp of the immediate causal
+        // predecessors plus 1.
+        let lamport = op_predecessors
+            .iter()
+            .filter_map(|p| self.cgka_op_lamport_timestamps.get(p).copied())
+            .max()
+            .map_or(0, |latest| latest.saturating_add(1));
+        self.cgka_op_lamport_timestamps.insert(op_hash, lamport);
         self.cgka_ops_predecessors.insert(op_hash, op_predecessors);
+    }
+
+    pub fn lamport_ts_for(&self, op_hash: &Digest<Signed<CgkaOperation>>) -> Option<u32> {
+        self.cgka_op_lamport_timestamps.get(op_hash).copied()
     }
 
     pub fn heads_contained_in(&self, heads: &Set<Digest<Signed<CgkaOperation>>>) -> bool {
@@ -382,5 +457,111 @@ impl CgkaOperationGraph {
         }
 
         Ok(NonEmpty::from_vec(op_hashes).expect("to have at least one op hash"))
+    }
+}
+
+#[cfg(test)]
+mod lamport_timestamp_tests {
+    use super::*;
+    use crate::id::TreeId;
+    use keyhive_crypto::{
+        share_key::ShareSecretKey,
+        signer::{async_signer, memory::MemorySigner},
+        verifiable::Verifiable,
+    };
+
+    async fn sign(signer: &MemorySigner, op: CgkaOperation) -> Signed<CgkaOperation> {
+        async_signer::try_sign_async::<future_form::Local, _, _>(signer, op)
+            .await
+            .unwrap()
+    }
+
+    /// A distinct operation each time.
+    fn add_op(doc_id: TreeId, leaf_index: u32) -> CgkaOperation {
+        CgkaOperation::Add {
+            added_id: MemberId::public(),
+            pk: ShareSecretKey::generate(&mut rand::thread_rng()).share_key(),
+            leaf_index,
+            predecessors: Vec::new(),
+            add_predecessors: Vec::new(),
+            doc_id,
+        }
+    }
+
+    #[tokio::test]
+    async fn lamport_ts_is_written_once_and_never_revised() {
+        let signer = MemorySigner::generate(&mut rand::thread_rng());
+        let doc_id = TreeId::from(signer.verifying_key());
+        let mut graph = CgkaOperationGraph::new();
+
+        // The first operation's ts is 0 because it has no predecessors.
+        let root = sign(&signer, add_op(doc_id, 0)).await;
+        let root_hash = Digest::hash(&root);
+        graph.add_local_op(&root);
+        assert_eq!(graph.lamport_ts_for(&root_hash), Some(0));
+
+        // Ten descendants, each following the last.
+        let mut hashes = alloc::vec![root_hash];
+        for expected in 1..=10u32 {
+            let op = sign(&signer, add_op(doc_id, expected)).await;
+            let hash = Digest::hash(&op);
+            graph.add_local_op(&op);
+            assert_eq!(graph.lamport_ts_for(&hash), Some(expected));
+            hashes.push(hash);
+
+            // And nothing already in the graph has moved.
+            for (i, earlier) in hashes.iter().enumerate() {
+                assert_eq!(graph.lamport_ts_for(earlier), Some(i as u32));
+            }
+        }
+
+        // An ancestor is always strictly earlier than its descendant.
+        assert_eq!(graph.lamport_ts_for(&hashes[3]), Some(3));
+        assert_eq!(graph.lamport_ts_for(&hashes[9]), Some(9));
+        assert!(graph.lamport_ts_for(&hashes[3]) < graph.lamport_ts_for(&hashes[9]));
+    }
+
+    #[tokio::test]
+    async fn a_merge_timestamp_is_one_greater_than_its_latest_predecessor() {
+        let signer = MemorySigner::generate(&mut rand::thread_rng());
+        let doc_id = TreeId::from(signer.verifying_key());
+        let mut graph = CgkaOperationGraph::new();
+
+        let root = sign(&signer, add_op(doc_id, 0)).await;
+        let root_hash = Digest::hash(&root);
+        graph.add_local_op(&root);
+
+        // One branch two operations long. The other only one.
+        let a1 = sign(&signer, add_op(doc_id, 1)).await;
+        let a1_hash = Digest::hash(&a1);
+        graph.add_op(&a1, &Set::from_iter([root_hash]));
+        let a2 = sign(&signer, add_op(doc_id, 2)).await;
+        let a2_hash = Digest::hash(&a2);
+        graph.add_op(&a2, &Set::from_iter([a1_hash]));
+
+        let b1 = sign(&signer, add_op(doc_id, 3)).await;
+        let b1_hash = Digest::hash(&b1);
+        graph.add_op(&b1, &Set::from_iter([root_hash]));
+
+        assert_eq!(graph.lamport_ts_for(&a2_hash), Some(2));
+        assert_eq!(graph.lamport_ts_for(&b1_hash), Some(1));
+
+        // a1 and b1 are concurrent and tie.
+        assert_eq!(
+            graph.lamport_ts_for(&a1_hash),
+            graph.lamport_ts_for(&b1_hash)
+        );
+
+        let merge = sign(&signer, add_op(doc_id, 4)).await;
+        let merge_hash = Digest::hash(&merge);
+        graph.add_op(&merge, &Set::from_iter([a2_hash, b1_hash]));
+
+        // One greater than the longer branch.
+        assert_eq!(graph.lamport_ts_for(&merge_hash), Some(3));
+
+        // Every ancestor is strictly earlier, regardless of branch.
+        for ancestor in [root_hash, a1_hash, a2_hash, b1_hash] {
+            assert!(graph.lamport_ts_for(&ancestor) < graph.lamport_ts_for(&merge_hash));
+        }
     }
 }

--- a/beekem/src/pcs_key.rs
+++ b/beekem/src/pcs_key.rs
@@ -67,6 +67,7 @@ impl<Cr: ContentRef> ApplicationSecret<Cr> {
 
 /// A key used to derive application secrets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct PcsKey(pub ShareSecretKey);
 
 impl PcsKey {

--- a/keyhive_core/src/cgka.rs
+++ b/keyhive_core/src/cgka.rs
@@ -158,12 +158,15 @@ impl Cgka {
         self.0.has_pcs_key()
     }
 
+    /// Add a member, returning its add operation and a [`CgkaOperation::Invite`]
+    /// (if we know of a root secret used to encrypt content). Empty if the member
+    /// is already in the tree.
     pub async fn add<F: FutureForm, S: AsyncSigner<F>>(
         &mut self,
         id: IndividualId,
         pk: ShareKey,
         signer: &S,
-    ) -> Result<Option<Signed<CgkaOperation>>, CgkaError> {
+    ) -> Result<Vec<Signed<CgkaOperation>>, CgkaError> {
         self.0.add(MemberId(id.verifying_key()), pk, signer).await
     }
 

--- a/keyhive_core/src/debug_events.rs
+++ b/keyhive_core/src/debug_events.rs
@@ -82,6 +82,13 @@ pub enum CgkaOperationDetails {
         path_length: usize,
         predecessors: Vec<Hash>,
     },
+    Invite {
+        invitee: Hash,
+        invitee_sharekey: Hash,
+        inviter_sharekey: Hash,
+        pcs_key: Hash,
+        predecessors: Vec<Hash>,
+    },
 }
 
 impl DebugEventTable {
@@ -241,6 +248,29 @@ impl DebugEventRow {
                                 .collect(),
                         };
                         ("Update", op_details)
+                    }
+                    beekem::operation::CgkaOperation::Invite {
+                        invitation,
+                        predecessors,
+                        ..
+                    } => {
+                        let op_details = CgkaOperationDetails::Invite {
+                            invitee: Hash::new(invitation.invitee_id.as_bytes(), nicknames),
+                            invitee_sharekey: Hash::new(
+                                invitation.invitee_pk.as_bytes(),
+                                nicknames,
+                            ),
+                            inviter_sharekey: Hash::new(
+                                invitation.inviter_pk.as_bytes(),
+                                nicknames,
+                            ),
+                            pcs_key: Hash::new(invitation.pcs_key_hash.as_slice(), nicknames),
+                            predecessors: predecessors
+                                .iter()
+                                .map(|predecessor| Hash::new(predecessor.as_slice(), nicknames))
+                                .collect(),
+                        };
+                        ("Invite", op_details)
                     }
                 };
 

--- a/keyhive_core/src/debug_events/terminal.rs
+++ b/keyhive_core/src/debug_events/terminal.rs
@@ -174,6 +174,28 @@ fn format_details(details: &DebugEventDetails, verbose: bool) -> String {
                         preds
                     )
                 }
+                CgkaOperationDetails::Invite {
+                    invitee,
+                    invitee_sharekey,
+                    inviter_sharekey,
+                    pcs_key,
+                    predecessors,
+                } => {
+                    let preds = predecessors
+                        .iter()
+                        .map(|p| p.short_hex())
+                        .collect::<Vec<String>>()
+                        .join(", ");
+                    format!(
+                        "Invitee: {}\nInvitee Sharekey: {}\nInviter Sharekey: {}\nPCS Key: \
+                         {}\nPredecessors: {}",
+                        invitee.short_hex(),
+                        invitee_sharekey.short_hex(),
+                        inviter_sharekey.short_hex(),
+                        pcs_key.short_hex(),
+                        preds
+                    )
+                }
             };
 
             if verbose {

--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -717,6 +717,7 @@ impl<
         doc.lock().await.try_decrypt_content_keyed(encrypted)
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn try_causal_decrypt_content(
         &self,
         doc: Arc<Mutex<Document<F, S, T, L>>>,

--- a/keyhive_core/src/principal/document.rs
+++ b/keyhive_core/src/principal/document.rs
@@ -290,9 +290,7 @@ impl<F: FutureForm, S: AsyncSigner<F>, T: ContentRef, L: MembershipListener<F, S
     ) -> Result<Vec<Signed<CgkaOperation>>, CgkaError> {
         let mut acc = Vec::new();
         for (id, prekey) in prekeys.iter() {
-            if let Some(op) = self.cgka_mut()?.add(*id, *prekey, signer).await? {
-                acc.push(op);
-            }
+            acc.extend(self.cgka_mut()?.add(*id, *prekey, signer).await?);
         }
         Ok(acc)
     }

--- a/keyhive_core/tests/encrypt.rs
+++ b/keyhive_core/tests/encrypt.rs
@@ -167,23 +167,8 @@ async fn test_application_secret_key_round_trips() -> TestResult {
     Ok(())
 }
 
-/// Encrypt before adding Bob, with no re-key or re-encryption afterwards.
-///
-/// Bob must not be able to decrypt that content. The content was encrypted
-/// with a PCS key derived from the CGKA tree root at an epoch when only
-/// Alice was in the tree. The path secrets that climb to that root were
-/// only ever encrypted to Alice's path, never to Bob, so Bob has no key
-/// material to recover the key. This is the forward-secrecy boundary of
-/// CGKA: a member added at epoch N cannot compute group secrets from
-/// epochs before N.
-///
-/// This document is forward-secret (the default), so there is no predecessor
-/// key chain: a member added later cannot read content from before they joined,
-/// even after a rekey. See `test_encrypt_to_added_member` for the working case
-/// where encryption happens after the add, and the forward-secrecy-disabled
-/// tests below for the model where later members can read prior history.
 #[tokio::test]
-async fn test_cannot_decrypt_content_from_before_joining() -> TestResult {
+async fn test_invitation_allows_reading_content_based_on_the_invitation_alone() -> TestResult {
     test_utils::init_logging();
 
     let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
@@ -220,27 +205,77 @@ async fn test_cannot_decrypt_content_from_before_joining() -> TestResult {
     bob.ingest_unsorted_static_events(alice_events.into_values().collect())
         .await;
 
-    // Sanity check the other side of the boundary: Alice, who encrypted the
-    // content at that epoch, can still decrypt it. This proves the ciphertext
-    // is valid and that the failure below is specific to Bob lacking the
-    // pre-join key material, not a generally broken encryption.
+    // Sanity check the other side of the boundary. Alice, who encrypted the
+    // content at that epoch, can still decrypt it.
     let doc_on_alice = alice.get_document(doc_id).await.unwrap();
     let alice_decrypted = alice
         .try_decrypt_content(doc_on_alice, encrypted.encrypted_content())
         .await?;
     assert_eq!(alice_decrypted, init_content);
 
-    // Bob cannot derive the pre-join epoch key, so decryption must fail.
+    // Bob cannot derive the PCS key from before joining from the tree. But he
+    // gets it through the invitation.
     let doc_on_bob = bob.get_document(doc_id).await.unwrap();
-    let result = bob
+    let bob_decrypted = bob
         .try_decrypt_content(doc_on_bob.clone(), encrypted.encrypted_content())
+        .await?;
+    assert_eq!(
+        bob_decrypted, init_content,
+        "Bob's invitation should open content encrypted before he joined"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invitation_is_useless_to_a_non_member() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+
+    let init_content = "hello world".as_bytes().to_vec();
+    let init_hash = blake3::hash(&init_content);
+
+    let doc = alice
+        .generate_doc(vec![], nonempty![init_hash.into()])
+        .await?;
+    let doc_id = { doc.lock().await.doc_id() };
+
+    let encrypted = alice
+        .try_encrypt_content(doc.clone(), &init_hash.into(), &vec![], &init_content)
+        .await?;
+
+    // Bob is added and so gets an invitation. Carol is not.
+    let NewKeyhive { keyhive: bob, .. } = make_keyhive().await;
+    let indie_bob = { bob.active().lock().await.individual().lock().await.clone() };
+    alice
+        .add_member(
+            Agent::Individual(indie_bob.id(), Arc::new(Mutex::new(indie_bob))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Read,
+            &[],
+        )
+        .await?;
+
+    // Hand Carol everything Bob would receive, invitation included.
+    let NewKeyhive { keyhive: carol, .. } = make_keyhive().await;
+    let alice_events = alice
+        .static_events_for_agent(&bob.active().lock().await.clone().into())
+        .await;
+    carol
+        .ingest_unsorted_static_events(alice_events.into_values().collect())
+        .await;
+
+    let Some(doc_on_carol) = carol.get_document(doc_id).await else {
+        // Carol never became a member, so she may not have the document at all.
+        return Ok(());
+    };
+    let result = carol
+        .try_decrypt_content(doc_on_carol, encrypted.encrypted_content())
         .await;
     assert!(
-        matches!(
-            result,
-            Err(keyhive_core::principal::document::DecryptError::KeyNotFound)
-        ),
-        "Bob should not be able to decrypt content from before he joined, got: {:?}",
+        result.is_err(),
+        "Carol holds no key for the prekey the invitation is encrypted to, got: {:?}",
         result.map(|_| "decrypted"),
     );
 
@@ -1954,6 +1989,377 @@ async fn test_dual_instance_public_via_server_relay_decrypt() -> TestResult {
         .try_decrypt_content(doc_on_bob, encrypted.encrypted_content())
         .await?;
     assert_eq!(decrypted, init_content);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invitation_survives_a_rotation_after_the_last_write() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+
+    let init_content = "hello world".as_bytes().to_vec();
+    let init_hash = blake3::hash(&init_content);
+
+    let doc = alice
+        .generate_doc(vec![], nonempty![init_hash.into()])
+        .await?;
+    let doc_id = { doc.lock().await.doc_id() };
+
+    let encrypted = alice
+        .try_encrypt_content(doc.clone(), &init_hash.into(), &vec![], &init_content)
+        .await?;
+
+    alice.force_pcs_update(doc.clone()).await?;
+
+    let NewKeyhive { keyhive: bob, .. } = make_keyhive().await;
+    let indie_bob = { bob.active().lock().await.individual().lock().await.clone() };
+    alice
+        .add_member(
+            Agent::Individual(indie_bob.id(), Arc::new(Mutex::new(indie_bob))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Read,
+            &[],
+        )
+        .await?;
+
+    let alice_events = alice
+        .static_events_for_agent(&bob.active().lock().await.clone().into())
+        .await;
+    bob.ingest_unsorted_static_events(alice_events.into_values().collect())
+        .await;
+
+    let doc_on_bob = bob.get_document(doc_id).await.unwrap();
+    let bob_decrypted = bob
+        .try_decrypt_content(doc_on_bob, encrypted.encrypted_content())
+        .await?;
+    assert_eq!(
+        bob_decrypted, init_content,
+        "the invitation should include the key associated with encrypted content"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_reader_invites_to_the_newest_content_it_has_read() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+
+    let first = b"written before Bob joined".to_vec();
+    let first_hash = blake3::hash(&first);
+    let second = b"written after Bob joined".to_vec();
+    let second_hash = blake3::hash(&second);
+
+    let doc = alice
+        .generate_doc(vec![], nonempty![first_hash.into()])
+        .await?;
+    let doc_id = { doc.lock().await.doc_id() };
+
+    let encrypted_first = alice
+        .try_encrypt_content(doc.clone(), &first_hash.into(), &vec![], &first)
+        .await?;
+
+    let NewKeyhive { keyhive: bob, .. } = make_keyhive().await;
+    let indie_bob = { bob.active().lock().await.individual().lock().await.clone() };
+    alice
+        .add_member(
+            Agent::Individual(indie_bob.id(), Arc::new(Mutex::new(indie_bob))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Admin,
+            &[],
+        )
+        .await?;
+
+    // Adding Bob blanked the path to the root, so this write rotates and uses
+    // a key newer than the one the first write used.
+    let encrypted_second = alice
+        .try_encrypt_content(doc.clone(), &second_hash.into(), &vec![], &second)
+        .await?;
+
+    let bob_agent: Agent<_, _, _, _> = bob.active().lock().await.clone().into();
+    let alice_events = alice.static_events_for_agent(&bob_agent).await;
+    bob.ingest_unsorted_static_events(alice_events.into_values().collect())
+        .await;
+
+    let doc_on_bob = bob.get_document(doc_id).await.unwrap();
+    assert_eq!(
+        bob.try_decrypt_content(doc_on_bob.clone(), encrypted_second.encrypted_content())
+            .await?,
+        second
+    );
+    assert_eq!(
+        bob.try_decrypt_content(doc_on_bob.clone(), encrypted_first.encrypted_content())
+            .await?,
+        first
+    );
+
+    // Bob, who has never written, adds Carol.
+    let NewKeyhive { keyhive: carol, .. } = make_keyhive().await;
+    let indie_carol = {
+        carol
+            .active()
+            .lock()
+            .await
+            .individual()
+            .lock()
+            .await
+            .clone()
+    };
+    bob.add_member(
+        Agent::Individual(indie_carol.id(), Arc::new(Mutex::new(indie_carol))),
+        &Membered::Document(doc_id, doc_on_bob.dupe()),
+        Access::Read,
+        &[],
+    )
+    .await?;
+
+    let carol_agent: Agent<_, _, _, _> = carol.active().lock().await.clone().into();
+    let mut all_events: HashMap<Digest<StaticEvent<[u8; 32]>>, StaticEvent<[u8; 32]>> =
+        HashMap::new();
+    all_events.extend(alice.static_events_for_agent(&carol_agent).await);
+    all_events.extend(bob.static_events_for_agent(&carol_agent).await);
+    carol
+        .ingest_unsorted_static_events(all_events.into_values().collect())
+        .await;
+
+    let doc_on_carol = carol.get_document(doc_id).await.unwrap();
+    assert_eq!(
+        carol
+            .try_decrypt_content(doc_on_carol.dupe(), encrypted_second.encrypted_content())
+            .await?,
+        second,
+        "the second piece is later in causal order, so Bob's invitation should \
+         include its key even though he read the first piece more recently"
+    );
+
+    let earlier = carol
+        .try_decrypt_content(doc_on_carol, encrypted_first.encrypted_content())
+        .await;
+    assert!(
+        earlier.is_err(),
+        "carol holds the key for the second piece only, got: {:?}",
+        earlier.map(|_| "decrypted")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invitation_includes_the_key_encrypting_newest() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+    let NewKeyhive { keyhive: bob, .. } = make_keyhive().await;
+
+    let first = b"first piece".to_vec();
+    let first_ref = *blake3::hash(&first).as_bytes();
+    let doc = alice.generate_doc(vec![], nonempty![first_ref]).await?;
+    let doc_id = { doc.lock().await.doc_id() };
+    let enc_first = alice
+        .try_encrypt_content(doc.dupe(), &first_ref, &vec![], &first)
+        .await?;
+
+    // Rotate so the write below is encrypted under a later key than the first
+    // write.
+    alice.force_pcs_update(doc.dupe()).await?;
+
+    let second = b"second piece".to_vec();
+    let second_ref = *blake3::hash(&second).as_bytes();
+    let enc_second = alice
+        .try_encrypt_content(doc.dupe(), &second_ref, &vec![first_ref], &second)
+        .await?;
+
+    assert_ne!(
+        enc_first.encrypted_content().pcs_key_hash,
+        enc_second.encrypted_content().pcs_key_hash,
+        "the two pieces have to be encrypted under different keys for this test \
+         to mean anything"
+    );
+
+    let indie_bob = { bob.active().lock().await.individual().lock().await.clone() };
+    alice
+        .add_member(
+            Agent::Individual(indie_bob.id(), Arc::new(Mutex::new(indie_bob))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Edit,
+            &[],
+        )
+        .await?;
+
+    let events = alice
+        .static_events_for_agent(&bob.active().lock().await.clone().into())
+        .await;
+    bob.ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let doc_on_bob = bob
+        .get_document(doc_id)
+        .await
+        .expect("bob has the document");
+    let newest = bob
+        .try_decrypt_content(doc_on_bob, enc_second.encrypted_content())
+        .await;
+    assert!(
+        newest.is_ok(),
+        "bob's invitation should include the key the newest piece used, got {:?}",
+        newest.map(|_| "decrypted")
+    );
+    Ok(())
+}
+#[tokio::test]
+async fn test_concurrent_invites_from_two_admins() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+    let NewKeyhive { keyhive: bob, .. } = make_keyhive().await;
+
+    let content = b"written before anyone else was added".to_vec();
+    let content_ref = *blake3::hash(&content).as_bytes();
+    let doc = alice.generate_doc(vec![], nonempty![content_ref]).await?;
+    let doc_id = { doc.lock().await.doc_id() };
+
+    // Encrypted first, so it predates every add below.
+    let encrypted = alice
+        .try_encrypt_content(doc.dupe(), &content_ref, &vec![], &content)
+        .await?;
+
+    let indie_bob = { bob.active().lock().await.individual().lock().await.clone() };
+    alice
+        .add_member(
+            Agent::Individual(indie_bob.id(), Arc::new(Mutex::new(indie_bob))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Admin,
+            &[],
+        )
+        .await?;
+
+    let events = alice
+        .static_events_for_agent(&bob.active().lock().await.clone().into())
+        .await;
+    bob.ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let doc_on_bob = bob
+        .get_document(doc_id)
+        .await
+        .expect("bob has the document");
+
+    let NewKeyhive { keyhive: carol, .. } = make_keyhive().await;
+    let NewKeyhive { keyhive: dave, .. } = make_keyhive().await;
+
+    // Neither admin sees the other before acting.
+    let indie_carol = {
+        carol
+            .active()
+            .lock()
+            .await
+            .individual()
+            .lock()
+            .await
+            .clone()
+    };
+    alice
+        .add_member(
+            Agent::Individual(indie_carol.id(), Arc::new(Mutex::new(indie_carol))),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Read,
+            &[],
+        )
+        .await?;
+    let indie_dave = { dave.active().lock().await.individual().lock().await.clone() };
+    bob.add_member(
+        Agent::Individual(indie_dave.id(), Arc::new(Mutex::new(indie_dave))),
+        &Membered::Document(doc_id, doc_on_bob.dupe()),
+        Access::Read,
+        &[],
+    )
+    .await?;
+
+    let events = bob
+        .static_events_for_agent(&alice.active().lock().await.clone().into())
+        .await;
+    alice
+        .ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let events = alice
+        .static_events_for_agent(&bob.active().lock().await.clone().into())
+        .await;
+    bob.ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let events = alice
+        .static_events_for_agent(&carol.active().lock().await.clone().into())
+        .await;
+    carol
+        .ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let events = alice
+        .static_events_for_agent(&dave.active().lock().await.clone().into())
+        .await;
+    dave.ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    for (reader, who) in [(&carol, "carol"), (&dave, "dave")] {
+        let doc = reader
+            .get_document(doc_id)
+            .await
+            .unwrap_or_else(|| panic!("{who} should have the document"));
+        let decrypted = reader
+            .try_decrypt_content(doc, encrypted.encrypted_content())
+            .await
+            .unwrap_or_else(|e| panic!("{who} should decrypt content from before joining: {e:?}"));
+        assert_eq!(decrypted, content, "{who} decrypted the wrong bytes");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_making_a_document_public_opens_its_history() -> TestResult {
+    test_utils::init_logging();
+
+    let NewKeyhive { keyhive: alice, .. } = make_keyhive().await;
+
+    let earlier = b"written before the document was public".to_vec();
+    let earlier_ref = *blake3::hash(&earlier).as_bytes();
+    let doc = alice.generate_doc(vec![], nonempty![earlier_ref]).await?;
+    let doc_id = { doc.lock().await.doc_id() };
+    let encrypted = alice
+        .try_encrypt_content(doc.dupe(), &earlier_ref, &vec![], &earlier)
+        .await?;
+
+    alice
+        .add_member(
+            public_agent(),
+            &Membered::Document(doc_id, doc.dupe()),
+            Access::Read,
+            &[],
+        )
+        .await?;
+
+    // Carol was never added, but like everyone she holds Public's key.
+    let NewKeyhive { keyhive: carol, .. } = make_keyhive().await;
+    let events = alice.static_events_for_agent(&public_agent()).await;
+    carol
+        .ingest_unsorted_static_events(events.into_values().collect())
+        .await;
+
+    let doc_on_carol = carol
+        .get_document(doc_id)
+        .await
+        .expect("carol has the public document");
+    let decrypted = carol
+        .try_decrypt_content(doc_on_carol, encrypted.encrypted_content())
+        .await?;
+    assert_eq!(
+        decrypted, earlier,
+        "a public document should be readable from its start, not only from the \
+         next write onward"
+    );
 
     Ok(())
 }

--- a/keyhive_wasm/src/js/cgka_operation.rs
+++ b/keyhive_wasm/src/js/cgka_operation.rs
@@ -14,6 +14,7 @@ impl JsCgkaOperation {
             CgkaOperation::Add { .. } => JsCgkaOperationVariant::Add,
             CgkaOperation::Remove { .. } => JsCgkaOperationVariant::Remove,
             CgkaOperation::Update { .. } => JsCgkaOperationVariant::Update,
+            CgkaOperation::Invite { .. } => JsCgkaOperationVariant::Invite,
         }
         .to_string()
     }
@@ -24,6 +25,7 @@ pub enum JsCgkaOperationVariant {
     Add,
     Remove,
     Update,
+    Invite,
 }
 
 impl std::fmt::Display for JsCgkaOperationVariant {
@@ -32,6 +34,7 @@ impl std::fmt::Display for JsCgkaOperationVariant {
             JsCgkaOperationVariant::Add => write!(f, "CGKA_ADD"),
             JsCgkaOperationVariant::Remove => write!(f, "CGKA_REMOVE"),
             JsCgkaOperationVariant::Update => write!(f, "CGKA_UPDATE"),
+            JsCgkaOperationVariant::Invite => write!(f, "CGKA_INVITE"),
         }
     }
 }


### PR DESCRIPTION
This PR adds a new kind of CGKA op: an `Invite`. An invite is used to provide a way for a new member to decrypt content immediately. This removes the need for the clunky and error-prone "nudge edit" strategy currently used in `automerge-repo-keyhive`.

When a new member is added to the tree, it does not yet have access to any root secret that was used to encrypt content. This means it must currently wait until a PCS update followed by newly encrypted content. The "nudge edit" forced this after adding a new member, at the cost of writing into the document. Worse, this nudge edit machinery needed to be implemented in the client.

An `Invite` wraps the last known root secret used to encrypt content. That secret is encrypted to the share key of the new member so only it can decrypt it. `Invite` ops do not alter the tree, but are kept to the side. If you can't decrypt a piece of content because you don't have access to the corresponding secret, you can check for an invitation.

Note that this means at the CGKA level (though not in the `beekem` crate itself), this is a violation of forward secrecy, since it gives you access to a root secret in a version of the tree you did not belong to. This is consistent with our current tradeoff profile for keyhive/automerge, but should be made configurable in the future.

I tested this against both ARK/keyhive-demo and a pure Rust keyhive client. Disabling the nudge edit breaks the added member's ability to decrypt on keyhive main, but not against this branch.