### PR TITLE
Refactor WASM API to match core API refactor and address existing inconsistencies

### DIFF
--- a/keyhive_core/src/keyhive.rs
+++ b/keyhive_core/src/keyhive.rs
@@ -1571,6 +1571,24 @@ impl<
         self.docs.lock().await.get(&id).duped()
     }
 
+    /// Whether a document with this id is known.
+    #[instrument(skip_all)]
+    pub async fn has_document(&self, id: DocumentId) -> bool {
+        self.docs.lock().await.contains_key(&id)
+    }
+
+    /// Whether a group with this id is known.
+    #[instrument(skip_all)]
+    pub async fn has_group(&self, id: GroupId) -> bool {
+        self.groups.lock().await.contains_key(&id)
+    }
+
+    /// Whether an individual with this id is known.
+    #[instrument(skip_all)]
+    pub async fn has_individual(&self, id: IndividualId) -> bool {
+        self.individuals.lock().await.contains_key(&id)
+    }
+
     #[instrument(skip_all)]
     pub async fn get_peer(&self, id: Identifier) -> Option<Peer<F, S, T, L>> {
         let indie_id = IndividualId(id);

--- a/keyhive_core/tests/access_control.rs
+++ b/keyhive_core/tests/access_control.rs
@@ -708,7 +708,7 @@ async fn revoking_a_group_removes_only_those_who_needed_it() -> Result<()> {
     // because they were removed.
     ctx.sync_all_unsent().await?;
     assert!(
-        bob.get_document(design_doc).await.is_some(),
+        bob.has_document(design_doc).await,
         "bob holds the document while he is still a member"
     );
 

--- a/keyhive_core/tests/archive.rs
+++ b/keyhive_core/tests/archive.rs
@@ -149,7 +149,7 @@ async fn an_instance_caught_up_by_syncing_can_read_what_it_missed() -> Result<()
 
     let restored = ctx.rebuild_from_archive(&early, "alice-restored").await?;
     assert!(
-        restored.get_document(design_doc).await.is_none(),
+        !restored.has_document(design_doc).await,
         "the archive predates the document"
     );
 

--- a/keyhive_core/tests/content.rs
+++ b/keyhive_core/tests/content.rs
@@ -253,7 +253,7 @@ async fn a_non_member_is_not_even_sent_the_document() -> Result<()> {
     ctx.sync_all_unsent().await?;
 
     assert!(
-        mallory.get_document(design_doc).await.is_none(),
+        !mallory.has_document(design_doc).await,
         "a non-member is never told the document exists"
     );
     // So the question "can she derive the key" cannot be reached, and asking is an error

--- a/keyhive_core/tests/instances.rs
+++ b/keyhive_core/tests/instances.rs
@@ -85,7 +85,7 @@ async fn a_sibling_needs_the_prekey_secrets_to_open_an_invitation() -> Result<()
     ctx.sync_all_unsent().await?;
 
     // Both instances know the document and both are members.
-    assert!(alice_worker.get_document(design_doc).await.is_some());
+    assert!(alice_worker.has_document(design_doc).await);
     assert_eq!(
         bob.access_for_doc(alice_worker.id(), design_doc).await,
         Some(Read)
@@ -161,11 +161,11 @@ async fn two_instances_creating_documents_independently_converge() -> Result<()>
     ctx.sync(&alice_worker, &alice).await?;
 
     assert!(
-        alice.get_document(from_worker).await.is_some(),
+        alice.has_document(from_worker).await,
         "alice learned about the document the worker made"
     );
     assert!(
-        alice_worker.get_document(from_alice).await.is_some(),
+        alice_worker.has_document(from_alice).await,
         "and the worker about alice's"
     );
     assert_eq!(alice.stats().await.pending_total(), 0);
@@ -271,7 +271,7 @@ async fn a_peer_cannot_read_an_instance_it_has_not_heard_from() -> Result<()> {
     // Everything alice has, which is everything except the worker's write.
     ctx.sync(&alice, &bob).await?;
     assert!(
-        bob.get_document(design_doc).await.is_some(),
+        bob.has_document(design_doc).await,
         "bob has the document itself"
     );
     assert!(

--- a/keyhive_wasm/README.md
+++ b/keyhive_wasm/README.md
@@ -18,9 +18,10 @@ Install Playwright's browser binaries:
 npx playwright install
 ```
 
-Run tests:
+Run tests. This builds the Wasm package and copies it where the test server
+serves it from, so it picks up Rust changes:
 ```
-npx playwright test
+pnpm test
 ```
 
 View Playwright report:

--- a/keyhive_wasm/e2e/document.spec.ts
+++ b/keyhive_wasm/e2e/document.spec.ts
@@ -6,27 +6,26 @@ test.beforeEach(async ({ page }) => {
   await page.waitForFunction(() => !!window.keyhive);
 });
 
-test.describe("Document", async () => {
-  test("constructor", async ({ page }) => {
-    const out = await page.evaluate(async () => {
-      const { Keyhive, Signer, ChangeId, CiphertextStore } = window.keyhive;
+test("the id generateDocument returns resolves to that document", async ({
+  page,
+}) => {
+  const out = await page.evaluate(async () => {
+    const { Keyhive, Signer, ChangeId, CiphertextStore } = window.keyhive;
 
-      const store = CiphertextStore.newInMemory();
-      const kh = await Keyhive.init(
-        await Signer.generate(),
-        store,
-        console.log
-      );
-      const changeId = new ChangeId(new Uint8Array([1, 2, 3]));
+    const store = CiphertextStore.newInMemory();
+    const kh = await Keyhive.init(await Signer.generate(), store, console.log);
+    const changeId = new ChangeId(new Uint8Array([1, 2, 3]));
 
-      const g = await kh.generateGroup([])
-      const doc = await kh.generateDocument([g.toPeer()], changeId, [])
-      const docId = doc.id
+    const groupId = await kh.generateGroup([]);
+    const docId = await kh.generateDocument(
+      [groupId.toIdentifier()],
+      changeId,
+      [],
+    );
+    const doc = await kh.getDocument(docId);
 
-      return { doc, docId };
-    });
-
-    expect(out.doc).toBeDefined();
-    expect(out.docId).toBeDefined();
+    return { docId: docId.toString(), fetchedId: doc.docId.toString() };
   });
+
+  expect(out.fetchedId).toBe(out.docId);
 });

--- a/keyhive_wasm/e2e/keyhive.spec.ts
+++ b/keyhive_wasm/e2e/keyhive.spec.ts
@@ -42,35 +42,28 @@ test.describe("Keyhive", async () => {
       const vk = sk.verifyingKey;
       const store = CiphertextStore.newInMemory();
       const keyhive = await Keyhive.init(sk, store, console.log);
-      return { id: keyhive.id.bytes, vk };
+      return { id: keyhive.id.toBytes(), vk };
     });
 
     expect(out.id).toStrictEqual(out.vk);
   });
 
-  test.describe("idString", async () => {
-    const scenario = async () => {
+  test("idString is 0x followed by 64 hex digits", async ({ page }) => {
+    const out = await page.evaluate(async () => {
       const { Keyhive, Signer, CiphertextStore } = window.keyhive;
       const key = await Signer.generate();
-      const vKey = key.verifyingKey;
       const store = CiphertextStore.newInMemory();
       const keyhive = await Keyhive.init(key, store, console.log);
-      return { idString: keyhive.idString, vKey };
-    };
-
-    test("is >= 66 charecters", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.idString.length).toBeLessThanOrEqual(66);
+      return { idString: keyhive.idString };
     });
 
-    test("is a hex string starting with 0x", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.idString).toMatch(/0x[0-9a-fA-F]+/);
-    });
+    expect(out.idString).toMatch(/^0x[0-9a-f]{64}$/);
   });
 
-  test.describe("generateGroup", async () => {
-    const scenario = async () => {
+  test("generateGroup returns the id of a group whose sole member is an admin", async ({
+    page,
+  }) => {
+    const out = await page.evaluate(async () => {
       const { Keyhive, Signer, CiphertextStore } = window.keyhive;
       const store = CiphertextStore.newInMemory();
       const keyhive = await Keyhive.init(
@@ -79,41 +72,36 @@ test.describe("Keyhive", async () => {
         (_) => {},
       );
 
-      const group = await keyhive.generateGroup([]);
-      const { groupId } = group;
+      const groupId = await keyhive.generateGroup([]);
+      const group = await keyhive.getGroup(groupId);
       const members = await group.members();
-      const canStr = members[0].can.toString();
-      return { group, groupId, members, canStr };
-    };
-
-    test("makes a new group", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.group).toBeDefined();
+      return {
+        groupId: groupId.toString(),
+        fetchedGroupId: group.groupId.toString(),
+        members,
+        canStr: members[0].can.toString(),
+      };
     });
 
-    test("the associated group has an groupId (is an actual group)", async ({
-      page,
-    }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.groupId).toBeDefined();
-    });
-
-    test("group has exacty one member", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.members).toHaveLength(1);
-    });
-
-    test("the sole group member is an admin", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.canStr).toStrictEqual("Admin");
-    });
+    expect(out.fetchedGroupId).toBe(out.groupId);
+    expect(out.members).toHaveLength(1);
+    expect(out.canStr).toStrictEqual("Admin");
   });
 
-  test.describe("archive", async () => {
-    const testContactCardJson = getTestContactCard();
-    const scenario = async (contactCardJson) => {
-      const { Keyhive, Signer, Access, Archive, ChangeId, CiphertextStore, ContactCard, Individual } =
-        window.keyhive
+  test("an archive serializes to bytes and round trips back to a keyhive", async ({
+    page,
+  }) => {
+    const out = await page.evaluate(async (contactCardJson) => {
+      const {
+        Keyhive,
+        Signer,
+        Access,
+        Archive,
+        ChangeId,
+        CiphertextStore,
+        ContactCard,
+        MemberedId,
+      } = window.keyhive;
       const testContactCard = ContactCard.fromJson(contactCardJson);
 
       const signer = await Signer.generate();
@@ -121,81 +109,110 @@ test.describe("Keyhive", async () => {
       const kh = await Keyhive.init(signer, ciphertextStore, () => {});
       const changeId = new ChangeId(new Uint8Array([1, 2, 3]));
 
-      const g1 = await kh.generateGroup([]);
-      const arr = [g1.toPeer()];
-      const g2 = await kh.generateGroup(arr);
+      const g1Id = await kh.generateGroup([]);
+      const arr = [g1Id.toIdentifier()];
+      const g2Id = await kh.generateGroup(arr);
       const _ = await kh.generateGroup(arr);
-      const d1 = await kh.generateDocument([g2.toPeer()], changeId, []);
-      await kh.generateGroup([d1.toPeer()]);
-      await kh.generateGroup([g2.toPeer(), d1.toPeer()]);
+      const d1Id = await kh.generateDocument(
+        [g2Id.toIdentifier()],
+        changeId,
+        [],
+      );
+      await kh.generateGroup([d1Id.toIdentifier()]);
+      await kh.generateGroup([g2Id.toIdentifier(), d1Id.toIdentifier()]);
 
-      const individual = await kh.receiveContactCard(testContactCard)
+      const individualId = await kh.receiveContactCard(testContactCard);
       const access = Access.tryFromString("edit");
-      await kh.addMember(individual.toAgent(), g2.toMembered(), access, []);
+      await kh.addMember(
+        individualId.toIdentifier(),
+        MemberedId.group(g2Id),
+        access,
+        [],
+      );
 
-      const archive = await kh.intoArchive();
+      const archive = await kh.toArchive();
       const archiveBytes = archive.toBytes();
       const archiveBytesIsUint8Array = archiveBytes instanceof Uint8Array;
       const newStore = CiphertextStore.newInMemory();
       const archive2 = new Archive(archiveBytes);
-      const roundTrip = await archive2.tryToKeyhive(
-        newStore,
-        signer
-      );
+      const roundTrip = await archive2.tryToKeyhive(newStore, signer);
       return {
         archive,
         archiveBytes,
         keyhive: kh,
         roundTrip,
-        archiveBytesIsUint8Array
+        archiveBytesIsUint8Array,
       };
-    }
+    }, getTestContactCard());
 
-    test("makes a new group", async ({ page }) => {
-      const out = await page.evaluate(scenario, testContactCardJson);
-      expect(out.keyhive).toBeDefined();
-    });
-
-    test("serializes to bytes", async ({ page }) => {
-      const out = await page.evaluate(scenario, testContactCardJson);
-      expect(out.archiveBytesIsUint8Array).toBe(true);
-    });
-
-    test("round trip", async ({ page }) => {
-      const out = await page.evaluate(scenario, testContactCardJson);
-      expect(out.keyhive.id).toBe(out.roundTrip.id);
-    });
+    expect(out.archiveBytesIsUint8Array).toBe(true);
+    expect(out.keyhive.id).toBe(out.roundTrip.id);
   });
 
-  test.describe("event listener", async () => {
-    const scenario = async () => {
+  test("receiveContactCard returns the id for the card", async ({ page }) => {
+    const out = await page.evaluate(async (contactCardJson) => {
+      const { Keyhive, Signer, CiphertextStore, ContactCard } = window.keyhive;
+      const card = ContactCard.fromJson(contactCardJson);
+      const kh = await Keyhive.init(
+        await Signer.generate(),
+        CiphertextStore.newInMemory(),
+        () => {},
+      );
+      const individualId = await kh.receiveContactCard(card);
+      return {
+        received: individualId.toString(),
+        expected: card.individualId.toString(),
+      };
+    }, getTestContactCard());
+
+    expect(out.received).toBe(out.expected);
+  });
+
+  test("a listener records a prekey rotation", async ({ page }) => {
+    const out = await page.evaluate(async () => {
       const { Keyhive, Signer, CiphertextStore } = window.keyhive;
       const events = [];
-      const ciphertextStore = CiphertextStore.newInMemory();
       const keyhive = await Keyhive.init(
         await Signer.generate(),
-        ciphertextStore,
+        CiphertextStore.newInMemory(),
         (event) => {
-          console.log(event);
           events.push(event.variant);
         },
       );
 
       await keyhive.expandPrekeys();
       return { events };
-    };
-
-    test("records a prekey rotation", async ({ page }) => {
-      const out = await page.evaluate(scenario);
-      expect(out.events).toHaveLength(1);
-      expect(out.events[0]).toBe("PREKEYS_EXPANDED");
     });
+
+    expect(out.events).toHaveLength(1);
+    expect(out.events[0]).toBe("PREKEYS_EXPANDED");
+  });
+
+  test("a listener that throws leaves the keyhive usable", async ({ page }) => {
+    const out = await page.evaluate(async () => {
+      const { Keyhive, Signer, CiphertextStore } = window.keyhive;
+      const keyhive = await Keyhive.init(
+        await Signer.generate(),
+        CiphertextStore.newInMemory(),
+        () => {
+          throw new Error("listener failed");
+        },
+      );
+
+      await keyhive.expandPrekeys();
+      return { idString: keyhive.idString };
+    });
+
+    expect(out.idString).toMatch(/^0x[0-9a-f]{64}$/);
   });
 
   test.describe("archive ingestion across keyhives", async () => {
-    test("different keyhive can ingest archive with document", async ({ page }) => {
+    test("different keyhive can ingest archive with document", async ({
+      page,
+    }) => {
       const out = await page.evaluate(async () => {
-        const { Keyhive, Signer, ChangeId, CiphertextStore, Archive } = window.keyhive;
+        const { Keyhive, Signer, ChangeId, CiphertextStore, Archive } =
+          window.keyhive;
 
         // Create first keyhive and a document
         const signer1 = await Signer.generate();
@@ -244,7 +261,16 @@ test.describe("Keyhive", async () => {
     test("can load archive after revoking a delegation", async ({ page }) => {
       const testContactCardJson = getTestContactCard();
       const out = await page.evaluate(async (contactCardJson) => {
-        const { Keyhive, Signer, ChangeId, CiphertextStore, Archive, ContactCard, Access } = window.keyhive;
+        const {
+          Keyhive,
+          Signer,
+          ChangeId,
+          CiphertextStore,
+          Archive,
+          ContactCard,
+          Access,
+          MemberedId,
+        } = window.keyhive;
 
         const testContactCard = ContactCard.fromJson(contactCardJson);
 
@@ -252,15 +278,17 @@ test.describe("Keyhive", async () => {
         const store = CiphertextStore.newInMemory();
         const kh = await Keyhive.init(signer, store, () => {});
         const changeId = new ChangeId(new Uint8Array([1, 2, 3]));
-        const doc = await kh.generateDocument([], changeId, []);
+        const docId = await kh.generateDocument([], changeId, []);
 
         // Delegate to an individual
-        const individual = await kh.receiveContactCard(testContactCard);
+        const individualId = await kh.receiveContactCard(testContactCard);
+        const member = individualId.toIdentifier();
+        const membered = MemberedId.document(docId);
         const access = Access.tryFromString("edit");
-        await kh.addMember(individual.toAgent(), doc.toMembered(), access, []);
+        await kh.addMember(member, membered, access, []);
 
         // Revoke that individual
-        await kh.revokeMember(individual.toAgent(), true, doc.toMembered());
+        await kh.revokeMember(member, true, membered);
 
         // Create an archive
         const archive = await kh.toArchive();
@@ -272,10 +300,7 @@ test.describe("Keyhive", async () => {
         try {
           const freshStore = CiphertextStore.newInMemory();
           const archiveToLoad = new Archive(archiveBytes);
-          const freshKh = await archiveToLoad.tryToKeyhive(
-            freshStore,
-            signer,
-          );
+          const freshKh = await archiveToLoad.tryToKeyhive(freshStore, signer);
           loadSuccess = true;
         } catch (e) {
           loadError = {
@@ -292,7 +317,10 @@ test.describe("Keyhive", async () => {
       }, testContactCardJson);
 
       if (!out.loadSuccess) {
-        console.log("Load failed with error:", JSON.stringify(out.loadError, null, 2));
+        console.log(
+          "Load failed with error:",
+          JSON.stringify(out.loadError, null, 2),
+        );
       }
 
       expect(out.loadSuccess).toBe(true);

--- a/keyhive_wasm/e2e/signed.spec.ts
+++ b/keyhive_wasm/e2e/signed.spec.ts
@@ -15,9 +15,7 @@ test.describe("Signed", async () => {
         const { Signer } = window.keyhive;
         const key = await Signer.generate();
         const signed = await key.trySign(new Uint8Array(input.toSign));
-        const { payload, verifyingKey, signature } = signed;
-        const verified = signed.verify();
-        return { input, payload, verifyingKey, signature, verified, key };
+        return { verified: signed.verify() };
       },
       { toSign },
     );
@@ -31,7 +29,7 @@ test.describe("Signed", async () => {
         const { Signer } = window.keyhive;
         const key = await Signer.generate();
         const signed = await key.trySign(new Uint8Array(input.toSign));
-        return { payload: signed.payload };
+        return { payload: signed.payload() };
       },
       { toSign },
     );

--- a/keyhive_wasm/e2e/signer.spec.ts
+++ b/keyhive_wasm/e2e/signer.spec.ts
@@ -62,8 +62,7 @@ test.describe("Signer", async () => {
         const { Signer } = window.keyhive;
         const key = Signer.generateMemory();
         const signed = await key.trySign(new Uint8Array(input.toSign));
-        const { payload, verifyingKey, signature } = signed;
-        return { input, payload, verifyingKey, signature, key };
+        return { payload: signed.payload(), signature: signed.signature };
       };
 
       test("has a signature", async ({ page }) => {
@@ -137,8 +136,7 @@ test.describe("Signer", async () => {
         const { Signer } = window.keyhive;
         const key = await Signer.generateWebCrypto();
         const signed = await key.trySign(new Uint8Array(input.toSign));
-        const { payload, verifyingKey, signature } = signed;
-        return { input, payload, verifyingKey, signature, key };
+        return { payload: signed.payload(), signature: signed.signature };
       };
 
       test("has a signature", async ({ page, browserName }) => {

--- a/keyhive_wasm/package.json
+++ b/keyhive_wasm/package.json
@@ -9,7 +9,8 @@
     "build-bundler": "wasm-pack build --out-dir pkg --target bundler --release",
     "build-web": "wasm-pack build --out-dir pkg-web --target web --release",
     "build-slim": "node build_slim.js",
-    "copy-e2e": "cp -r pkg-slim/* e2e/server/pkg/"
+    "copy-e2e": "mkdir -p pkg && cp -r pkg-slim/* e2e/server/pkg/",
+    "test": "pnpm run build-slim && pnpm run copy-e2e && playwright test --project=chromium"
   },
   "keywords": [],
   "author": "",

--- a/keyhive_wasm/src/js.rs
+++ b/keyhive_wasm/src/js.rs
@@ -28,7 +28,7 @@ pub mod individual;
 pub mod individual_id;
 pub mod invocation;
 pub mod keyhive;
-pub mod membered;
+pub mod membered_id;
 pub mod membership;
 pub mod peer;
 pub mod revocation;

--- a/keyhive_wasm/src/js/agent.rs
+++ b/keyhive_wasm/src/js/agent.rs
@@ -30,17 +30,17 @@ impl JsAgent {
             })
     }
 
-    #[wasm_bindgen(js_name = isIndividual)]
+    #[wasm_bindgen(getter, js_name = isIndividual)]
     pub fn is_individual(&self) -> bool {
         matches!(self.0, Agent::Individual(_, _))
     }
 
-    #[wasm_bindgen(js_name = isGroup)]
+    #[wasm_bindgen(getter, js_name = isGroup)]
     pub fn is_group(&self) -> bool {
         matches!(self.0, Agent::Group(_, _))
     }
 
-    #[wasm_bindgen(js_name = isDocument)]
+    #[wasm_bindgen(getter, js_name = isDocument)]
     pub fn is_document(&self) -> bool {
         matches!(self.0, Agent::Document(_, _))
     }

--- a/keyhive_wasm/src/js/archive.rs
+++ b/keyhive_wasm/src/js/archive.rs
@@ -39,14 +39,14 @@ impl JsArchive {
     #[wasm_bindgen(js_name = tryToKeyhive)]
     pub async fn try_to_keyhive(
         &self,
-        ciphertext_store: JsCiphertextStore,
+        ciphertext_store: &JsCiphertextStore,
         signer: &JsSigner,
         event_handler: &js_sys::Function,
     ) -> Result<JsKeyhive, JsTryFromArchiveError> {
         Ok(Keyhive::try_from_archive(
             &self.0,
             signer.clone(),
-            ciphertext_store,
+            ciphertext_store.clone(),
             event_handler.clone().into(),
             Arc::new(Mutex::new(OsRng)),
         )

--- a/keyhive_wasm/src/js/change_id.rs
+++ b/keyhive_wasm/src/js/change_id.rs
@@ -18,8 +18,8 @@ impl JsChangeId {
         Self(bytes)
     }
 
-    #[wasm_bindgen(getter)]
-    pub fn bytes(&self) -> Vec<u8> {
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.0.clone()
     }
 

--- a/keyhive_wasm/src/js/contact_card.rs
+++ b/keyhive_wasm/src/js/contact_card.rs
@@ -34,6 +34,7 @@ impl JsContactCard {
         JsEvent(Event::from(self.0.op().clone()))
     }
 
+    #[wasm_bindgen(getter)]
     pub fn signature(&self) -> Vec<u8> {
         self.0.signature().to_bytes().to_vec()
     }

--- a/keyhive_wasm/src/js/decrypted_keyed.rs
+++ b/keyhive_wasm/src/js/decrypted_keyed.rs
@@ -9,7 +9,7 @@ pub struct JsDecryptedKeyed {
 
 #[wasm_bindgen(js_class = DecryptedKeyed)]
 impl JsDecryptedKeyed {
-    #[wasm_bindgen(getter)]
+    /// Copies the plaintext out of wasm memory on every call.
     pub fn plaintext(&self) -> Vec<u8> {
         self.plaintext.clone()
     }

--- a/keyhive_wasm/src/js/doc_content_refs.rs
+++ b/keyhive_wasm/src/js/doc_content_refs.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use super::{change_id::JsChangeId, document_id::JsDocumentId};
+use super::{
+    change_id::{JsChangeId, JsChangeIdRef},
+    document_id::JsDocumentId,
+};
+use from_js_ref::FromJsRef;
 use futures::lock::Mutex;
 use wasm_bindgen::prelude::*;
 
@@ -13,16 +17,18 @@ pub struct DocContentRefs {
 #[wasm_bindgen]
 impl DocContentRefs {
     #[wasm_bindgen(constructor)]
-    pub fn new(doc_id: JsDocumentId, change_hashes: Vec<JsChangeId>) -> Result<Self, String> {
-        Ok(Self {
-            doc_id,
-            change_hashes: Arc::new(Mutex::new(change_hashes)),
-        })
+    pub fn new(doc_id: &JsDocumentId, change_hashes: Vec<JsChangeIdRef>) -> Self {
+        Self {
+            doc_id: *doc_id,
+            change_hashes: Arc::new(Mutex::new(
+                change_hashes.iter().map(JsChangeId::from_js_ref).collect(),
+            )),
+        }
     }
 
     #[wasm_bindgen(js_name = addChangeId)]
-    pub async fn add_change_id(&self, hash: JsChangeId) {
-        self.change_hashes.lock().await.push(hash)
+    pub async fn add_change_id(&self, hash: &JsChangeId) {
+        self.change_hashes.lock().await.push(hash.clone())
     }
 
     #[wasm_bindgen(getter, js_name = docId)]
@@ -30,7 +36,7 @@ impl DocContentRefs {
         self.doc_id
     }
 
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(js_name = changeHashes)]
     pub async fn change_hashes(&self) -> Vec<JsChangeId> {
         self.change_hashes.lock().await.clone()
     }

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -1,4 +1,4 @@
-use crate::js::{document_id::JsDocumentId, membered::JsMembered};
+use crate::js::document_id::JsDocumentId;
 
 use super::{
     agent::JsAgent, capability::Capability, change_id::JsChangeId, event_handler::JsEventHandler,
@@ -11,7 +11,6 @@ use futures::lock::Mutex;
 use keyhive_core::principal::{
     agent::Agent,
     document::{id::DocumentId, Document},
-    membered::Membered,
     peer::Peer,
 };
 use std::sync::Arc;
@@ -47,11 +46,6 @@ impl JsDocument {
     pub fn to_agent(&self) -> JsAgent {
         tracing::debug!("JsDocument::to_agent");
         JsAgent(Agent::Document(self.doc_id, self.inner.dupe()))
-    }
-
-    #[wasm_bindgen(js_name = toMembered)]
-    pub fn to_membered(&self) -> JsMembered {
-        JsMembered(Membered::Document(self.doc_id, self.inner.dupe()))
     }
 
     /// The individuals in this document's CGKA tree.

--- a/keyhive_wasm/src/js/document.rs
+++ b/keyhive_wasm/src/js/document.rs
@@ -15,7 +15,6 @@ use keyhive_core::principal::{
 };
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
-use wasm_refgen::wasm_refgen;
 
 #[wasm_bindgen(js_name = Document)]
 #[derive(Debug, Clone, Dupe)]
@@ -24,7 +23,6 @@ pub struct JsDocument {
     pub(crate) inner: Arc<Mutex<Document<Local, JsSigner, JsChangeId, JsEventHandler>>>,
 }
 
-#[wasm_refgen(js_ref = JsDocumentRef)]
 #[wasm_bindgen(js_class = Document)]
 impl JsDocument {
     #[wasm_bindgen(getter)]
@@ -32,7 +30,7 @@ impl JsDocument {
         JsIdentifier(self.doc_id.into())
     }
 
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = docId)]
     pub fn doc_id(&self) -> JsDocumentId {
         JsDocumentId(self.doc_id)
     }

--- a/keyhive_wasm/src/js/document_id.rs
+++ b/keyhive_wasm/src/js/document_id.rs
@@ -1,12 +1,15 @@
+use crate::js::identifier::JsIdentifier;
 use derive_more::{Display, From, Into};
 use keyhive_core::principal::{document::id::DocumentId, identifier::Identifier};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
+use wasm_refgen::wasm_refgen;
 
 #[wasm_bindgen(js_name = DocumentId)]
 #[derive(Debug, Clone, Copy, Display, From, Into)]
 pub struct JsDocumentId(pub(crate) keyhive_core::principal::document::id::DocumentId);
 
+#[wasm_refgen(js_ref = JsDocumentIdRef)]
 #[wasm_bindgen(js_class = DocumentId)]
 impl JsDocumentId {
     #[wasm_bindgen(constructor)]
@@ -32,6 +35,11 @@ impl JsDocumentId {
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()
+    }
+
+    #[wasm_bindgen(js_name = toIdentifier)]
+    pub fn to_identifier(&self) -> JsIdentifier {
+        JsIdentifier(Identifier::from(self.0))
     }
 }
 

--- a/keyhive_wasm/src/js/encrypted.rs
+++ b/keyhive_wasm/src/js/encrypted.rs
@@ -11,11 +11,7 @@ pub struct JsEncrypted(pub(crate) EncryptedContent<Vec<u8>, JsChangeId>);
 #[wasm_bindgen(js_class = Encrypted)]
 impl JsEncrypted {
     #[wasm_bindgen(js_name = toBytes)]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.ciphertext.clone()
-    }
-
-    pub fn serialize(&self) -> Result<Vec<u8>, JsValue> {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, JsValue> {
         bincode::serialize(&self.0).map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
@@ -26,7 +22,7 @@ impl JsEncrypted {
         Ok(JsEncrypted(encrypted))
     }
 
-    #[wasm_bindgen(getter)]
+    /// Copies the ciphertext out of wasm memory on every call.
     pub fn ciphertext(&self) -> Vec<u8> {
         self.0.ciphertext.clone()
     }
@@ -36,17 +32,18 @@ impl JsEncrypted {
         self.0.nonce.as_bytes().to_vec()
     }
 
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = pcsKeyHash)]
     pub fn pcs_key_hash(&self) -> Vec<u8> {
         self.0.pcs_key_hash.raw.as_bytes().to_vec()
     }
 
-    #[wasm_bindgen(getter)]
+    /// Copies the content ref out of wasm memory on every call.
+    #[wasm_bindgen(js_name = contentRef)]
     pub fn content_ref(&self) -> Vec<u8> {
-        self.0.content_ref.bytes().to_vec()
+        self.0.content_ref.to_bytes()
     }
 
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = predRefs)]
     pub fn pred_refs(&self) -> Vec<u8> {
         self.0.pred_refs.raw.as_bytes().to_vec()
     }

--- a/keyhive_wasm/src/js/encrypted_content_with_update.rs
+++ b/keyhive_wasm/src/js/encrypted_content_with_update.rs
@@ -11,10 +11,12 @@ pub struct JsEncryptedContentWithUpdate(pub(crate) EncryptedContentWithUpdate<Js
 
 #[wasm_bindgen(js_class = EncryptedContentWithUpdate)]
 impl JsEncryptedContentWithUpdate {
+    #[wasm_bindgen(js_name = encryptedContent)]
     pub fn encrypted_content(&self) -> JsEncrypted {
         self.0.encrypted_content().clone().into()
     }
 
+    #[wasm_bindgen(js_name = updateOp)]
     pub fn update_op(&self) -> Option<JsSignedCgkaOperation> {
         self.0.update_op().map(|op| op.clone().into())
     }

--- a/keyhive_wasm/src/js/encrypted_keyed.rs
+++ b/keyhive_wasm/src/js/encrypted_keyed.rs
@@ -14,10 +14,12 @@ pub struct JsEncryptedKeyed {
 
 #[wasm_bindgen(js_class = EncryptedKeyed)]
 impl JsEncryptedKeyed {
+    #[wasm_bindgen(js_name = encryptedContent)]
     pub fn encrypted_content(&self) -> JsEncrypted {
         self.inner.encrypted_content().clone().into()
     }
 
+    #[wasm_bindgen(js_name = updateOp)]
     pub fn update_op(&self) -> Option<JsSignedCgkaOperation> {
         self.inner.update_op().map(|op| op.clone().into())
     }

--- a/keyhive_wasm/src/js/event.rs
+++ b/keyhive_wasm/src/js/event.rs
@@ -31,16 +31,16 @@ impl JsEvent {
         matches!(self.0, Event::Revoked(_))
     }
 
-    #[wasm_bindgen(js_name = tryIntoSignedDelegation)]
-    pub fn try_into_signed_delegation(&self) -> Option<JsSignedDelegation> {
+    #[wasm_bindgen(js_name = asSignedDelegation)]
+    pub fn as_signed_delegation(&self) -> Option<JsSignedDelegation> {
         match &self.0 {
             Event::Delegated(d) => Some(d.dupe().into()),
             _ => None,
         }
     }
 
-    #[wasm_bindgen(js_name = tryIntoSignedRevocation)]
-    pub fn try_into_signed_revocation(&self) -> Option<JsSignedRevocation> {
+    #[wasm_bindgen(js_name = asSignedRevocation)]
+    pub fn as_signed_revocation(&self) -> Option<JsSignedRevocation> {
         match &self.0 {
             Event::Revoked(r) => Some(r.dupe().into()),
             _ => None,

--- a/keyhive_wasm/src/js/event_handler.rs
+++ b/keyhive_wasm/src/js/event_handler.rs
@@ -21,7 +21,12 @@ pub struct JsEventHandler(pub(crate) js_sys::Function);
 
 impl JsEventHandler {
     pub fn call(&self, event: JsEvent) {
-        self.0.call1(&JsValue::NULL, &event.into()).unwrap();
+        // A listener is application code and may throw. The event is dispatched
+        // while a lock is held, so unwrapping the error unwinds without dropping
+        // the guard, and every later locking call then blocks forever.
+        if let Err(err) = self.0.call1(&JsValue::NULL, &event.into()) {
+            tracing::warn!(?err, "event listener threw");
+        }
     }
 }
 

--- a/keyhive_wasm/src/js/generate_doc_error.rs
+++ b/keyhive_wasm/src/js/generate_doc_error.rs
@@ -1,5 +1,5 @@
 use derive_more::{Display, From};
-use keyhive_core::{error::not_found::NotFound, principal::document::GenerateDocError};
+use keyhive_core::principal::document::GenerateDocError;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
@@ -8,10 +8,6 @@ pub enum JsGenerateDocError {
     /// Generating the document failed.
     #[display("{_0}")]
     GenerateDoc(GenerateDocError),
-
-    /// The document was created and could not then be read back.
-    #[display("{_0}")]
-    NotFound(NotFound),
 }
 
 impl From<JsGenerateDocError> for JsValue {

--- a/keyhive_wasm/src/js/generate_group_error.rs
+++ b/keyhive_wasm/src/js/generate_group_error.rs
@@ -1,5 +1,5 @@
 use derive_more::{Display, From};
-use keyhive_core::{error::not_found::NotFound, keyhive::GenerateGroupError};
+use keyhive_core::keyhive::GenerateGroupError;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 
@@ -8,10 +8,6 @@ pub enum JsGenerateGroupError {
     /// Generating the group failed.
     #[display("{_0}")]
     GenerateGroup(GenerateGroupError),
-
-    /// The group was created and could not then be read back.
-    #[display("{_0}")]
-    NotFound(NotFound),
 }
 
 impl From<JsGenerateGroupError> for JsValue {

--- a/keyhive_wasm/src/js/group.rs
+++ b/keyhive_wasm/src/js/group.rs
@@ -1,5 +1,3 @@
-use crate::js::membered::JsMembered;
-
 use super::{
     agent::JsAgent,
     capability::Capability,
@@ -18,7 +16,6 @@ use futures::lock::Mutex;
 use keyhive_core::principal::{
     agent::Agent,
     group::{id::GroupId, Group},
-    membered::Membered,
     peer::Peer,
 };
 use std::sync::Arc;
@@ -83,10 +80,5 @@ impl JsGroup {
     pub fn to_agent(&self) -> JsAgent {
         tracing::debug!("JsGroup::to_agent");
         JsAgent(Agent::Group(self.group_id, self.inner.dupe()))
-    }
-
-    #[wasm_bindgen(js_name = toMembered)]
-    pub fn to_membered(&self) -> JsMembered {
-        JsMembered(Membered::Group(self.group_id, self.inner.dupe()))
     }
 }

--- a/keyhive_wasm/src/js/group.rs
+++ b/keyhive_wasm/src/js/group.rs
@@ -20,7 +20,6 @@ use keyhive_core::principal::{
 };
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
-use wasm_refgen::wasm_refgen;
 
 #[wasm_bindgen(js_name = Group)]
 #[derive(Debug, Clone, Dupe, Into, From)]
@@ -29,7 +28,6 @@ pub struct JsGroup {
     pub(crate) inner: Arc<Mutex<Group<Local, JsSigner, JsChangeId, JsEventHandler>>>,
 }
 
-#[wasm_refgen(js_ref = JsGroupRef)]
 #[wasm_bindgen(js_class = Group)]
 impl JsGroup {
     #[wasm_bindgen(getter)]

--- a/keyhive_wasm/src/js/group_id.rs
+++ b/keyhive_wasm/src/js/group_id.rs
@@ -1,3 +1,4 @@
+use crate::js::identifier::JsIdentifier;
 use keyhive_core::principal::{group::id::GroupId, identifier::Identifier};
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
@@ -25,6 +26,11 @@ impl JsGroupId {
     #[wasm_bindgen(js_name = toString)]
     pub fn to_js_string(&self) -> String {
         self.0.to_string()
+    }
+
+    #[wasm_bindgen(js_name = toIdentifier)]
+    pub fn to_identifier(&self) -> JsIdentifier {
+        JsIdentifier(Identifier::from(self.0))
     }
 }
 

--- a/keyhive_wasm/src/js/identifier.rs
+++ b/keyhive_wasm/src/js/identifier.rs
@@ -27,6 +27,11 @@ impl JsIdentifier {
         JsIdentifier(Public.id())
     }
 
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_js_string(&self) -> String {
+        self.0.to_string()
+    }
+
     #[wasm_bindgen(js_name = toBytes)]
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()

--- a/keyhive_wasm/src/js/identifier.rs
+++ b/keyhive_wasm/src/js/identifier.rs
@@ -2,11 +2,13 @@ use keyhive_core::principal::{identifier::Identifier, public::Public};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
+use wasm_refgen::wasm_refgen;
 
 #[wasm_bindgen(js_name = Identifier)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct JsIdentifier(pub(crate) Identifier);
 
+#[wasm_refgen(js_ref = JsIdentifierRef)]
 #[wasm_bindgen(js_class = Identifier)]
 impl JsIdentifier {
     #[wasm_bindgen(constructor)]

--- a/keyhive_wasm/src/js/individual.rs
+++ b/keyhive_wasm/src/js/individual.rs
@@ -43,7 +43,7 @@ impl JsIndividual {
     }
 
     #[wasm_bindgen(js_name = pickPrekey)]
-    pub async fn pick_prekey(&self, doc_id: JsDocumentId) -> JsShareKey {
+    pub async fn pick_prekey(&self, doc_id: &JsDocumentId) -> JsShareKey {
         let locked = self.inner.lock().await;
         JsShareKey(*locked.pick_prekey(doc_id.0))
     }

--- a/keyhive_wasm/src/js/individual_id.rs
+++ b/keyhive_wasm/src/js/individual_id.rs
@@ -1,4 +1,5 @@
-use keyhive_core::principal::individual::id::IndividualId;
+use crate::js::identifier::JsIdentifier;
+use keyhive_core::principal::{identifier::Identifier, individual::id::IndividualId};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = IndividualId)]
@@ -10,6 +11,11 @@ impl JsIndividualId {
     #[wasm_bindgen(getter)]
     pub fn bytes(&self) -> Box<[u8]> {
         Box::new(self.0.to_bytes())
+    }
+
+    #[wasm_bindgen(js_name = toIdentifier)]
+    pub fn to_identifier(&self) -> JsIdentifier {
+        JsIdentifier(Identifier::from(self.0))
     }
 }
 

--- a/keyhive_wasm/src/js/individual_id.rs
+++ b/keyhive_wasm/src/js/individual_id.rs
@@ -1,4 +1,4 @@
-use crate::js::identifier::JsIdentifier;
+use crate::js::identifier::{CannotParseIdentifier, JsIdentifier};
 use keyhive_core::principal::{identifier::Identifier, individual::id::IndividualId};
 use wasm_bindgen::prelude::*;
 
@@ -8,9 +8,23 @@ pub struct JsIndividualId(pub(crate) IndividualId);
 
 #[wasm_bindgen(js_class = IndividualId)]
 impl JsIndividualId {
-    #[wasm_bindgen(getter)]
-    pub fn bytes(&self) -> Box<[u8]> {
-        Box::new(self.0.to_bytes())
+    /// Build an individual id from its 32 raw bytes.
+    #[wasm_bindgen(constructor)]
+    pub fn new(bytes: Vec<u8>) -> Result<Self, CannotParseIdentifier> {
+        let vec: [u8; 32] = bytes.try_into().map_err(|_| CannotParseIdentifier)?;
+        let vk =
+            ed25519_dalek::VerifyingKey::from_bytes(&vec).map_err(|_| CannotParseIdentifier)?;
+        Ok(Self(IndividualId(Identifier::from(vk))))
+    }
+
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_js_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
     }
 
     #[wasm_bindgen(js_name = toIdentifier)]

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -811,7 +811,7 @@ mod tests {
         #[allow(unused)]
         async fn test_length() {
             let bh = setup().await;
-            assert_eq!(bh.id().bytes().len(), 32);
+            assert_eq!(bh.id().to_bytes().len(), 32);
         }
     }
 

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -5,7 +5,7 @@ use keyhive_core::principal::identifier::Identifier;
 use crate::{
     js::{
         archive::JsSerializationError,
-        document_id::JsDocumentId,
+        document_id::{JsDocumentId, JsDocumentIdRef},
         event::JsEvent,
         group_id::JsGroupId,
         individual::JsIndividual,
@@ -25,7 +25,7 @@ use super::{
     ciphertext_store::JsCiphertextStore,
     contact_card::JsContactCard,
     decrypted_keyed::JsDecryptedKeyed,
-    document::{JsDocument, JsDocumentRef},
+    document::JsDocument,
     encrypted::JsEncrypted,
     encrypted_content_with_update::JsEncryptedContentWithUpdate,
     encrypted_keyed::JsEncryptedKeyed,
@@ -33,10 +33,9 @@ use super::{
     generate_doc_error::JsGenerateDocError,
     generate_group_error::JsGenerateGroupError,
     group::JsGroup,
-    identifier::JsIdentifier,
+    identifier::{JsIdentifier, JsIdentifierRef},
     individual_id::JsIndividualId,
-    membered::JsMembered,
-    peer::{JsPeer, JsPeerRef},
+    membered_id::JsMemberedId,
     revoke_member_error::JsRevokeMemberError,
     share_key::JsShareKey,
     signed::JsSigned,
@@ -132,38 +131,30 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = generateGroup)]
     pub async fn generate_group(
         &self,
-        js_coparents: Vec<JsPeerRef>,
-    ) -> Result<JsGroup, JsGenerateGroupError> {
-        let coparents = js_coparents
-            .into_iter()
-            .map(|js_peer| JsPeer::from_js_ref(&js_peer).0.id())
+        coparents: Vec<JsIdentifierRef>,
+    ) -> Result<JsGroupId, JsGenerateGroupError> {
+        let coparents = coparents
+            .iter()
+            .map(|r| JsIdentifier::from_js_ref(r).0)
             .collect::<Vec<_>>();
-
-        let group_id = self.0.generate_group(coparents).await?;
-        let inner = self
-            .0
-            .get_group(group_id)
-            .await
-            .ok_or_else(|| NotFound::new(group_id))?;
-
-        Ok(JsGroup { group_id, inner })
+        Ok(JsGroupId(self.0.generate_group(coparents).await?))
     }
 
     /// Generate a document.
     #[wasm_bindgen(js_name = generateDocument)]
     pub async fn generate_doc(
         &self,
-        coparents: Vec<JsPeerRef>,
+        coparents: Vec<JsIdentifierRef>,
         initial_content_ref_head: &JsChangeId,
         more_initial_content_refs: Vec<JsChangeIdRef>,
-    ) -> Result<JsDocument, JsGenerateDocError> {
+    ) -> Result<JsDocumentId, JsGenerateDocError> {
         init_span!("JsKeyhive::generate_doc");
         let doc_id = self
             .0
             .generate_doc(
                 coparents
-                    .into_iter()
-                    .map(|js_peer| JsPeer::from_js_ref(&js_peer).0.id())
+                    .iter()
+                    .map(|r| JsIdentifier::from_js_ref(r).0)
                     .collect::<Vec<_>>(),
                 NonEmpty {
                     head: initial_content_ref_head.clone(),
@@ -174,13 +165,8 @@ impl JsKeyhive {
                 },
             )
             .await?;
-        let inner = self
-            .0
-            .get_document(doc_id)
-            .await
-            .ok_or_else(|| NotFound::new(doc_id))?;
 
-        Ok(JsDocument { doc_id, inner })
+        Ok(JsDocumentId(doc_id))
     }
 
     #[wasm_bindgen(js_name = trySign)]
@@ -192,7 +178,7 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryEncrypt)]
     pub async fn try_encrypt(
         &self,
-        doc: &JsDocument,
+        doc: &JsDocumentId,
         content_ref: &JsChangeId,
         js_pred_refs: Vec<JsChangeIdRef>,
         content: &[u8],
@@ -205,7 +191,7 @@ impl JsKeyhive {
 
         Ok(self
             .0
-            .try_encrypt_content(doc.doc_id, content_ref, &pred_refs, content)
+            .try_encrypt_content(doc.0, content_ref, &pred_refs, content)
             .await?
             .into())
     }
@@ -215,7 +201,7 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryEncryptKeyed)]
     pub async fn try_encrypt_keyed(
         &self,
-        doc: &JsDocument,
+        doc: &JsDocumentId,
         content_ref: &JsChangeId,
         js_pred_refs: Vec<JsChangeIdRef>,
         content: &[u8],
@@ -228,7 +214,7 @@ impl JsKeyhive {
 
         let (inner, key) = self
             .0
-            .try_encrypt_content_keyed(doc.doc_id, content_ref, &pred_refs, content)
+            .try_encrypt_content_keyed(doc.0, content_ref, &pred_refs, content)
             .await?;
         Ok(JsEncryptedKeyed {
             inner,
@@ -239,24 +225,24 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryDecrypt)]
     pub async fn try_decrypt(
         &self,
-        doc: &JsDocument,
+        doc: &JsDocumentId,
         encrypted: &JsEncrypted,
     ) -> Result<Vec<u8>, JsDecryptError> {
         init_span!("JsKeyhive::try_decrypt");
-        Ok(self.0.try_decrypt_content(doc.doc_id, &encrypted.0).await?)
+        Ok(self.0.try_decrypt_content(doc.0, &encrypted.0).await?)
     }
 
     /// Decrypt content and also return the 32-byte application secret key used.
     #[wasm_bindgen(js_name = tryDecryptKeyed)]
     pub async fn try_decrypt_keyed(
         &self,
-        doc: &JsDocument,
+        doc: &JsDocumentId,
         encrypted: &JsEncrypted,
     ) -> Result<JsDecryptedKeyed, JsDecryptError> {
         init_span!("JsKeyhive::try_decrypt_keyed");
         let (plaintext, key) = self
             .0
-            .try_decrypt_content_keyed(doc.doc_id, &encrypted.0)
+            .try_decrypt_content_keyed(doc.0, &encrypted.0)
             .await?;
         Ok(JsDecryptedKeyed::new(plaintext, key.as_slice().to_vec()))
     }
@@ -265,25 +251,20 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = addMember)]
     pub async fn add_member(
         &self,
-        to_add: &JsAgent,
-        membered: &JsMembered,
+        to_add: &JsIdentifier,
+        membered: &JsMemberedId,
         access: &JsAccess,
-        other_relevant_docs: Vec<JsDocumentRef>,
+        other_relevant_docs: Vec<JsDocumentIdRef>,
     ) -> Result<JsSignedDelegation, JsAddMemberError> {
         init_span!("JsKeyhive::add_member");
         let other_docs: Vec<_> = other_relevant_docs
             .iter()
-            .map(|js_doc| JsDocument::from_js_ref(js_doc).doc_id)
+            .map(|r| JsDocumentId::from_js_ref(r).0)
             .collect();
 
         let res = self
             .0
-            .add_member(
-                to_add.0.id(),
-                membered.0.membered_id(),
-                **access,
-                other_docs.as_slice(),
-            )
+            .add_member(to_add.0, membered.0, **access, other_docs.as_slice())
             .await?;
 
         Ok(res.delegation.into())
@@ -292,18 +273,14 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = revokeMember)]
     pub async fn revoke_member(
         &self,
-        to_revoke: &JsAgent,
+        to_revoke: &JsIdentifier,
         retain_all_other_members: bool,
-        membered: &JsMembered,
+        membered: &JsMemberedId,
     ) -> Result<Vec<JsSignedRevocation>, JsRevokeMemberError> {
         init_span!("JsKeyhive::revoke_member");
         let res = self
             .0
-            .revoke_member(
-                to_revoke.id().0,
-                retain_all_other_members,
-                membered.0.membered_id(),
-            )
+            .revoke_member(to_revoke.0, retain_all_other_members, membered.0)
             .await?;
 
         Ok(res
@@ -333,11 +310,11 @@ impl JsKeyhive {
     /// `importPrekeySecrets` accepts).
     /// The returned bytes are secret key material: do not log or persist unencrypted.
     #[wasm_bindgen(js_name = forcePcsUpdate)]
-    pub async fn force_pcs_update(&self, doc: &JsDocument) -> Result<Box<[u8]>, JsValue> {
+    pub async fn force_pcs_update(&self, doc: &JsDocumentId) -> Result<Box<[u8]>, JsValue> {
         init_span!("JsKeyhive::force_pcs_update");
         let (_op, new_share_key, new_share_secret_key) = self
             .0
-            .force_pcs_update(doc.doc_id)
+            .force_pcs_update(doc.0)
             .await
             .map_err(EncryptContentError::from)
             .map_err(JsEncryptError::from)?;
@@ -347,9 +324,9 @@ impl JsKeyhive {
     }
 
     #[wasm_bindgen(js_name = tryPcsKeyHash)]
-    pub async fn try_pcs_key_hash(&self, doc: &JsDocument) -> Option<Vec<u8>> {
+    pub async fn try_pcs_key_hash(&self, doc: &JsDocumentId) -> Option<Vec<u8>> {
         self.0
-            .try_pcs_key_hash(doc.doc_id)
+            .try_pcs_key_hash(doc.0)
             .await
             .map(|d| d.as_slice().to_vec())
     }
@@ -388,19 +365,11 @@ impl JsKeyhive {
     pub async fn receive_contact_card(
         &self,
         contact_card: &JsContactCard,
-    ) -> Result<JsIndividual, JsReceivePreKeyOpError> {
+    ) -> Result<JsIndividualId, JsReceivePreKeyOpError> {
         init_span!("JsKeyhive::receive_contact_card");
-        match self.0.receive_contact_card(&contact_card.clone()).await {
-            Ok(id) => {
-                let inner = self
-                    .0
-                    .get_individual(id)
-                    .await
-                    .ok_or_else(|| NotFound::new(id))?;
-                Ok(JsIndividual { id, inner })
-            }
-            Err(err) => Err(err.into()),
-        }
+        Ok(JsIndividualId(
+            self.0.receive_contact_card(&contact_card.clone()).await?,
+        ))
     }
 
     #[wasm_bindgen(js_name = getAgent)]
@@ -579,6 +548,21 @@ impl JsKeyhive {
             group_id: id,
             inner: g.dupe(),
         })
+    }
+
+    #[wasm_bindgen(js_name = hasDocument)]
+    pub async fn has_document(&self, doc_id: &JsDocumentId) -> bool {
+        self.0.has_document(doc_id.0).await
+    }
+
+    #[wasm_bindgen(js_name = hasGroup)]
+    pub async fn has_group(&self, group_id: &JsGroupId) -> bool {
+        self.0.has_group(group_id.0).await
+    }
+
+    #[wasm_bindgen(js_name = hasIndividual)]
+    pub async fn has_individual(&self, id: &JsIndividualId) -> bool {
+        self.0.has_individual(id.0).await
     }
 
     #[wasm_bindgen(js_name = getDocument)]
@@ -767,10 +751,6 @@ impl From<JsNotFound> for JsValue {
 pub enum JsReceivePreKeyOpError {
     #[error(transparent)]
     ReceivePrekeyOp(#[from] ReceivePrekeyOpError),
-
-    /// The individual was registered and could not then be read back.
-    #[error(transparent)]
-    NotFound(#[from] NotFound),
 }
 
 impl From<JsReceivePreKeyOpError> for JsValue {

--- a/keyhive_wasm/src/js/keyhive.rs
+++ b/keyhive_wasm/src/js/keyhive.rs
@@ -52,7 +52,6 @@ use future_form::Local;
 use keyhive_core::{
     all_agent_events::EventDigest,
     crypto::digest::Digest,
-    error::not_found::NotFound,
     event::{static_event::StaticEvent, Event},
     keyhive::{EncryptContentError, Keyhive, ReceiveStaticEventError},
     principal::{
@@ -103,7 +102,6 @@ impl JsKeyhive {
         self.0.id().into()
     }
 
-    #[wasm_bindgen(getter)]
     pub async fn individual(&self) -> JsIndividual {
         init_span!("JsKeyhive::individual");
         JsIndividual {
@@ -178,7 +176,7 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryEncrypt)]
     pub async fn try_encrypt(
         &self,
-        doc: &JsDocumentId,
+        doc_id: &JsDocumentId,
         content_ref: &JsChangeId,
         js_pred_refs: Vec<JsChangeIdRef>,
         content: &[u8],
@@ -191,7 +189,7 @@ impl JsKeyhive {
 
         Ok(self
             .0
-            .try_encrypt_content(doc.0, content_ref, &pred_refs, content)
+            .try_encrypt_content(doc_id.0, content_ref, &pred_refs, content)
             .await?
             .into())
     }
@@ -201,7 +199,7 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryEncryptKeyed)]
     pub async fn try_encrypt_keyed(
         &self,
-        doc: &JsDocumentId,
+        doc_id: &JsDocumentId,
         content_ref: &JsChangeId,
         js_pred_refs: Vec<JsChangeIdRef>,
         content: &[u8],
@@ -214,7 +212,7 @@ impl JsKeyhive {
 
         let (inner, key) = self
             .0
-            .try_encrypt_content_keyed(doc.0, content_ref, &pred_refs, content)
+            .try_encrypt_content_keyed(doc_id.0, content_ref, &pred_refs, content)
             .await?;
         Ok(JsEncryptedKeyed {
             inner,
@@ -225,24 +223,24 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = tryDecrypt)]
     pub async fn try_decrypt(
         &self,
-        doc: &JsDocumentId,
+        doc_id: &JsDocumentId,
         encrypted: &JsEncrypted,
     ) -> Result<Vec<u8>, JsDecryptError> {
         init_span!("JsKeyhive::try_decrypt");
-        Ok(self.0.try_decrypt_content(doc.0, &encrypted.0).await?)
+        Ok(self.0.try_decrypt_content(doc_id.0, &encrypted.0).await?)
     }
 
     /// Decrypt content and also return the 32-byte application secret key used.
     #[wasm_bindgen(js_name = tryDecryptKeyed)]
     pub async fn try_decrypt_keyed(
         &self,
-        doc: &JsDocumentId,
+        doc_id: &JsDocumentId,
         encrypted: &JsEncrypted,
     ) -> Result<JsDecryptedKeyed, JsDecryptError> {
         init_span!("JsKeyhive::try_decrypt_keyed");
         let (plaintext, key) = self
             .0
-            .try_decrypt_content_keyed(doc.0, &encrypted.0)
+            .try_decrypt_content_keyed(doc_id.0, &encrypted.0)
             .await?;
         Ok(JsDecryptedKeyed::new(plaintext, key.as_slice().to_vec()))
     }
@@ -252,7 +250,7 @@ impl JsKeyhive {
     pub async fn add_member(
         &self,
         to_add: &JsIdentifier,
-        membered: &JsMemberedId,
+        membered_id: &JsMemberedId,
         access: &JsAccess,
         other_relevant_docs: Vec<JsDocumentIdRef>,
     ) -> Result<JsSignedDelegation, JsAddMemberError> {
@@ -264,7 +262,7 @@ impl JsKeyhive {
 
         let res = self
             .0
-            .add_member(to_add.0, membered.0, **access, other_docs.as_slice())
+            .add_member(to_add.0, membered_id.0, **access, other_docs.as_slice())
             .await?;
 
         Ok(res.delegation.into())
@@ -275,12 +273,12 @@ impl JsKeyhive {
         &self,
         to_revoke: &JsIdentifier,
         retain_all_other_members: bool,
-        membered: &JsMemberedId,
+        membered_id: &JsMemberedId,
     ) -> Result<Vec<JsSignedRevocation>, JsRevokeMemberError> {
         init_span!("JsKeyhive::revoke_member");
         let res = self
             .0
-            .revoke_member(to_revoke.0, retain_all_other_members, membered.0)
+            .revoke_member(to_revoke.0, retain_all_other_members, membered_id.0)
             .await?;
 
         Ok(res
@@ -310,11 +308,11 @@ impl JsKeyhive {
     /// `importPrekeySecrets` accepts).
     /// The returned bytes are secret key material: do not log or persist unencrypted.
     #[wasm_bindgen(js_name = forcePcsUpdate)]
-    pub async fn force_pcs_update(&self, doc: &JsDocumentId) -> Result<Box<[u8]>, JsValue> {
+    pub async fn force_pcs_update(&self, doc_id: &JsDocumentId) -> Result<Box<[u8]>, JsValue> {
         init_span!("JsKeyhive::force_pcs_update");
         let (_op, new_share_key, new_share_secret_key) = self
             .0
-            .force_pcs_update(doc.0)
+            .force_pcs_update(doc_id.0)
             .await
             .map_err(EncryptContentError::from)
             .map_err(JsEncryptError::from)?;
@@ -324,9 +322,9 @@ impl JsKeyhive {
     }
 
     #[wasm_bindgen(js_name = tryPcsKeyHash)]
-    pub async fn try_pcs_key_hash(&self, doc: &JsDocumentId) -> Option<Vec<u8>> {
+    pub async fn try_pcs_key_hash(&self, doc_id: &JsDocumentId) -> Option<Vec<u8>> {
         self.0
-            .try_pcs_key_hash(doc.0)
+            .try_pcs_key_hash(doc_id.0)
             .await
             .map(|d| d.as_slice().to_vec())
     }
@@ -368,7 +366,7 @@ impl JsKeyhive {
     ) -> Result<JsIndividualId, JsReceivePreKeyOpError> {
         init_span!("JsKeyhive::receive_contact_card");
         Ok(JsIndividualId(
-            self.0.receive_contact_card(&contact_card.clone()).await?,
+            self.0.receive_contact_card(contact_card).await?,
         ))
     }
 
@@ -550,18 +548,24 @@ impl JsKeyhive {
         })
     }
 
+    /// Whether a document with this id is known.
     #[wasm_bindgen(js_name = hasDocument)]
     pub async fn has_document(&self, doc_id: &JsDocumentId) -> bool {
+        init_span!("JsKeyhive::has_document");
         self.0.has_document(doc_id.0).await
     }
 
+    /// Whether a group with this id is known.
     #[wasm_bindgen(js_name = hasGroup)]
     pub async fn has_group(&self, group_id: &JsGroupId) -> bool {
+        init_span!("JsKeyhive::has_group");
         self.0.has_group(group_id.0).await
     }
 
+    /// Whether an individual with this id is known.
     #[wasm_bindgen(js_name = hasIndividual)]
     pub async fn has_individual(&self, id: &JsIndividualId) -> bool {
+        init_span!("JsKeyhive::has_individual");
         self.0.has_individual(id.0).await
     }
 
@@ -662,12 +666,6 @@ impl JsKeyhive {
             .map_err(JsSerializationError::from)
     }
 
-    #[wasm_bindgen(js_name = intoArchive)]
-    pub async fn into_archive(self) -> JsArchive {
-        init_span!("JsKeyhive::into_archive");
-        self.0.into_archive().await.into()
-    }
-
     #[wasm_bindgen(js_name = toArchive)]
     pub async fn to_archive(&self) -> JsArchive {
         init_span!("JsKeyhive::to_archive");
@@ -732,18 +730,6 @@ impl JsKeyhive {
     #[wasm_bindgen(js_name = stats)]
     pub async fn stats(&self) -> JsStats {
         JsStats(self.0.stats().await)
-    }
-}
-
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct JsNotFound(#[from] NotFound);
-
-impl From<JsNotFound> for JsValue {
-    fn from(err: JsNotFound) -> Self {
-        let err = js_sys::Error::new(&err.to_string());
-        err.set_name("NotFound");
-        err.into()
     }
 }
 

--- a/keyhive_wasm/src/js/membered.rs
+++ b/keyhive_wasm/src/js/membered.rs
@@ -1,8 +1,0 @@
-use super::{change_id::JsChangeId, event_handler::JsEventHandler, signer::JsSigner};
-use future_form::Local;
-use keyhive_core::principal::membered::Membered;
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen(js_name = Membered)]
-#[derive(Debug, Clone)]
-pub struct JsMembered(pub(crate) Membered<Local, JsSigner, JsChangeId, JsEventHandler>);

--- a/keyhive_wasm/src/js/membered_id.rs
+++ b/keyhive_wasm/src/js/membered_id.rs
@@ -1,0 +1,60 @@
+use super::{document_id::JsDocumentId, group_id::JsGroupId};
+use crate::js::identifier::JsIdentifier;
+use keyhive_core::principal::{identifier::Identifier, membered::id::MemberedId};
+use std::fmt::{Display, Formatter};
+use wasm_bindgen::prelude::*;
+
+/// ID for a resource that can have members, which is either a group or a document.
+#[wasm_bindgen(js_name = MemberedId)]
+#[derive(Debug, Clone, Copy)]
+pub struct JsMemberedId(pub(crate) MemberedId);
+
+#[wasm_bindgen(js_class = MemberedId)]
+impl JsMemberedId {
+    #[wasm_bindgen(js_name = group)]
+    pub fn group(group_id: &JsGroupId) -> Self {
+        JsMemberedId(MemberedId::GroupId(group_id.0))
+    }
+
+    #[wasm_bindgen(js_name = document)]
+    pub fn document(doc_id: &JsDocumentId) -> Self {
+        JsMemberedId(MemberedId::DocumentId(doc_id.0))
+    }
+
+    #[wasm_bindgen(js_name = isGroup)]
+    pub fn is_group(&self) -> bool {
+        matches!(self.0, MemberedId::GroupId(_))
+    }
+
+    #[wasm_bindgen(js_name = isDocument)]
+    pub fn is_document(&self) -> bool {
+        matches!(self.0, MemberedId::DocumentId(_))
+    }
+
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
+    }
+
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_js_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[wasm_bindgen(js_name = toIdentifier)]
+    pub fn to_identifier(&self) -> JsIdentifier {
+        JsIdentifier(Identifier::from(self.0))
+    }
+}
+
+impl From<MemberedId> for JsMemberedId {
+    fn from(id: MemberedId) -> Self {
+        JsMemberedId(id)
+    }
+}
+
+impl Display for JsMemberedId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/keyhive_wasm/src/js/membered_id.rs
+++ b/keyhive_wasm/src/js/membered_id.rs
@@ -1,7 +1,6 @@
 use super::{document_id::JsDocumentId, group_id::JsGroupId};
 use crate::js::identifier::JsIdentifier;
 use keyhive_core::principal::{identifier::Identifier, membered::id::MemberedId};
-use std::fmt::{Display, Formatter};
 use wasm_bindgen::prelude::*;
 
 /// ID for a resource that can have members, which is either a group or a document.
@@ -11,22 +10,22 @@ pub struct JsMemberedId(pub(crate) MemberedId);
 
 #[wasm_bindgen(js_class = MemberedId)]
 impl JsMemberedId {
-    #[wasm_bindgen(js_name = group)]
+    #[wasm_bindgen]
     pub fn group(group_id: &JsGroupId) -> Self {
-        JsMemberedId(MemberedId::GroupId(group_id.0))
+        Self(MemberedId::GroupId(group_id.0))
     }
 
-    #[wasm_bindgen(js_name = document)]
+    #[wasm_bindgen]
     pub fn document(doc_id: &JsDocumentId) -> Self {
-        JsMemberedId(MemberedId::DocumentId(doc_id.0))
+        Self(MemberedId::DocumentId(doc_id.0))
     }
 
-    #[wasm_bindgen(js_name = isGroup)]
+    #[wasm_bindgen(getter, js_name = isGroup)]
     pub fn is_group(&self) -> bool {
         matches!(self.0, MemberedId::GroupId(_))
     }
 
-    #[wasm_bindgen(js_name = isDocument)]
+    #[wasm_bindgen(getter, js_name = isDocument)]
     pub fn is_document(&self) -> bool {
         matches!(self.0, MemberedId::DocumentId(_))
     }
@@ -44,17 +43,5 @@ impl JsMemberedId {
     #[wasm_bindgen(js_name = toIdentifier)]
     pub fn to_identifier(&self) -> JsIdentifier {
         JsIdentifier(Identifier::from(self.0))
-    }
-}
-
-impl From<MemberedId> for JsMemberedId {
-    fn from(id: MemberedId) -> Self {
-        JsMemberedId(id)
-    }
-}
-
-impl Display for JsMemberedId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
     }
 }

--- a/keyhive_wasm/src/js/peer.rs
+++ b/keyhive_wasm/src/js/peer.rs
@@ -6,13 +6,11 @@ use dupe::Dupe;
 use future_form::Local;
 use keyhive_core::principal::peer::Peer;
 use wasm_bindgen::prelude::*;
-use wasm_refgen::wasm_refgen;
 
 #[wasm_bindgen(js_name = Peer)]
 #[derive(Debug, Clone, Dupe)]
 pub struct JsPeer(pub(crate) Peer<Local, JsSigner, JsChangeId, JsEventHandler>);
 
-#[wasm_refgen(js_ref = JsPeerRef)]
 #[wasm_bindgen(js_class = Peer)]
 impl JsPeer {
     #[wasm_bindgen(getter)]
@@ -32,17 +30,17 @@ impl JsPeer {
             })
     }
 
-    #[wasm_bindgen(js_name = isIndividual)]
+    #[wasm_bindgen(getter, js_name = isIndividual)]
     pub fn is_individual(&self) -> bool {
         matches!(self.0, Peer::Individual(_, _))
     }
 
-    #[wasm_bindgen(js_name = isGroup)]
+    #[wasm_bindgen(getter, js_name = isGroup)]
     pub fn is_group(&self) -> bool {
         matches!(self.0, Peer::Group(_, _))
     }
 
-    #[wasm_bindgen(js_name = isDocument)]
+    #[wasm_bindgen(getter, js_name = isDocument)]
     pub fn is_document(&self) -> bool {
         matches!(self.0, Peer::Document(_, _))
     }

--- a/keyhive_wasm/src/js/revocation.rs
+++ b/keyhive_wasm/src/js/revocation.rs
@@ -14,7 +14,7 @@ pub struct JsRevocation(pub(crate) Revocation<Local, JsSigner, JsChangeId, JsEve
 
 #[wasm_bindgen(js_class = Revocation)]
 impl JsRevocation {
-    #[wasm_bindgen(getter)]
+    #[wasm_bindgen(getter, js_name = subjectId)]
     pub fn subject_id(&self) -> JsIdentifier {
         self.0.subject_id().into()
     }

--- a/keyhive_wasm/src/js/signed.rs
+++ b/keyhive_wasm/src/js/signed.rs
@@ -25,9 +25,14 @@ impl JsSigned {
         self.0.try_verify().is_ok()
     }
 
-    #[wasm_bindgen(getter)]
+    /// Copies the payload out of wasm memory on every call.
     pub fn payload(&self) -> Vec<u8> {
         self.0.payload().clone()
+    }
+
+    #[wasm_bindgen(getter, js_name = payloadLength)]
+    pub fn payload_length(&self) -> usize {
+        self.0.payload().len()
     }
 
     #[wasm_bindgen(getter, js_name = verifyingKey)]

--- a/keyhive_wasm/src/js/signer.rs
+++ b/keyhive_wasm/src/js/signer.rs
@@ -25,7 +25,7 @@ impl JsSigner {
     }
 
     #[cfg(not(feature = "web-sys"))]
-    #[wasm_bindgen(constructor, js_name = generate)]
+    #[wasm_bindgen]
     pub async fn generate() -> Self {
         Self::generate_memory()
     }


### PR DESCRIPTION
History is rewritten for easier reviewing (test-related changes were pulled out into their own commit, which means the first two commits don't compile on their own):

1. The WASM API changes to match the new core API
2. Fixing inconsistencies in the WASM API
3. Adding tests and test-related changes